### PR TITLE
feat: use PR draft status instead of labels for review signaling

### DIFF
--- a/docs/plans/2026-02-01-feat-controller-skill-redesign-plan.md
+++ b/docs/plans/2026-02-01-feat-controller-skill-redesign-plan.md
@@ -220,7 +220,7 @@ The controller runs a Python script that consolidates all state checking:
     "ENG-21": {
       "status": "Needs Review",
       "labels": ["worker-done"],
-      "pr_labels": ["worker-approved"],
+      "pr_is_draft": false,
       "has_live_worker": false,
       "suggested_action": "transition_to_retro"
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "anyio>=4.0",
     "async-lru>=2.0",
     "click>=8.0",
+    "tenacity>=9.1.2",
 ]
 
 [project.scripts]

--- a/skills/legion-controller/SKILL.md
+++ b/skills/legion-controller/SKILL.md
@@ -52,7 +52,7 @@ Output:
     "ENG-21": {
       "status": "Needs Review",
       "labels": ["worker-done"],
-      "pr_labels": ["worker-approved"],
+      "pr_is_draft": false,
       "has_live_worker": false,
       "suggested_action": "transition_to_retro",
       "session_id": "uuid-for-implement-mode",
@@ -107,9 +107,9 @@ tmux send-keys -t "$SESSION:main" \
 
 **Resume worker:**
 ```bash
-# Same session ID computation - resumes existing session
+# Use --resume to continue existing session (not --session-id)
 tmux send-keys -t "$SESSION:main" \
-  "claude --dangerously-skip-permissions --session-id '$SESSION_ID' \
+  "claude --dangerously-skip-permissions --resume '$SESSION_ID' \
    -p 'Continue: address PR comments'" Enter
 ```
 
@@ -158,7 +158,7 @@ Todo → In Progress → Needs Review → Retro → Done
 |--------|-------------|----------------|
 | Todo | plan | Plan posted to Linear |
 | In Progress | implement | PR opened |
-| Needs Review | review | PR labeled + `worker-done` |
+| Needs Review | review | PR marked ready/draft + `worker-done` |
 | Retro | implement (retro) | Learnings documented |
 | Done | finish | PR merged, workspace cleaned |
 
@@ -169,9 +169,9 @@ Todo → In Progress → Needs Review → Retro → Done
 - `user-input-needed` - Waiting for human (controller skips)
 - `user-feedback-given` - Human answered (controller relays to worker)
 
-**GitHub PR:**
-- `worker-approved` - Review passed
-- `worker-changes-requested` - Review found issues
+**GitHub PR (via draft status):**
+- PR ready (not draft) = Review approved → transition to Retro
+- PR draft = Changes requested → resume implementer
 
 ## Important
 

--- a/skills/legion-worker/SKILL.md
+++ b/skills/legion-worker/SKILL.md
@@ -35,11 +35,11 @@ Required:
 
 Note: `retro` runs before `finish` because retro adds learnings to the workspace, and finish deletes it.
 
-## Review Mode Labels
+## Review Mode Signaling
 
-Review adds a GitHub PR label BEFORE `worker-done`:
-- `worker-approved` - no blocking issues
-- `worker-changes-requested` - blocking issues found
+Review signals outcome via PR draft status BEFORE `worker-done`:
+- **PR ready** (not draft) - no blocking issues, approved
+- **PR draft** - blocking issues found, changes requested
 
 ## Reference
 

--- a/skills/legion-worker/references/linear-labels.md
+++ b/skills/legion-worker/references/linear-labels.md
@@ -14,17 +14,18 @@ Preserve existing labels when adding:
 3. mcp__linear__update_issue(id: ISSUE_ID, labelIds: [...existing, workerDoneId])
 ```
 
-## GitHub PR Labels (Not Linear)
+## GitHub PR Draft Status (Not Linear)
 
-Review outcomes go on the **GitHub PR**, not Linear:
+Review outcomes signaled via **PR draft status**, not labels:
 
-| Label | Meaning |
-|-------|---------|
-| `worker-approved` | PR passes review |
-| `worker-changes-requested` | PR needs work |
+| Status | Meaning |
+|--------|---------|
+| Ready (not draft) | PR passes review |
+| Draft | PR needs work |
 
 ```bash
-gh pr edit --add-label <label>
+gh pr ready "$LINEAR_ISSUE_ID"        # Mark approved
+gh pr ready "$LINEAR_ISSUE_ID" --undo # Mark changes requested
 ```
 
-**Critical ordering for reviewers:** Add PR label BEFORE `worker-done` on Linear.
+**Critical ordering for reviewers:** Set draft status BEFORE `worker-done` on Linear.

--- a/skills/legion-worker/workflows/review.md
+++ b/skills/legion-worker/workflows/review.md
@@ -5,7 +5,7 @@ Deep PR review with line-level comments. Code is already local in the workspace.
 ## Constraint
 
 **Cannot approve/request changes via GitHub API** - same user as PR author.
-Signal outcome via GitHub PR labels instead.
+Signal outcome via PR draft status instead (draft = changes requested, ready = approved).
 
 ## Workflow
 
@@ -70,16 +70,16 @@ gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
 
 Group related issues when they affect the same area.
 
-### 5. Add GitHub PR Label
+### 5. Set PR Draft Status
 
-**Order matters:** Add PR label BEFORE `worker-done` to avoid race condition with controller.
+**Order matters:** Set draft status BEFORE `worker-done` to avoid race condition with controller.
 
 ```bash
-# If any CRITICAL/P1 issues found:
-gh pr edit "$LINEAR_ISSUE_ID" --add-label "worker-changes-requested"
+# If any CRITICAL/P1 issues found - convert to draft:
+gh pr ready "$LINEAR_ISSUE_ID" --undo
 
-# If no CRITICAL issues:
-gh pr edit "$LINEAR_ISSUE_ID" --add-label "worker-approved"
+# If no CRITICAL issues - mark ready for merge:
+gh pr ready "$LINEAR_ISSUE_ID"
 ```
 
 ### 6. Signal Completion

--- a/src/legion/state/__init__.py
+++ b/src/legion/state/__init__.py
@@ -15,20 +15,24 @@ CLI usage:
 
 from legion.state.decision import ACTION_TO_MODE, build_collected_state, build_issue_state, suggest_action
 from legion.state.fetch import (
+    GitHubAPIError,
     check_worker_blocked,
     fetch_all_issue_data,
     get_live_workers,
-    get_pr_labels_batch,
+    get_pr_draft_status_batch,
     parse_linear_issues,
 )
 from legion.state.types import (
     ActionType,
     CollectedState,
     FetchedIssueData,
+    GitHubPRRef,
     IssueState,
     IssueStatus,
+    IssueStatusLiteral,
     ParsedIssue,
     WorkerMode,
+    WorkerModeLiteral,
     compute_session_id,
 )
 
@@ -37,10 +41,14 @@ __all__ = [
     "ActionType",
     "CollectedState",
     "FetchedIssueData",
+    "GitHubAPIError",
+    "GitHubPRRef",
     "IssueState",
     "IssueStatus",
+    "IssueStatusLiteral",
     "ParsedIssue",
     "WorkerMode",
+    "WorkerModeLiteral",
     # Functions
     "ACTION_TO_MODE",
     "build_collected_state",
@@ -49,7 +57,7 @@ __all__ = [
     "compute_session_id",
     "fetch_all_issue_data",
     "get_live_workers",
-    "get_pr_labels_batch",
+    "get_pr_draft_status_batch",
     "parse_linear_issues",
     "suggest_action",
 ]

--- a/src/legion/state/decision.py
+++ b/src/legion/state/decision.py
@@ -14,6 +14,7 @@ from legion.state.types import (
     IssueState,
     IssueStatus,
     WorkerMode,
+    WorkerModeLiteral,
 )
 
 
@@ -21,7 +22,7 @@ def suggest_action(
     status: str,
     has_worker_done: bool,
     has_live_worker: bool,
-    pr_labels: list[str],
+    pr_is_draft: bool | None,
     is_blocked: bool,
 ) -> ActionType:
     """Suggest action based on issue state.
@@ -30,7 +31,7 @@ def suggest_action(
         status: Normalized issue status
         has_worker_done: Whether issue has worker-done label
         has_live_worker: Whether a tmux worker session is running
-        pr_labels: Labels on the associated PR
+        pr_is_draft: PR draft status (None if no PR, True if draft, False if ready)
         is_blocked: Whether the worker is blocked on user input
 
     Returns:
@@ -60,19 +61,18 @@ def suggest_action(
 
         case IssueStatus.NEEDS_REVIEW:
             if has_worker_done:
-                has_changes_requested = "worker-changes-requested" in pr_labels
-                has_approved = "worker-approved" in pr_labels
-
-                # Handle conflicting labels: treat as changes requested
-                # (controller will remove both labels, implementer will re-evaluate)
-                if has_changes_requested and has_approved:
+                # Review outcome is signaled by PR draft status:
+                # - PR ready (not draft) = approved → transition to retro
+                # - PR still draft = changes requested → resume implementer
+                # - No PR = wait for PR to be created
+                if pr_is_draft is None:
+                    # No PR yet - wait for it
+                    return "skip"
+                if pr_is_draft:
+                    # PR is draft = changes requested
                     return "resume_implementer_for_changes"
-                if has_changes_requested:
-                    return "resume_implementer_for_changes"
-                if has_approved:
-                    return "transition_to_retro"
-                # No PR label yet - wait for propagation
-                return "skip"
+                # PR is ready (not draft) = approved
+                return "transition_to_retro"
             if has_live_worker:
                 return "skip"
             return "dispatch_reviewer"
@@ -89,7 +89,7 @@ def suggest_action(
 
 
 # Direct mapping from action to worker mode
-ACTION_TO_MODE: dict[ActionType, str] = {
+ACTION_TO_MODE: dict[ActionType, WorkerModeLiteral] = {
     "skip": WorkerMode.IMPLEMENT,  # default
     "dispatch_planner": WorkerMode.PLAN,
     "dispatch_implementer": WorkerMode.IMPLEMENT,
@@ -121,7 +121,7 @@ def build_issue_state(data: FetchedIssueData, team_id: str) -> IssueState:
             status=data.status,
             has_worker_done="worker-done" in data.labels,
             has_live_worker=data.has_live_worker,
-            pr_labels=data.pr_labels,
+            pr_is_draft=data.pr_is_draft,
             is_blocked=data.is_blocked,
         )
 
@@ -132,7 +132,7 @@ def build_issue_state(data: FetchedIssueData, team_id: str) -> IssueState:
     return IssueState(
         status=data.status,
         labels=data.labels,
-        pr_labels=data.pr_labels,
+        pr_is_draft=data.pr_is_draft,
         has_live_worker=data.has_live_worker,
         suggested_action=action,
         session_id=session_id,

--- a/uv.lock
+++ b/uv.lock
@@ -80,6 +80,7 @@ dependencies = [
     { name = "anyio" },
     { name = "async-lru" },
     { name = "click" },
+    { name = "tenacity" },
 ]
 
 [package.dev-dependencies]
@@ -94,6 +95,7 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.0" },
     { name = "async-lru", specifier = ">=2.0" },
     { name = "click", specifier = ">=8.0" },
+    { name = "tenacity", specifier = ">=9.1.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -156,4 +158,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/00/44/a02e5877a671b0940f21a7a0d9704c22097b123ed5cdbcca9cab39f17acc/pytest-anyio-0.0.0.tar.gz", hash = "sha256:b41234e9e9ad7ea1dbfefcc1d6891b23d5ef7c9f07ccf804c13a9cc338571fd3", size = 1560, upload-time = "2021-06-29T22:57:30.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/25/bd6493ae85d0a281b6a0f248d0fdb1d9aa2b31f18bcd4a8800cf397d8209/pytest_anyio-0.0.0-py2.py3-none-any.whl", hash = "sha256:dc8b5c4741cb16ff90be37fddd585ca943ed12bbeb563de7ace6cd94441d8746", size = 1999, upload-time = "2021-06-29T22:57:29.158Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
 ]


### PR DESCRIPTION
## Summary

Replace GitHub PR labels (`worker-approved`, `worker-changes-requested`) with PR draft status for review outcome signaling:

- **PR ready (not draft)** = Review approved → transition to Retro
- **PR draft** = Changes requested → resume implementer

## Changes

### Python (`src/legion/state/`)
- `types.py`: `pr_labels: list[str]` → `pr_is_draft: bool | None`
- `decision.py`: Updated `suggest_action()` logic for draft status
- `fetch.py`: `get_pr_labels_batch()` → `get_pr_draft_status_batch()` (fetches `isDraft` via GraphQL)
- `__init__.py`: Updated exports

### Skills
- `legion-controller/SKILL.md`: Use `--resume` instead of `--session-id` for session resumption
- `legion-worker/SKILL.md`: Updated review signaling docs
- `workflows/review.md`: Use `gh pr ready` / `gh pr ready --undo`
- `references/linear-labels.md`: Updated documentation

### Docs
- Updated example JSON and code snippets in plans and solutions

## Test Plan
- [x] All 37 unit tests pass
- [x] E2E: State script correctly fetches `pr_is_draft` from GitHub GraphQL
- [x] E2E: `--resume` flag successfully continues existing sessions

🤖 Generated with [Claude Code](https://claude.ai/code)