### PR TITLE
feat: oracle sub-skill and user feedback relay

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,5 +6,11 @@
     "name": "Sami Jawhar"
   },
   "repository": "https://github.com/sjawhar/legion",
-  "license": "MIT"
+  "license": "MIT",
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,22 @@ legion/
 uv sync
 ```
 
+### Required Claude Code Plugins
+
+Legion workers use skills and agents from these plugins:
+
+| Plugin | Purpose |
+|--------|---------|
+| `superpowers@claude-plugins-official` | TDD, debugging, workflows |
+| `compound-engineering@every-marketplace` | Research agents, review agents |
+
+Install with:
+```bash
+legion install
+```
+
+**Note:** Context7 (for framework documentation lookup) is bundled in Legion's plugin config.
+
 ### Testing
 
 ```bash

--- a/docs/plans/2026-02-01-feat-oracle-skill-design-plan.md
+++ b/docs/plans/2026-02-01-feat-oracle-skill-design-plan.md
@@ -1,0 +1,316 @@
+# Oracle Skill Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add oracle research sub-skill for workers and user-feedback relay to controller.
+
+**Architecture:** Oracle is a worker workflow that searches docs/solutions/, codebase, and external docs before the worker escalates to the user. Controller handles `user-feedback-given` by prompting the blocked worker to read Linear comments.
+
+**Tech Stack:** Claude Code skills (markdown), Linear MCP, tmux
+
+---
+
+## Task 1: Create Oracle Workflow
+
+**Files:**
+- Create: `skills/legion-worker/workflows/oracle.md`
+
+**Step 1: Create the oracle workflow file**
+
+```markdown
+# Oracle Workflow
+
+Research skill for answering questions before escalating to user.
+
+## When to Use
+
+Invoke `/oracle [question]` when:
+- Unsure about existing patterns in the codebase
+- Documentation might exist but location unknown
+- Before using `AskUserQuestion` for something that might be documented
+
+## Research Strategy
+
+Search in this order until you find a clear answer:
+
+### 1. Institutional Learnings
+
+```bash
+# Search docs/solutions/ for relevant learnings
+Grep pattern: [keywords from question]
+Path: docs/solutions/
+```
+
+Read any matching files. These contain solved problems and established patterns.
+
+### 2. Codebase Patterns
+
+```bash
+# Search for similar implementations
+Grep pattern: [relevant function/class names]
+Path: src/
+```
+
+Look for existing code that solves similar problems.
+
+### 3. External Documentation
+
+If the question is about a framework or library:
+- Use `mcp__plugin_compound-engineering_context7__resolve-library-id` to find the library
+- Use `mcp__plugin_compound-engineering_context7__query-docs` to search documentation
+
+For general best practices:
+- Use `WebSearch` with specific technical queries
+
+## Output
+
+Return what you found:
+- If found: Provide the answer with source references
+- If not found: Say "I couldn't find enough information about [topic]"
+
+The calling workflow decides whether to proceed with the answer or escalate to the user.
+
+## Example
+
+```
+/oracle How does this codebase handle authentication?
+
+Searching docs/solutions/... found auth-patterns.md
+Searching src/... found src/auth/session.py
+
+Answer: Based on docs/solutions/auth-patterns.md and src/auth/session.py,
+authentication uses session-based auth with JWT tokens stored in httpOnly cookies.
+The Session class at src/auth/session.py:45 handles token validation.
+```
+```
+
+**Step 2: Verify file was created**
+
+Run: `cat skills/legion-worker/workflows/oracle.md | head -20`
+Expected: Shows the workflow header and "When to Use" section
+
+**Step 3: Commit**
+
+```bash
+jj describe -m "feat(worker): add oracle research workflow"
+```
+
+---
+
+## Task 2: Update Worker SKILL.md to Reference Oracle
+
+**Files:**
+- Modify: `skills/legion-worker/SKILL.md`
+
+**Step 1: Add oracle to the mode routing table**
+
+Add after the existing table (around line 32):
+
+```markdown
+## Research Sub-Skill
+
+Before using `AskUserQuestion`, workers should invoke the oracle:
+
+| Sub-Skill | Workflow | Purpose |
+|-----------|----------|---------|
+| `oracle` | @workflows/oracle.md | Research before escalating |
+
+Usage: `/oracle [your question]`
+```
+
+**Step 2: Verify the change**
+
+Run: `grep -A5 "Research Sub-Skill" skills/legion-worker/SKILL.md`
+Expected: Shows the new section with oracle reference
+
+**Step 3: Commit**
+
+```bash
+jj describe -m "feat(worker): reference oracle sub-skill in SKILL.md"
+```
+
+---
+
+## Task 3: Add User Feedback Handling to Controller
+
+**Files:**
+- Modify: `skills/legion-controller/SKILL.md`
+
+**Step 1: Add `relay_user_feedback` action to the process table**
+
+In section "2. Process Issues", add to the action table (around line 80):
+
+```markdown
+| `relay_user_feedback` | Prompt blocked worker to read Linear comments |
+```
+
+**Step 2: Add relay implementation after "Resume worker" section**
+
+Add after the "Resume worker" bash block (around line 114):
+
+```markdown
+**Relay user feedback:**
+```bash
+# When user-feedback-given label is present
+ISSUE_ID="ENG-21"
+ISSUE_ID_LOWER=$(echo "$ISSUE_ID" | tr '[:upper:]' '[:lower:]')
+SESSION="legion-$LEGION_SHORT_ID-worker-$ISSUE_ID_LOWER"
+
+# Prompt worker to read comments (safe - no user content injected)
+tmux send-keys -t "$SESSION:main" -l "User answered on Linear. Read the comments on your issue."
+tmux send-keys -t "$SESSION:main" Enter
+
+# Remove the user-feedback-given label
+mcp__linear__update_issue with:
+  id: <issue_id>
+  labelIds: [<all labels except user-feedback-given>]
+```
+```
+
+**Step 3: Verify the changes**
+
+Run: `grep -A10 "relay_user_feedback" skills/legion-controller/SKILL.md`
+Expected: Shows the new action and implementation
+
+**Step 4: Commit**
+
+```bash
+jj describe -m "feat(controller): add user feedback relay to blocked workers"
+```
+
+---
+
+## Task 4: Update State Module for Relay Action
+
+**Files:**
+- Modify: `src/legion/state/types.py`
+- Modify: `src/legion/state/decision.py`
+
+**Step 1: Add action type**
+
+In `src/legion/state/types.py`, find the `ActionType` literal and add:
+
+```python
+ActionType = Literal[
+    "skip",
+    "dispatch_planner",
+    "dispatch_implementer",
+    "dispatch_reviewer",
+    "dispatch_finisher",
+    "resume_implementer_for_changes",
+    "resume_implementer_for_retro",
+    "transition_to_in_progress",
+    "transition_to_retro",
+    "escalate_blocked",
+    "relay_user_feedback",  # Add this
+]
+```
+
+**Step 2: Add decision logic**
+
+In `src/legion/state/decision.py`, find where `has_user_feedback` is checked and add relay logic:
+
+```python
+# If worker is blocked AND user has provided feedback, relay it
+if data.is_blocked and data.has_user_feedback:
+    return "relay_user_feedback"
+```
+
+**Step 3: Run tests**
+
+Run: `uv run pytest tests/state/ -v`
+Expected: All tests pass (or identify which tests need updating)
+
+**Step 4: Commit**
+
+```bash
+jj describe -m "feat(state): add relay_user_feedback action"
+```
+
+---
+
+## Task 5: Add Test for Relay Action
+
+**Files:**
+- Modify: `tests/state/test_decision.py` (or appropriate test file)
+
+**Step 1: Write the test**
+
+```python
+def test_relay_user_feedback_when_blocked_with_feedback():
+    """When worker is blocked and user gave feedback, relay it."""
+    data = FetchedIssueData(
+        issue_id="ENG-21",
+        status="In Progress",
+        labels=["user-input-needed", "user-feedback-given"],
+        pr_is_draft=None,
+        has_live_worker=True,
+        is_blocked=True,
+        blocked_question="Which approach should I use?",
+        has_user_feedback=True,
+        has_user_input_needed=True,
+    )
+
+    action = suggest_action(data)
+
+    assert action == "relay_user_feedback"
+```
+
+**Step 2: Run the test**
+
+Run: `uv run pytest tests/state/test_decision.py::test_relay_user_feedback_when_blocked_with_feedback -v`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+jj describe -m "test(state): add test for relay_user_feedback action"
+```
+
+---
+
+## Task 6: Integration Test
+
+**Step 1: Verify oracle workflow is loadable**
+
+Run: `cat skills/legion-worker/workflows/oracle.md`
+Expected: Full oracle workflow content
+
+**Step 2: Verify controller references are consistent**
+
+Run: `grep -r "user-feedback-given" skills/`
+Expected: Shows controller SKILL.md with relay implementation
+
+**Step 3: Verify state module**
+
+Run: `uv run python -c "from legion.state.types import ActionType; print('relay_user_feedback' in ActionType.__args__)"`
+Expected: `True`
+
+**Step 4: Run full test suite**
+
+Run: `uv run pytest -x -q`
+Expected: All tests pass
+
+**Step 5: Final commit**
+
+```bash
+jj describe -m "feat: oracle sub-skill and user feedback relay
+
+- Add oracle.md workflow for research before escalation
+- Update worker SKILL.md to reference oracle
+- Add relay_user_feedback action to controller
+- Add state machine support for relay action"
+```
+
+---
+
+## Summary
+
+| Task | Files | Description |
+|------|-------|-------------|
+| 1 | `workflows/oracle.md` | Create oracle research workflow |
+| 2 | `SKILL.md` (worker) | Reference oracle sub-skill |
+| 3 | `SKILL.md` (controller) | Add user feedback relay |
+| 4 | `types.py`, `decision.py` | State machine for relay action |
+| 5 | `test_decision.py` | Test for relay action |
+| 6 | - | Integration verification |

--- a/docs/plans/2026-02-02-backlog-management-design.md
+++ b/docs/plans/2026-02-02-backlog-management-design.md
@@ -1,0 +1,304 @@
+# Legion Backlog Management Design
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Expand Legion to handle the full issue lifecycle, from raw intake through completion, with a persistent controller that builds context over time.
+
+---
+
+## Overview
+
+This design adds:
+
+1. **Persistent controller** - Builds context, handles triage directly, manages full lifecycle
+2. **New statuses** - Triage and Icebox for intake management
+3. **New `architect` worker mode** - Breaks down and specs Icebox items
+4. **Renamed `merge` mode** - Previously called `finish`
+
+**Key insight:** `worker-done` is the universal signal for "controller should take action." Items without it sit and wait.
+
+---
+
+## Status Flow
+
+```
+Triage ──┬──► Icebox ──► Backlog ──► Todo ──► In Progress ──► Needs Review ──► Retro ──► Done
+         │                  ▲           ▲            ▲               │
+         │                  │           │            │               │
+         ├──────────────────┘           │            └───────────────┘
+         │   (already spec-ready)       │            (changes requested)
+         │                              │
+         └──────────────────────────────┘
+                    (urgent + clear)
+```
+
+| Status | Description | Who acts |
+|--------|-------------|----------|
+| Triage | Raw incoming items | Controller routes |
+| Icebox | Needs architecture work | Controller pulls when capacity |
+| Backlog | Holding area for spec work | Architect processes, controller moves forward |
+| Todo | Ready for implementation planning | Planner processes |
+| In Progress | Being implemented | Implementer processes |
+| Needs Review | PR open, needs review | Reviewer processes |
+| Retro | Capturing learnings | Retro worker processes |
+| Done | Ready to merge and close | Merge worker processes |
+
+---
+
+## Controller (Persistent)
+
+The controller is persistent to build context about ongoing work. This enables smarter triage decisions based on current priorities and in-flight work.
+
+### Query Priority
+
+Each iteration, the controller processes in order:
+
+1. **Urgent Triage items** - Route high-priority items first
+2. **`worker-done` items** (any status) - Process completions, move forward
+3. **Non-urgent Triage items** - Route remaining triage items
+4. **If capacity remains** - Pull from Icebox, move to Backlog, dispatch architect
+
+**Implementation note:** Design the query to fetch all needed data in a single GraphQL call from Linear, then process in priority order locally.
+
+### Triage Logic
+
+When the controller sees a Triage item:
+
+1. Read title, description, comments
+2. Assess and route:
+   - **Blocking bug / urgent + clear** → Todo (dispatch planner)
+   - **Well-specified feature** → Backlog (will get prioritized)
+   - **Vague / large / needs breakdown** → Icebox (will get architect)
+3. Set appropriate priority
+
+The controller's persistence lets it consider context: related in-flight work, recent patterns, overall capacity.
+
+### Processing `worker-done`
+
+When the controller sees an item with `worker-done`:
+
+| Current Status | Action |
+|----------------|--------|
+| Backlog | Move to Todo, dispatch planner |
+| Todo | Move to In Progress, dispatch implementer |
+| In Progress | Move to Needs Review, dispatch reviewer |
+| Needs Review (PR ready) | Move to Retro, dispatch retro worker |
+| Needs Review (PR draft) | Keep in Needs Review, resume implementer |
+| Retro | Move to Done, dispatch merge worker |
+
+Always remove `worker-done` after processing.
+
+### Pulling from Icebox
+
+When the controller has capacity:
+
+1. Select highest priority Icebox item
+2. Move to Backlog
+3. Dispatch architect
+
+### Health Implications
+
+Since the controller is persistent:
+- Daemon must monitor for staleness carefully
+- May need periodic context summarization
+- Session resume strategy on crash/restart
+
+---
+
+## Worker Modes
+
+| Mode | Dispatched for | Output | Adds `worker-done` |
+|------|----------------|--------|-------------------|
+| `architect` | Backlog (from Icebox) | Spec-ready issue(s) | Yes (or on children) |
+| `plan` | Todo | Executable implementation plan | Yes |
+| `implement` | In Progress | PR opened | No |
+| `review` | Needs Review | PR marked ready/draft | Yes |
+| `retro` | Retro | Learnings documented | Yes |
+| `merge` | Done | PR merged, workspace cleaned | No |
+
+### Architect Workflow
+
+**Purpose:** Turn vague/large Icebox items into spec-ready work.
+
+**Definition of Ready** (what "spec-ready" means):
+
+- Clear problem statement (what and why)
+- Acceptance criteria (testable conditions)
+- Right-sized (fits in one PR, 1-3 days implementation)
+- No unresolved blocking questions
+
+Uses INVEST as a guide:
+- **I**ndependent - No blocking dependencies
+- **N**egotiable - Details refined during planning
+- **V**aluable - Clear user/business value
+- **E**stimable - Small enough to estimate
+- **S**mall - Reasonable work unit
+- **T**estable - Has acceptance criteria
+
+**Workflow:**
+
+```
+1. Fetch Backlog issue (controller already moved it from Icebox)
+2. Read title, description, comments
+3. Assess size and clarity
+
+4. If unclear requirements:
+   → Add `user-input-needed` label
+   → Post comment with specific questions
+   → Exit (no `worker-done`)
+
+5. If needs research:
+   → Invoke oracle for guidance
+   → Reassess with new context
+
+6. If too big (won't fit in one PR):
+   → Create sub-issues in Backlog, each with `worker-done`
+   → Leave parent in Backlog (no label)
+   → Exit
+   (Controller will move children to Todo)
+   (Linear auto-closes parent when children complete)
+
+7. If spec-ready:
+   → Add/refine acceptance criteria in description
+   → Add `worker-done`
+   → Exit
+   (Controller will move to Todo)
+```
+
+**Sub-issue creation:**
+
+When breaking down, architect creates Linear sub-issues:
+- Title: Clear description of subset
+- Description: Scoped requirements, acceptance criteria
+- Status: Backlog
+- Parent: Linked via Linear's parent field
+- Label: `worker-done` (so controller picks them up)
+
+### Plan Workflow
+
+No changes from existing. See `skills/legion-worker/workflows/plan.md`.
+
+### Implement Workflow
+
+No changes from existing. See `skills/legion-worker/workflows/implement.md`.
+
+### Review Workflow
+
+No changes from existing. See `skills/legion-worker/workflows/review.md`.
+
+### Retro Workflow
+
+No changes from existing. See `skills/legion-worker/workflows/retro.md`.
+
+### Merge Workflow (renamed from Finish)
+
+No changes from existing behavior. See `skills/legion-worker/workflows/finish.md` (to be renamed to `merge.md`).
+
+---
+
+## Labels
+
+Minimal label set:
+
+| Label | Meaning | Added by | Removed by |
+|-------|---------|----------|------------|
+| `worker-done` | Worker finished, controller should act | Worker | Controller |
+| `user-input-needed` | Blocked on human input | Worker | Controller |
+| `user-feedback-given` | Human answered | Human | Controller |
+
+**Key principle:** `worker-done` is the universal "ready for controller action" signal. Items without it are invisible to the controller (except Triage and Icebox pulls).
+
+---
+
+## Oracle
+
+The oracle is a skill (not a worker mode) that provides research and guidance. It can be invoked by:
+
+- **Controller** - For strategic/triage decisions
+- **Architect** - For requirements research
+- **Implementer** - For technical guidance
+- **Planner** - For approach decisions
+
+See existing `/oracle` skill usage in `skills/legion-worker/workflows/plan.md`.
+
+---
+
+## Parent Issue Handling
+
+When architect breaks down a large issue:
+
+1. Parent stays in Backlog with **no label**
+2. Children created in Backlog with `worker-done`
+3. Controller sees children's `worker-done`, moves them to Todo
+4. Parent sits in Backlog, invisible to controller
+5. Linear auto-closes parent when all children complete
+
+**Why parent is safe from re-processing:**
+- Controller only acts on `worker-done` items (for moving forward)
+- Controller only pulls from Icebox (not Backlog) for new architect work
+- Parent has no `worker-done`, so controller ignores it
+
+---
+
+## Implementation Tasks
+
+### Task 1: Add new Linear statuses
+
+Create in Linear:
+- Triage
+- Icebox
+
+Verify existing:
+- Backlog
+- Todo
+- In Progress
+- Needs Review
+- Retro (may need to create)
+- Done
+
+### Task 2: Update controller skill
+
+Modify `skills/legion-controller/SKILL.md`:
+- Make persistent (remove "exit after one iteration")
+- Add triage logic (routing)
+- Add Icebox pull logic
+- Update query patterns for `worker-done` processing
+
+### Task 3: Create architect workflow
+
+Create `skills/legion-worker/workflows/architect.md`:
+- Definition of Ready criteria
+- Breakdown logic
+- Sub-issue creation
+- Oracle integration
+
+### Task 4: Update worker skill routing
+
+Modify `skills/legion-worker/SKILL.md`:
+- Add `architect` mode
+- Rename `finish` to `merge` in routing table
+
+### Task 5: Rename finish workflow
+
+Rename `skills/legion-worker/workflows/finish.md` to `merge.md`
+
+### Task 6: Update daemon for persistent controller
+
+Modify daemon to handle persistent controller:
+- Health monitoring changes
+- Context management
+- Session resume on crash
+
+### Task 7: Update state machine
+
+Modify `src/legion/state/` to handle new statuses and transitions.
+
+---
+
+## Open Questions
+
+1. **Controller context management** - How do we handle context window limits for a persistent controller? Periodic summarization? Session handoff?
+
+2. **Icebox prioritization** - How does controller decide which Icebox item to pull? FIFO? Priority field? Age?
+
+3. **Capacity detection** - How does controller know it "has capacity" to pull from Icebox? Based on active worker count? Time since last dispatch?

--- a/docs/plans/2026-02-02-feat-architect-workflow-plan.md
+++ b/docs/plans/2026-02-02-feat-architect-workflow-plan.md
@@ -1,0 +1,194 @@
+---
+title: "feat: Create Architect Workflow for Legion Worker"
+type: feat
+date: 2026-02-02
+---
+
+# Create Architect Workflow for Legion Worker
+
+## Overview
+
+Add a new `architect` worker mode that turns vague/large Backlog items into spec-ready work. The architect assesses issues for clarity and size, breaks down large issues into sub-issues, and adds acceptance criteria.
+
+## Problem Statement
+
+Legion workers can only handle well-specified issues. Vague or large issues sit without a path to implementation. The architect fills this gap.
+
+## Proposed Solution
+
+Create `skills/legion-worker/workflows/architect.md` with:
+- Simple decision: clear + small enough? → finalize. Too big? → break down. Unclear? → escalate.
+- Sub-issue creation via Linear MCP
+- Oracle available for research if needed
+
+## Technical Considerations
+
+**Environment simplification**: Workers are launched in their workspace directory. The only required environment variable is `LINEAR_ISSUE_ID`. Remove `WORKSPACE_DIR` and `LEGION_DIR` requirements from SKILL.md.
+
+**Linear API gotchas**:
+- `parentId` must be UUID (call `get_issue` first to resolve)
+- `labels` array on `update_issue` replaces all labels (fetch current first)
+- Label objects have `.name` property - extract names before updating
+
+---
+
+## Acceptance Criteria
+
+- [x] `skills/legion-worker/workflows/architect.md` created
+- [x] `skills/legion-worker/SKILL.md` routing table includes `architect` mode
+- [x] `skills/legion-worker/SKILL.md` environment simplified to just `LINEAR_ISSUE_ID`
+- [x] Workflow follows existing patterns (numbered steps, MCP tool calls)
+
+---
+
+## Implementation Tasks
+
+### Task 1: Create architect workflow file
+
+**File:** `skills/legion-worker/workflows/architect.md`
+
+```markdown
+# Architect Workflow
+
+Turn Backlog issues into spec-ready work.
+
+## Workflow
+
+```dot
+digraph {
+    rankdir=LR;
+    fetch [label="1. Fetch"];
+    assess [label="2. Assess"];
+    act [label="3. Act"];
+    fetch -> assess -> act;
+}
+```
+
+### 1. Fetch Issue
+
+```
+mcp__linear__get_issue with id: $LINEAR_ISSUE_ID
+mcp__linear__list_comments with issueId: $LINEAR_ISSUE_ID
+```
+
+Extract title, description, comments, current labels.
+
+### 2. Assess
+
+**Is it clear?** Does it have testable acceptance criteria and no unresolved questions?
+
+If unclear and researchable, try `/oracle [your question]`.
+If still unclear, escalate.
+
+**Is it small enough?** Could it be split into independent, shippable pieces?
+
+### 3. Act
+
+**If unclear:** Add `user-input-needed` label, post comment with specific questions, exit.
+
+**If too big:** Break down into sub-issues. Each sub-issue must be spec-ready:
+- Clear problem statement (what needs to change and why)
+- Testable acceptance criteria (how we verify it's done)
+- Small enough for one PR
+- No blocking questions
+
+Create each sub-issue with `worker-done` label. Leave parent unlabeled. Exit.
+
+**If spec-ready:** Ensure acceptance criteria are present and testable, add `worker-done` label. Exit.
+
+## What Makes Good Acceptance Criteria
+
+Acceptance criteria must be **testable** - a human or CI can verify pass/fail.
+
+**Bad (vague):**
+- "Should be fast"
+- "Handle errors gracefully"
+- "Nice UX"
+
+**Good (testable):**
+- "Page loads in under 500ms"
+- "Shows error message with retry button on API timeout"
+- "Form validates email format before submit"
+
+Each criterion should answer: "How will we know this is done?"
+
+## Sub-Issue Creation
+
+```
+parent = mcp__linear__get_issue with id: $LINEAR_ISSUE_ID
+
+mcp__linear__create_issue with:
+  title: [Scoped title]
+  team: [Same team as parent]
+  parentId: parent.id  # UUID required
+  description: |
+    ## Acceptance Criteria
+    - [ ] [Testable condition]
+
+    Part of $LINEAR_ISSUE_ID.
+  state: "Backlog"
+  labels: ["worker-done"]
+```
+
+Post comment to parent explaining the breakdown.
+
+## Updating Labels
+
+Labels array replaces all labels. Fetch current labels first:
+
+```
+issue = mcp__linear__get_issue with id: $LINEAR_ISSUE_ID
+current_label_names = [label.name for label in issue.labels]
+
+mcp__linear__update_issue with:
+  id: $LINEAR_ISSUE_ID
+  labels: current_label_names + ["worker-done"]
+```
+
+## Completion Signals
+
+| Outcome | Label | On |
+|---------|-------|-----|
+| Spec-ready | `worker-done` | Issue |
+| Broken down | `worker-done` | Each child |
+| Broken down | (none) | Parent |
+| Unclear | `user-input-needed` | Issue |
+
+## Common Mistakes
+
+| Mistake | Correction |
+|---------|------------|
+| Adding `worker-done` to parent after breakdown | Only children get it |
+| Using identifier as `parentId` | Must use UUID from `get_issue` |
+| Updating labels without fetching current | Fetch first, then append |
+```
+
+### Task 2: Update worker skill
+
+**File:** `skills/legion-worker/SKILL.md`
+
+**Changes:**
+
+1. Add `architect` to Mode Routing table:
+```markdown
+| Mode | Workflow | Adds `worker-done` |
+|------|----------|-------------------|
+| `architect` | @workflows/architect.md | Yes (or on children) |
+```
+
+2. Simplify Environment section to:
+```markdown
+## Environment
+
+Required:
+- `LINEAR_ISSUE_ID` - issue identifier (e.g., `ENG-21`)
+```
+
+3. Update lifecycle: architect → plan → implement → review → retro → finish
+
+---
+
+## References
+
+- Design document: `docs/plans/2026-02-02-backlog-management-design.md`
+- Existing workflow pattern: `skills/legion-worker/workflows/plan.md`

--- a/docs/solutions/integration-issues/github-graphql-pr-draft-status.md
+++ b/docs/solutions/integration-issues/github-graphql-pr-draft-status.md
@@ -1,0 +1,178 @@
+---
+title: "Using PR draft status instead of labels for review signaling"
+category: integration-issues
+tags:
+  - github
+  - graphql
+  - pull-requests
+  - state-machine
+  - pr-review
+  - draft-status
+  - batching
+module: legion.state
+component: fetch/decision
+symptoms:
+  - needed to detect PR review outcome for worker dispatch
+  - PR labels required worker to manage label state
+  - race conditions possible with label-based signaling
+  - extra API call needed to apply labels
+date_solved: 2026-02-01
+---
+
+# Using PR Draft Status Instead of Labels for Review Signaling
+
+## Problem
+
+Legion's state collection system needed to detect whether a GitHub PR was approved or had changes requested to determine the next action for worker dispatch. The initial approach used GitHub PR labels (`worker-approved`, `worker-changes-requested`), but this had problems:
+
+- **Label management complexity**: Required the review worker to add/remove labels on the PR
+- **Race conditions**: Labels could be in inconsistent states
+- **Extra API calls**: Needed to fetch PR labels separately for each PR
+- **Fragile coupling**: Relied on workers correctly managing label state
+
+## Solution
+
+Replace label-based signaling with the **native GitHub `isDraft` field**:
+
+- PR in draft state = changes requested (needs more work)
+- PR ready for review (not draft) = approved (ready to merge)
+
+This leverages GitHub's built-in PR workflow semantics and eliminates custom label management.
+
+## Implementation
+
+### 1. GitHubPRRef Type (types.py)
+
+Immutable value object for parsing PR URLs with input validation:
+
+```python
+@dataclass(frozen=True)
+class GitHubPRRef:
+    """Parsed GitHub PR reference from URL (immutable value object)."""
+
+    owner: str
+    repo: str
+    number: int
+
+    @classmethod
+    def from_url(cls, url: str) -> "GitHubPRRef | None":
+        """Parse a GitHub PR URL into a reference."""
+        match = re.match(r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)", url)
+        if not match:
+            return None
+        owner, repo = match.group(1), match.group(2)
+        # Validate owner/repo contain only safe characters
+        if not re.match(r"^[\w.-]+$", owner) or not re.match(r"^[\w.-]+$", repo):
+            return None
+        return cls(owner=owner, repo=repo, number=int(match.group(3)))
+```
+
+### 2. Batch GraphQL Fetching (fetch.py)
+
+Single GraphQL query with aliases to fetch multiple PRs across multiple repos:
+
+```python
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(GitHubAPIError),
+    reraise=True,
+)
+async def get_pr_draft_status_batch(
+    pr_refs: dict[str, GitHubPRRef],
+    *,
+    runner: CommandRunner = default_runner,
+) -> dict[str, bool | None]:
+    """Fetch PR draft status for multiple issues in a single GraphQL query."""
+    # Group by repository, build aliases, construct query...
+    query = f"query {{ {' '.join(query_parts)} }}"
+```
+
+**Generated GraphQL Query Example:**
+```graphql
+query {
+  repo0: repository(owner: "myorg", name: "myrepo") {
+    pr0: pullRequest(number: 123) { isDraft }
+    pr1: pullRequest(number: 456) { isDraft }
+  }
+  repo1: repository(owner: "otherorg", name: "otherrepo") {
+    pr0: pullRequest(number: 789) { isDraft }
+  }
+}
+```
+
+### 3. Decision Logic (decision.py)
+
+Uses `pr_is_draft` instead of labels to determine review outcome:
+
+```python
+case IssueStatus.NEEDS_REVIEW:
+    if has_worker_done:
+        # Review outcome is signaled by PR draft status:
+        # - PR ready (not draft) = approved → transition to retro
+        # - PR still draft = changes requested → resume implementer
+        # - No PR = wait for PR to be created
+        if pr_is_draft is None:
+            return "skip"
+        if pr_is_draft:
+            return "resume_implementer_for_changes"
+        return "transition_to_retro"
+```
+
+## Key Implementation Details
+
+| Aspect | Implementation |
+|--------|----------------|
+| **GraphQL Batching** | Uses aliases (`repo0`, `repo1`, `pr0`, `pr1`) to query multiple PRs in one call |
+| **Retry Logic** | `tenacity` with exponential backoff: 3 attempts, 1-10 second waits |
+| **Input Validation** | Regex validates owner/repo names contain only `[\w.-]+` to prevent injection |
+| **Null-Safe Parsing** | Uses `data.get("data") or {}` and checks for `isDraft` key presence |
+| **Error Handling** | Custom `GitHubAPIError` raised on non-zero exit or JSON parse failure |
+| **Type Safety** | `pr_is_draft: bool | None` - None means no PR exists, True/False for draft status |
+| **Selective Fetching** | Only queries PRs for issues in "Needs Review" status with `worker-done` label |
+
+## Prevention Strategies
+
+### Input Validation for URL-Derived Data
+- Always return `None` for parsing failures rather than raising exceptions
+- Validate extracted components against allowlists (alphanumeric, hyphen, underscore, dot)
+- Use anchored regexes (`^...$`) to prevent partial matches
+
+### Null-Safe Response Handling
+- Use `dict.get()` with fallback values (`or {}`) for nested access
+- Check for existence AND truthiness before accessing nested fields
+- Always provide a defined return value rather than omitting keys
+
+### Retry Logic for Transient Failures
+- Use exponential backoff to avoid overwhelming rate-limited APIs
+- Define a custom exception type for retryable failures
+- Limit retry attempts and re-raise after exhaustion
+
+## When to Use Batched GraphQL vs REST
+
+**Use Batched GraphQL when:**
+- Fetching the same field(s) from multiple entities
+- Data is spread across multiple repositories
+- Reducing API call count matters (rate limiting, latency)
+
+**Use REST when:**
+- Performing mutations
+- Simple single-resource queries
+- Using `gh` CLI's built-in commands
+
+## Related Documentation
+
+- [Controller Skill Redesign Plan](../../plans/2026-02-01-feat-controller-skill-redesign-plan.md) - Status transition rules
+- [Sync-to-Async Refactoring](../architecture-patterns/sync-to-async-modular-refactoring.md) - GraphQL batching pattern
+- [Worker Skill Design](../../plans/2026-01-31-worker-skill-design.md) - Issue state flow
+
+## Test Coverage
+
+Tests in `tests/test_state.py` cover:
+- Multiple PRs batched correctly
+- Missing PR returns `None`
+- `isDraft: null` treated as `False`
+- Retry exhaustion raises `GitHubAPIError`
+- Retry succeeds on transient failures
+- `{"data": null}` handled gracefully
+- Cross-repo batching in single query

--- a/skills/legion-controller/SKILL.md
+++ b/skills/legion-controller/SKILL.md
@@ -77,6 +77,7 @@ For each issue, execute the `suggested_action`:
 | `resume_implementer_for_retro` | Resume worker session, prompt to run retro |
 | `transition_to_in_progress` | Remove `worker-done`, update status to In Progress, dispatch implementer |
 | `transition_to_retro` | Remove `worker-done`, update status to Retro, resume implementer for retro |
+| `relay_user_feedback` | Prompt blocked worker to read Linear comments |
 | `escalate_blocked` | See step 3 |
 
 **Dispatch worker:**
@@ -111,6 +112,23 @@ tmux send-keys -t "$SESSION:main" \
 tmux send-keys -t "$SESSION:main" \
   "claude --dangerously-skip-permissions --resume '$SESSION_ID' \
    -p 'Continue: address PR comments'" Enter
+```
+
+**Relay user feedback:**
+```bash
+# When user-feedback-given label is present
+ISSUE_ID="ENG-21"
+ISSUE_ID_LOWER=$(echo "$ISSUE_ID" | tr '[:upper:]' '[:lower:]')
+SESSION="legion-$LEGION_SHORT_ID-worker-$ISSUE_ID_LOWER"
+
+# Prompt worker to read comments (safe - no user content injected)
+tmux send-keys -t "$SESSION:main" -l "User answered on Linear. Read the comments on your issue."
+tmux send-keys -t "$SESSION:main" Enter
+
+# Remove the user-feedback-given label
+mcp__linear__update_issue with:
+  id: <issue_id>
+  labelIds: [<all labels except user-feedback-given>]
 ```
 
 **Update Linear status:**

--- a/skills/legion-worker/SKILL.md
+++ b/skills/legion-worker/SKILL.md
@@ -11,27 +11,25 @@ Router skill for Legion issue work. Dispatched by controller with a mode paramet
 
 Required:
 - `LINEAR_ISSUE_ID` - issue identifier (e.g., `ENG-21`)
-- `WORKSPACE_DIR` - jj workspace path
-- `LEGION_DIR` - main Legion repo
 
 ## Essential Rules
 
 1. **Read Linear issue first** - `mcp__linear__get_issue`
-2. **Work in jj workspace** - all work in `$WORKSPACE_DIR`
-3. **Use jj, not git** - changes auto-tracked
-4. **Signal completion** - add `worker-done` label when done (see routing table)
+2. **Use jj, not git** - changes auto-tracked
+3. **Signal completion** - add `worker-done` label when done (see routing table)
 
 ## Mode Routing
 
 | Mode | Workflow | Adds `worker-done` |
 |------|----------|-------------------|
+| `architect` | @workflows/architect.md | Yes (or on children) |
 | `plan` | @workflows/plan.md | Yes |
 | `implement` | @workflows/implement.md | No |
 | `review` | @workflows/review.md | Yes |
 | `retro` | @workflows/retro.md | Yes |
 | `finish` | @workflows/finish.md | No |
 
-**Lifecycle order:** plan → implement → review → (implement if changes requested) → retro → finish
+**Lifecycle order:** architect → plan → implement → review → (implement if changes requested) → retro → finish
 
 Note: `retro` runs before `finish` because retro adds learnings to the workspace, and finish deletes it.
 
@@ -40,6 +38,16 @@ Note: `retro` runs before `finish` because retro adds learnings to the workspace
 Review signals outcome via PR draft status BEFORE `worker-done`:
 - **PR ready** (not draft) - no blocking issues, approved
 - **PR draft** - blocking issues found, changes requested
+
+## Research Sub-Skill
+
+Before using `AskUserQuestion`, workers should invoke the oracle:
+
+| Sub-Skill | Workflow | Purpose |
+|-----------|----------|---------|
+| `oracle` | @workflows/oracle.md | Research before escalating |
+
+Usage: `/oracle [your question]`
 
 ## Reference
 

--- a/skills/legion-worker/workflows/architect.md
+++ b/skills/legion-worker/workflows/architect.md
@@ -1,0 +1,124 @@
+# Architect Workflow
+
+Turn Backlog issues into spec-ready work.
+
+## Workflow
+
+```dot
+digraph {
+    rankdir=LR;
+    fetch [label="1. Fetch"];
+    assess [label="2. Assess"];
+    act [label="3. Act"];
+    fetch -> assess -> act;
+}
+```
+
+### 1. Fetch Issue
+
+```
+mcp__linear__get_issue with id: $LINEAR_ISSUE_ID
+mcp__linear__list_comments with issueId: $LINEAR_ISSUE_ID
+```
+
+Extract title, description, comments, current labels.
+
+### 2. Assess
+
+**Is it clear?** Does it have testable acceptance criteria and no unresolved questions?
+
+If unclear and researchable, try `/oracle [your question]`.
+If still unclear, escalate.
+
+**Is it small enough?** Could it be split into independent, shippable pieces?
+
+### 3. Act
+
+**If unclear:** Add `user-input-needed` label, post comment with specific questions, exit.
+
+**If too big:** Break down into sub-issues. Each sub-issue must be spec-ready:
+- Clear problem statement (what needs to change and why)
+- Testable acceptance criteria (how we verify it's done)
+- Small enough for one PR
+- No blocking questions
+
+Create each spec-ready sub-issue with `worker-done` label.
+
+**Partial breakdown allowed:** If some pieces are clear but others need clarification:
+1. Create sub-issues for the clear pieces (with `worker-done`)
+2. Add `user-input-needed` to parent with questions about unclear pieces
+3. Post comment listing created children AND what still needs clarification
+
+This unblocks work on clear pieces while getting answers on unclear ones.
+
+**If spec-ready:** Ensure acceptance criteria are present and testable, add `worker-done` label. Exit.
+
+## What Makes Good Acceptance Criteria
+
+Acceptance criteria must be **testable** - a human or CI can verify pass/fail.
+
+**Bad (vague):**
+- "Should be fast"
+- "Handle errors gracefully"
+- "Nice UX"
+
+**Good (testable):**
+- "Page loads in under 500ms"
+- "Shows error message with retry button on API timeout"
+- "Form validates email format before submit"
+
+Each criterion should answer: "How will we know this is done?"
+
+## Sub-Issue Creation
+
+```
+parent = mcp__linear__get_issue with id: $LINEAR_ISSUE_ID
+
+mcp__linear__create_issue with:
+  title: [Scoped title]
+  team: [Same team as parent]
+  parentId: parent.id  # UUID required
+  description: |
+    ## Acceptance Criteria
+    - [ ] [Testable condition]
+
+    Part of $LINEAR_ISSUE_ID.
+  state: "Backlog"
+  labels: ["worker-done"]
+```
+
+Post comment to parent explaining the breakdown.
+
+## Updating Labels
+
+Labels array replaces all labels. Fetch current labels first:
+
+```
+issue = mcp__linear__get_issue with id: $LINEAR_ISSUE_ID
+current_label_names = [label.name for label in issue.labels]
+
+mcp__linear__update_issue with:
+  id: $LINEAR_ISSUE_ID
+  labels: current_label_names + ["worker-done"]
+```
+
+## Completion Signals
+
+| Outcome | Action |
+|---------|--------|
+| Spec-ready | Add `worker-done` to issue |
+| Fully broken down | Add `worker-done` to each child, leave parent unchanged |
+| Partial breakdown | Add `worker-done` to clear children, add `user-input-needed` to parent |
+| Unclear | Add `user-input-needed` to issue |
+
+**After breakdown:** Parent keeps its existing labels. Do NOT add `worker-done` to parent - only children get it. Post comment to parent explaining what was created and what still needs clarification.
+
+## Common Mistakes
+
+| Mistake | Correction |
+|---------|------------|
+| Adding `worker-done` to parent after breakdown | Only children get it; parent stays unchanged |
+| Thinking "none" means remove labels from parent | "None" means don't add anything; keep existing labels |
+| Using identifier as `parentId` | Must use UUID from `get_issue` |
+| Updating labels without fetching current | Fetch first, then append |
+| Forgetting to comment on parent after breakdown | Always post comment explaining which children were created |

--- a/skills/legion-worker/workflows/oracle.md
+++ b/skills/legion-worker/workflows/oracle.md
@@ -1,0 +1,58 @@
+# Oracle Workflow
+
+Research institutional knowledge before escalating questions to users.
+
+## Core Principle
+
+**Check docs/solutions/ first.** This codebase captures learnings from past work.
+
+## When to Use
+
+```dot
+digraph oracle_decision {
+    "About to ask user a question?" [shape=diamond];
+    "Is it a preference/requirement?" [shape=diamond];
+    "Might be documented?" [shape=diamond];
+    "Ask user directly" [shape=box];
+    "Use oracle" [shape=box];
+
+    "About to ask user a question?" -> "Is it a preference/requirement?" [label="yes"];
+    "About to ask user a question?" -> "Ask user directly" [label="no - not asking"];
+    "Is it a preference/requirement?" -> "Ask user directly" [label="yes"];
+    "Is it a preference/requirement?" -> "Might be documented?" [label="no"];
+    "Might be documented?" -> "Use oracle" [label="yes"];
+    "Might be documented?" -> "Ask user directly" [label="no"];
+}
+```
+
+**Use oracle for:** patterns, conventions, solved problems, technical approaches
+
+**Ask directly for:** preferences, requirements, scope decisions, human judgment
+
+## Research Strategy
+
+Run steps 1-2 first (parallel OK), then 3-4 if needed:
+
+| Step | Tool | Query |
+|------|------|-------|
+| 1. Institutional learnings | `Task learnings-researcher` | Search docs/solutions/ for [question] |
+| 2. Codebase patterns | `Task Explore` | Find how src/ handles [topic] |
+| 3. Framework docs | Context7 MCP | resolve-library-id → query-docs |
+| 4. External practices | `Task best-practices-researcher` or `WebSearch` | Current best practices for [topic] |
+
+## Output
+
+**Found:** Answer with source (file:line or URL)
+
+**Not found:** "Checked docs/solutions/ and codebase - no relevant learnings found" → search externally OR escalate to user
+
+## Example
+
+```
+/oracle How should I handle GraphQL pagination?
+
+[learnings-researcher] → No matches
+[Explore] → Found src/legion/state/fetch.py uses cursor-based pagination
+
+Answer: Use cursor-based pagination per src/legion/state/fetch.py:42
+```

--- a/src/legion/state/fetch.py
+++ b/src/legion/state/fetch.py
@@ -328,7 +328,7 @@ async def check_worker_blocked_any_mode(
     Returns:
         Tuple of (is_blocked, question_text)
     """
-    for mode in (WorkerMode.IMPLEMENT, WorkerMode.REVIEW, WorkerMode.FINISH):
+    for mode in (WorkerMode.PLAN, WorkerMode.IMPLEMENT, WorkerMode.REVIEW, WorkerMode.FINISH):
         session_id = compute_session_id(team_id, issue_id, mode)
         session_file = session_dir / f"{session_id}.jsonl"
         blocked, question = await check_worker_blocked(session_file)
@@ -401,9 +401,6 @@ def parse_linear_issues(
             issue_id=issue_id,
             status=status,
             labels=labels,
-            has_worker_done="worker-done" in labels,
-            has_user_feedback="user-feedback-given" in labels,
-            has_user_input_needed="user-input-needed" in labels,
             pr_ref=pr_ref,
         ))
 


### PR DESCRIPTION
## Summary

- Add oracle workflow for workers to research before escalating questions to users
- Add `relay_user_feedback` action for controller to notify blocked workers when users respond
- Improve test coverage for blocked worker scenarios
- Type safety improvements in state module

## Changes

**New files:**
- `skills/legion-worker/workflows/oracle.md` - Research workflow (docs/solutions/, codebase, external docs)

**Modified:**
- `skills/legion-worker/SKILL.md` - Reference oracle sub-skill
- `skills/legion-controller/SKILL.md` - Add relay_user_feedback action
- `src/legion/state/types.py` - Add relay_user_feedback to ActionType, improve TypedDicts
- `src/legion/state/decision.py` - Add relay logic (blocked + feedback → relay)
- `src/legion/state/fetch.py` - Add PLAN mode to blocked check, simplify ParsedIssue
- `tests/test_state.py` - Add comprehensive tests for relay scenarios

## Test plan

- [x] All 101 tests pass
- [x] Type imports work correctly
- [x] Edge cases covered (dead workers, missing feedback, multiple statuses)

🤖 Generated with [Claude Code](https://claude.ai/code)