### PR TITLE
feat: implement backlog management with persistent controller

### DIFF
--- a/.github/workflows/pr-and-main.yaml
+++ b/.github/workflows/pr-and-main.yaml
@@ -1,0 +1,91 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  UV_VERSION: 0.9.18
+
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7.1.2
+        with:
+          version: "${{ env.UV_VERSION }}"
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.0.0
+        with:
+          python-version-file: pyproject.toml
+
+      - name: Install dependencies
+        run: |-
+          uv sync --all-extras --all-groups --locked
+          echo "$(pwd)/.venv/bin" >> $GITHUB_PATH
+
+      - name: Run lint
+        run: |-
+          ruff check . --output-format=github
+          ruff format --check .
+
+  typecheck:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7.1.2
+        with:
+          version: "${{ env.UV_VERSION }}"
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.0.0
+        with:
+          python-version-file: pyproject.toml
+
+      - name: Install dependencies
+        run: |-
+          uv sync --all-extras --all-groups --locked
+          echo "$(pwd)/.venv/bin" >> $GITHUB_PATH
+
+      - name: Run typecheck
+        run: basedpyright .
+
+  test:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7.1.2
+        with:
+          version: "${{ env.UV_VERSION }}"
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.0.0
+        with:
+          python-version-file: pyproject.toml
+
+      - name: Install dependencies
+        run: |-
+          uv sync --all-extras --all-groups --locked
+          echo "$(pwd)/.venv/bin" >> $GITHUB_PATH
+
+      - name: Run tests
+        run: pytest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ legion/
 │   └── short_id.py      # Legion instance IDs
 ├── skills/              # Claude Code skills
 │   ├── legion-controller/  # Polls Linear, dispatches workers
-│   └── legion-worker/      # Implements issues (plan/implement/review/retro/finish)
+│   └── legion-worker/      # Implements issues (plan/implement/review/retro/merge)
 ├── hooks/               # Claude Code hooks
 ├── tests/               # pytest test suite
 └── docs/
@@ -30,6 +30,8 @@ legion/
 - **Click** for CLI
 - **uv** for package management
 - **pytest** for testing
+- **ruff** for linting and formatting
+- **basedpyright** for type checking
 - **jj (Jujutsu)** for version control with workspaces
 - **Linear MCP** for issue tracking
 - **tmux** for worker session management
@@ -58,10 +60,13 @@ legion install
 
 **Note:** Context7 (for framework documentation lookup) is bundled in Legion's plugin config.
 
-### Testing
+### Quality Checks
 
 ```bash
-uv run pytest
+uv run ruff check .        # Lint
+uv run ruff format --check # Format check
+uv run basedpyright .      # Type check
+uv run pytest              # Test
 ```
 
 ### Version Control
@@ -89,21 +94,26 @@ Linear Issue → Controller → Worker (in jj workspace) → PR → Review → M
 ### Issue Lifecycle
 
 ```
-Todo → In Progress → Needs Review → Retro → Done
-         ↑              │
-         └──────────────┘
-         (changes requested)
+Triage ──┬──► Icebox ──► Backlog ──► Todo ──► In Progress ──► Needs Review ──► Retro ──► Done
+         │                  ^           ^            ^               │
+         │                  │           │            │               │
+         ├──────────────────┘           │            └───────────────┘
+         │   (already spec-ready)       │            (changes requested)
+         │                              │
+         └──────────────────────────────┘
+                    (urgent + clear)
 ```
 
 ### Worker Modes
 
 | Mode | Phase | Output |
 |------|-------|--------|
+| `architect` | Backlog | Spec-ready issue or sub-issues |
 | `plan` | Todo | Plan posted to Linear |
 | `implement` | In Progress | PR opened |
 | `review` | Needs Review | PR labeled |
 | `retro` | Retro | Learnings documented |
-| `finish` | Done | PR merged, workspace cleaned |
+| `merge` | Done | PR merged, workspace cleaned |
 
 ### Labels
 

--- a/docs/plans/2026-02-02-feat-persistent-controller-daemon-plan.md
+++ b/docs/plans/2026-02-02-feat-persistent-controller-daemon-plan.md
@@ -1,0 +1,1028 @@
+# Persistent Controller Daemon Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Update Legion daemon to supervise persistent controller with deterministic session IDs, session file-based liveness detection, and auto-restart.
+
+**Architecture:** Daemon monitors controller health by checking Claude Code session file mtime. Uses deterministic UUIDv5 session IDs so controller can resume context after restart. Controller runs in tmux, daemon restarts it if stale or crashed.
+
+**Tech Stack:** Python 3.13+, anyio, pytest, tmux, Claude Code CLI
+
+---
+
+## Task 1: Add `compute_controller_session_id` to types.py
+
+**Files:**
+- Modify: `src/legion/state/types.py:310-327` (after `compute_session_id`)
+- Test: `tests/test_state.py`
+
+**Step 1: Write the failing test**
+
+```python
+# Add to tests/test_state.py after TestComputeSessionId class
+
+class TestComputeControllerSessionId:
+    """Test controller session ID generation."""
+
+    def test_returns_uuid_string(self) -> None:
+        team_id = "7b4f0862-b775-4cb0-9a67-85400c6f44a8"
+        result = types.compute_controller_session_id(team_id)
+        parsed = uuid.UUID(result)
+        assert str(parsed) == result
+
+    def test_same_input_same_output(self) -> None:
+        team_id = "7b4f0862-b775-4cb0-9a67-85400c6f44a8"
+        result1 = types.compute_controller_session_id(team_id)
+        result2 = types.compute_controller_session_id(team_id)
+        assert result1 == result2
+
+    def test_different_from_worker_session_id(self) -> None:
+        team_id = "7b4f0862-b775-4cb0-9a67-85400c6f44a8"
+        controller_id = types.compute_controller_session_id(team_id)
+        worker_id = types.compute_session_id(team_id, "ENG-21", "implement")
+        assert controller_id != worker_id
+
+    def test_raises_value_error_for_invalid_team_id(self) -> None:
+        with pytest.raises(ValueError):
+            types.compute_controller_session_id("not-a-valid-uuid")
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_state.py::TestComputeControllerSessionId -v`
+Expected: FAIL with "AttributeError: module 'legion.state.types' has no attribute 'compute_controller_session_id'"
+
+**Step 3: Write minimal implementation**
+
+Add to `src/legion/state/types.py` after `compute_session_id`:
+
+```python
+def compute_controller_session_id(team_id: str) -> str:
+    """Compute deterministic session ID for controller.
+
+    Args:
+        team_id: Linear team UUID (must be valid UUID string)
+
+    Returns:
+        UUID string for the controller session
+
+    Raises:
+        ValueError: If team_id is not a valid UUID string
+    """
+    namespace = uuid.UUID(team_id)
+    return str(uuid.uuid5(namespace, "controller"))
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_state.py::TestComputeControllerSessionId -v`
+Expected: PASS (4 tests)
+
+**Step 5: Commit**
+
+```bash
+jj desc -m "feat(types): add compute_controller_session_id"
+```
+
+---
+
+## Task 2: Add `get_session_file_path` to daemon.py
+
+**Files:**
+- Modify: `src/legion/daemon.py` (add import and function)
+- Test: `tests/test_daemon.py` (create new file)
+
+**Step 1: Write the failing test**
+
+Create `tests/test_daemon.py`:
+
+```python
+"""Tests for daemon module."""
+
+from pathlib import Path
+
+from legion import daemon
+
+
+class TestGetSessionFilePath:
+    """Test Claude session file path computation."""
+
+    def test_encodes_simple_path(self) -> None:
+        workspace = Path("/home/sami/legion/default")
+        session_id = "abc-123"
+        result = daemon.get_session_file_path(workspace, session_id)
+        assert result == Path.home() / ".claude/projects/-home-sami-legion-default/abc-123.jsonl"
+
+    def test_encodes_dots_as_dashes(self) -> None:
+        workspace = Path("/home/sami/.dotfiles")
+        session_id = "abc-123"
+        result = daemon.get_session_file_path(workspace, session_id)
+        assert result == Path.home() / ".claude/projects/-home-sami--dotfiles/abc-123.jsonl"
+
+    def test_handles_trailing_slash(self) -> None:
+        workspace = Path("/home/sami/legion/default/")
+        session_id = "abc-123"
+        result = daemon.get_session_file_path(workspace, session_id)
+        # Path normalizes trailing slash
+        assert "-default-" not in str(result) or result.name == "abc-123.jsonl"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_daemon.py::TestGetSessionFilePath -v`
+Expected: FAIL with "AttributeError: module 'legion.daemon' has no attribute 'get_session_file_path'"
+
+**Step 3: Write minimal implementation**
+
+Add import at top of `src/legion/daemon.py` (after existing imports):
+
+```python
+import re
+```
+
+Add function after `validate_project_id`:
+
+```python
+def get_session_file_path(workspace: Path, session_id: str) -> Path:
+    """Get path to Claude Code session file.
+
+    Claude Code encodes workspace paths by replacing all non-alphanumeric
+    characters with dashes. Examples:
+    - /home/sami/legion/default -> -home-sami-legion-default
+    - /home/sami/.dotfiles -> -home-sami--dotfiles
+    """
+    encoded = re.sub(r"[^a-zA-Z0-9]", "-", str(workspace))
+    return Path.home() / ".claude" / "projects" / encoded / f"{session_id}.jsonl"
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_daemon.py::TestGetSessionFilePath -v`
+Expected: PASS (3 tests)
+
+**Step 5: Commit**
+
+```bash
+jj desc -m "feat(daemon): add get_session_file_path helper"
+```
+
+---
+
+## Task 3: Add `get_newest_mtime` to daemon.py
+
+**Files:**
+- Modify: `src/legion/daemon.py`
+- Test: `tests/test_daemon.py`
+
+**Step 1: Write the failing test**
+
+Add to `tests/test_daemon.py`:
+
+```python
+import tempfile
+import time
+
+import pytest
+
+
+class TestGetNewestMtime:
+    """Test session file mtime detection."""
+
+    @pytest.mark.anyio
+    async def test_returns_none_when_file_missing(self, tmp_path: Path) -> None:
+        session_file = tmp_path / "missing.jsonl"
+        result = await daemon.get_newest_mtime(session_file)
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_returns_mtime_of_session_file(self, tmp_path: Path) -> None:
+        session_file = tmp_path / "session.jsonl"
+        session_file.touch()
+        result = await daemon.get_newest_mtime(session_file)
+        assert result is not None
+        assert abs(result - time.time()) < 2  # Within 2 seconds
+
+    @pytest.mark.anyio
+    async def test_returns_newest_from_subagents(self, tmp_path: Path) -> None:
+        # Create session file
+        session_file = tmp_path / "session.jsonl"
+        session_file.touch()
+        old_mtime = session_file.stat().st_mtime
+
+        # Create subagent dir with newer file
+        subagent_dir = tmp_path / "session" / "subagents"
+        subagent_dir.mkdir(parents=True)
+        time.sleep(0.1)  # Ensure different mtime
+        subagent_file = subagent_dir / "agent-1.jsonl"
+        subagent_file.touch()
+
+        result = await daemon.get_newest_mtime(session_file)
+        assert result is not None
+        assert result > old_mtime
+
+    @pytest.mark.anyio
+    async def test_ignores_non_jsonl_subagent_files(self, tmp_path: Path) -> None:
+        session_file = tmp_path / "session.jsonl"
+        session_file.touch()
+        session_mtime = session_file.stat().st_mtime
+
+        subagent_dir = tmp_path / "session" / "subagents"
+        subagent_dir.mkdir(parents=True)
+        time.sleep(0.1)
+        (subagent_dir / "not-a-jsonl.txt").touch()
+
+        result = await daemon.get_newest_mtime(session_file)
+        assert result == session_mtime
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_daemon.py::TestGetNewestMtime -v`
+Expected: FAIL with "AttributeError: module 'legion.daemon' has no attribute 'get_newest_mtime'"
+
+**Step 3: Write minimal implementation**
+
+Add to `src/legion/daemon.py`:
+
+```python
+async def get_newest_mtime(session_file: Path) -> float | None:
+    """Get newest mtime from session file and any subagent files.
+
+    Returns None if session file doesn't exist.
+    """
+    session_path = anyio.Path(session_file)
+    if not await session_path.exists():
+        return None
+
+    newest = (await session_path.stat()).st_mtime
+
+    # Check subagent files
+    subagents_dir = session_file.parent / session_file.stem / "subagents"
+    subagents_path = anyio.Path(subagents_dir)
+    if await subagents_path.exists():
+        async for entry in subagents_path.iterdir():
+            if entry.suffix == ".jsonl":
+                stat = await entry.stat()
+                newest = max(newest, stat.st_mtime)
+
+    return newest
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_daemon.py::TestGetNewestMtime -v`
+Expected: PASS (4 tests)
+
+**Step 5: Commit**
+
+```bash
+jj desc -m "feat(daemon): add get_newest_mtime for session liveness"
+```
+
+---
+
+## Task 4: Add `new_session` to tmux.py
+
+**Files:**
+- Modify: `src/legion/tmux.py`
+- Test: `tests/test_tmux.py` (create new file)
+
+**Step 1: Write the failing test**
+
+Create `tests/test_tmux.py`:
+
+```python
+"""Tests for tmux module."""
+
+from unittest import mock
+
+import pytest
+
+from legion import tmux
+
+
+class TestNewSession:
+    """Test creating tmux session with command."""
+
+    @pytest.mark.anyio
+    async def test_creates_session_with_command(self) -> None:
+        with mock.patch.object(tmux, "run", new_callable=mock.AsyncMock) as mock_run:
+            mock_run.return_value = ("", "", 0)
+            await tmux.new_session("my-session", "main", "echo hello")
+            mock_run.assert_called_once_with([
+                "tmux", "new-session", "-d",
+                "-s", "my-session",
+                "-n", "main",
+                "echo hello",
+            ])
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_tmux.py::TestNewSession -v`
+Expected: FAIL with "AttributeError: module 'legion.tmux' has no attribute 'new_session'"
+
+**Step 3: Write minimal implementation**
+
+Add to `src/legion/tmux.py`:
+
+```python
+async def new_session(session: str, window: str, command: str) -> None:
+    """Create new tmux session with command.
+
+    Unlike create_session which just creates an empty session,
+    this runs a command directly in the new session.
+
+    Args:
+        session: Session name
+        window: Window name
+        command: Command to run in the session
+    """
+    await run([
+        "tmux", "new-session", "-d",
+        "-s", session,
+        "-n", window,
+        command,
+    ])
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_tmux.py::TestNewSession -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+jj desc -m "feat(tmux): add new_session with command support"
+```
+
+---
+
+## Task 5: Update `start_controller` with session ID and shlex
+
+**Files:**
+- Modify: `src/legion/daemon.py:62-72`
+- Test: `tests/test_daemon.py`
+
+**Step 1: Write the failing test**
+
+Add to `tests/test_daemon.py`:
+
+```python
+from unittest import mock
+
+
+class TestStartController:
+    """Test controller startup."""
+
+    @pytest.mark.anyio
+    async def test_uses_session_id_for_new_session(self, tmp_path: Path) -> None:
+        """When no session file exists, uses --session-id."""
+        with mock.patch("legion.daemon.tmux.new_session", new_callable=mock.AsyncMock) as mock_new:
+            await daemon.start_controller(
+                tmux_session="legion-abc-controller",
+                project_id="proj-123",
+                short="abc",
+                workspace=tmp_path,
+                session_id="session-uuid",
+            )
+            mock_new.assert_called_once()
+            cmd = mock_new.call_args[0][2]
+            assert "--session-id 'session-uuid'" in cmd
+
+    @pytest.mark.anyio
+    async def test_uses_resume_for_existing_session(self, tmp_path: Path) -> None:
+        """When session file exists, uses --resume."""
+        # Create fake session file
+        session_file = daemon.get_session_file_path(tmp_path, "session-uuid")
+        session_file.parent.mkdir(parents=True, exist_ok=True)
+        session_file.touch()
+
+        with mock.patch("legion.daemon.tmux.new_session", new_callable=mock.AsyncMock) as mock_new:
+            await daemon.start_controller(
+                tmux_session="legion-abc-controller",
+                project_id="proj-123",
+                short="abc",
+                workspace=tmp_path,
+                session_id="session-uuid",
+            )
+            cmd = mock_new.call_args[0][2]
+            assert "--resume 'session-uuid'" in cmd
+
+    @pytest.mark.anyio
+    async def test_escapes_paths_with_shlex(self, tmp_path: Path) -> None:
+        """Paths are properly escaped with shlex.quote."""
+        # Create workspace with space in name
+        weird_workspace = tmp_path / "my workspace"
+        weird_workspace.mkdir()
+
+        with mock.patch("legion.daemon.tmux.new_session", new_callable=mock.AsyncMock) as mock_new:
+            await daemon.start_controller(
+                tmux_session="legion-abc-controller",
+                project_id="proj-123",
+                short="abc",
+                workspace=weird_workspace,
+                session_id="session-uuid",
+            )
+            cmd = mock_new.call_args[0][2]
+            # shlex.quote wraps in single quotes for paths with spaces
+            assert "'my workspace'" in cmd or '"my workspace"' in cmd
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_daemon.py::TestStartController -v`
+Expected: FAIL (signature mismatch - current function doesn't take session_id)
+
+**Step 3: Write minimal implementation**
+
+Replace `start_controller` in `src/legion/daemon.py`:
+
+```python
+import shlex  # Add to imports at top
+
+async def start_controller(
+    tmux_session: str,
+    project_id: str,
+    short: str,
+    workspace: Path,
+    session_id: str,
+) -> None:
+    """Start controller in tmux session.
+
+    Uses --session-id for new sessions, --resume for existing ones.
+    Passes command directly to tmux new-session (not send_keys).
+    """
+    session_file = get_session_file_path(workspace, session_id)
+
+    # Decide whether to create new or resume
+    if await anyio.Path(session_file).exists():
+        session_flag = f"--resume {shlex.quote(session_id)}"
+    else:
+        session_flag = f"--session-id {shlex.quote(session_id)}"
+
+    cmd = (
+        f"cd {shlex.quote(str(workspace))} && "
+        f"LEGION_DIR={shlex.quote(str(workspace))} "
+        f"LINEAR_TEAM_ID={shlex.quote(project_id)} "
+        f"LEGION_SHORT_ID={shlex.quote(short)} "
+        f"claude --dangerously-skip-permissions {session_flag} "
+        f"-p 'Use the legion-controller skill. Project: {project_id}'"
+    )
+
+    await tmux.new_session(tmux_session, "main", cmd)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_daemon.py::TestStartController -v`
+Expected: PASS (3 tests)
+
+**Step 5: Commit**
+
+```bash
+jj desc -m "feat(daemon): update start_controller with session ID support"
+```
+
+---
+
+## Task 6: Add `controller_needs_restart` to daemon.py
+
+**Files:**
+- Modify: `src/legion/daemon.py`
+- Test: `tests/test_daemon.py`
+
+**Step 1: Write the failing test**
+
+Add to `tests/test_daemon.py`:
+
+```python
+class TestControllerNeedsRestart:
+    """Test restart decision logic."""
+
+    @pytest.mark.anyio
+    async def test_returns_true_when_tmux_session_missing(self, tmp_path: Path) -> None:
+        session_file = tmp_path / "session.jsonl"
+        session_file.touch()
+
+        with mock.patch("legion.daemon.tmux.session_exists", new_callable=mock.AsyncMock) as mock_exists:
+            mock_exists.return_value = False
+            result = await daemon.controller_needs_restart(
+                tmux_session="legion-abc-controller",
+                session_file=session_file,
+                threshold=600,
+            )
+            assert result is True
+
+    @pytest.mark.anyio
+    async def test_returns_true_when_session_file_missing(self, tmp_path: Path) -> None:
+        session_file = tmp_path / "missing.jsonl"
+
+        with mock.patch("legion.daemon.tmux.session_exists", new_callable=mock.AsyncMock) as mock_exists:
+            mock_exists.return_value = True
+            result = await daemon.controller_needs_restart(
+                tmux_session="legion-abc-controller",
+                session_file=session_file,
+                threshold=600,
+            )
+            assert result is True
+
+    @pytest.mark.anyio
+    async def test_returns_true_when_file_stale(self, tmp_path: Path) -> None:
+        session_file = tmp_path / "session.jsonl"
+        session_file.touch()
+        # Make file old
+        import os
+        old_time = time.time() - 1000
+        os.utime(session_file, (old_time, old_time))
+
+        with mock.patch("legion.daemon.tmux.session_exists", new_callable=mock.AsyncMock) as mock_exists:
+            mock_exists.return_value = True
+            result = await daemon.controller_needs_restart(
+                tmux_session="legion-abc-controller",
+                session_file=session_file,
+                threshold=600,
+            )
+            assert result is True
+
+    @pytest.mark.anyio
+    async def test_returns_false_when_healthy(self, tmp_path: Path) -> None:
+        session_file = tmp_path / "session.jsonl"
+        session_file.touch()  # Fresh file
+
+        with mock.patch("legion.daemon.tmux.session_exists", new_callable=mock.AsyncMock) as mock_exists:
+            mock_exists.return_value = True
+            result = await daemon.controller_needs_restart(
+                tmux_session="legion-abc-controller",
+                session_file=session_file,
+                threshold=600,
+            )
+            assert result is False
+
+    @pytest.mark.anyio
+    async def test_considers_subagent_activity(self, tmp_path: Path) -> None:
+        """Active subagent keeps controller alive even if main file is stale."""
+        session_file = tmp_path / "session.jsonl"
+        session_file.touch()
+        # Make session file old
+        import os
+        old_time = time.time() - 1000
+        os.utime(session_file, (old_time, old_time))
+
+        # But subagent is fresh
+        subagent_dir = tmp_path / "session" / "subagents"
+        subagent_dir.mkdir(parents=True)
+        (subagent_dir / "agent-1.jsonl").touch()
+
+        with mock.patch("legion.daemon.tmux.session_exists", new_callable=mock.AsyncMock) as mock_exists:
+            mock_exists.return_value = True
+            result = await daemon.controller_needs_restart(
+                tmux_session="legion-abc-controller",
+                session_file=session_file,
+                threshold=600,
+            )
+            assert result is False  # Subagent activity keeps it alive
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_daemon.py::TestControllerNeedsRestart -v`
+Expected: FAIL with "AttributeError: module 'legion.daemon' has no attribute 'controller_needs_restart'"
+
+**Step 3: Write minimal implementation**
+
+Add to `src/legion/daemon.py`:
+
+```python
+async def controller_needs_restart(
+    tmux_session: str,
+    session_file: Path,
+    threshold: int = 600,
+) -> bool:
+    """Check if controller needs restart.
+
+    Args:
+        tmux_session: tmux session name
+        session_file: Path to Claude Code session file
+        threshold: Staleness threshold in seconds (default 10 min)
+
+    Returns:
+        True if controller should be restarted
+    """
+    if not await tmux.session_exists(tmux_session):
+        return True
+
+    newest_mtime = await get_newest_mtime(session_file)
+    if newest_mtime is None:
+        return True
+
+    age = time.time() - newest_mtime
+    return age > threshold
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_daemon.py::TestControllerNeedsRestart -v`
+Expected: PASS (5 tests)
+
+**Step 5: Commit**
+
+```bash
+jj desc -m "feat(daemon): add controller_needs_restart logic"
+```
+
+---
+
+## Task 7: Update `health_loop` with restart logic
+
+**Files:**
+- Modify: `src/legion/daemon.py:75-100`
+- Test: `tests/test_daemon.py`
+
+**Step 1: Write the failing test**
+
+Add to `tests/test_daemon.py`:
+
+```python
+class TestHealthLoop:
+    """Test health monitoring loop."""
+
+    @pytest.mark.anyio
+    async def test_restarts_controller_when_needed(self, tmp_path: Path) -> None:
+        """Health loop restarts controller when needs_restart is True."""
+        restart_count = 0
+        check_count = 0
+
+        async def mock_needs_restart(*args, **kwargs) -> bool:
+            nonlocal check_count
+            check_count += 1
+            return check_count == 1  # Need restart only on first check
+
+        async def mock_start_controller(*args, **kwargs) -> None:
+            nonlocal restart_count
+            restart_count += 1
+
+        with (
+            mock.patch("legion.daemon.controller_needs_restart", side_effect=mock_needs_restart),
+            mock.patch("legion.daemon.start_controller", side_effect=mock_start_controller),
+            mock.patch("legion.daemon.tmux.session_exists", new_callable=mock.AsyncMock, return_value=False),
+            mock.patch("legion.daemon.tmux.kill_session", new_callable=mock.AsyncMock),
+            mock.patch("anyio.sleep", new_callable=mock.AsyncMock) as mock_sleep,
+        ):
+            # Stop after 2 iterations
+            mock_sleep.side_effect = [None, None, Exception("stop")]
+
+            with pytest.raises(Exception, match="stop"):
+                await daemon.health_loop(
+                    tmux_session="legion-abc-controller",
+                    project_id="proj-123",
+                    short="abc",
+                    workspace=tmp_path,
+                    session_id="session-uuid",
+                    check_interval=1.0,
+                    staleness_threshold=600,
+                    restart_cooldown=0.0,
+                )
+
+            assert restart_count == 1
+
+    @pytest.mark.anyio
+    async def test_enforces_restart_cooldown(self, tmp_path: Path) -> None:
+        """Cooldown prevents rapid restarts."""
+        restart_times: list[float] = []
+
+        async def mock_start_controller(*args, **kwargs) -> None:
+            restart_times.append(time.time())
+
+        with (
+            mock.patch("legion.daemon.controller_needs_restart", new_callable=mock.AsyncMock, return_value=True),
+            mock.patch("legion.daemon.start_controller", side_effect=mock_start_controller),
+            mock.patch("legion.daemon.tmux.session_exists", new_callable=mock.AsyncMock, return_value=False),
+            mock.patch("legion.daemon.tmux.kill_session", new_callable=mock.AsyncMock),
+            mock.patch("anyio.sleep", new_callable=mock.AsyncMock) as mock_sleep,
+        ):
+            # Stop after 2 restarts
+            call_count = 0
+            async def counting_sleep(duration: float) -> None:
+                nonlocal call_count
+                call_count += 1
+                if call_count > 3:
+                    raise Exception("stop")
+
+            mock_sleep.side_effect = counting_sleep
+
+            with pytest.raises(Exception, match="stop"):
+                await daemon.health_loop(
+                    tmux_session="legion-abc-controller",
+                    project_id="proj-123",
+                    short="abc",
+                    workspace=tmp_path,
+                    session_id="session-uuid",
+                    check_interval=0.0,
+                    staleness_threshold=600,
+                    restart_cooldown=60.0,  # 60s cooldown
+                )
+
+            # Should have been called with cooldown wait
+            cooldown_calls = [c for c in mock_sleep.call_args_list if c[0][0] > 0]
+            assert len(cooldown_calls) >= 1
+
+    @pytest.mark.anyio
+    async def test_handles_start_controller_failure(self, tmp_path: Path) -> None:
+        """Failed start_controller doesn't crash the loop."""
+        start_attempts = 0
+
+        async def failing_start(*args, **kwargs) -> None:
+            nonlocal start_attempts
+            start_attempts += 1
+            if start_attempts == 1:
+                raise RuntimeError("tmux failed")
+            # Second attempt succeeds
+
+        with (
+            mock.patch("legion.daemon.controller_needs_restart", new_callable=mock.AsyncMock, return_value=True),
+            mock.patch("legion.daemon.start_controller", side_effect=failing_start),
+            mock.patch("legion.daemon.tmux.session_exists", new_callable=mock.AsyncMock, return_value=False),
+            mock.patch("legion.daemon.tmux.kill_session", new_callable=mock.AsyncMock),
+            mock.patch("anyio.sleep", new_callable=mock.AsyncMock) as mock_sleep,
+        ):
+            call_count = 0
+            async def counting_sleep(duration: float) -> None:
+                nonlocal call_count
+                call_count += 1
+                if call_count > 2:
+                    raise Exception("stop")
+
+            mock_sleep.side_effect = counting_sleep
+
+            with pytest.raises(Exception, match="stop"):
+                await daemon.health_loop(
+                    tmux_session="legion-abc-controller",
+                    project_id="proj-123",
+                    short="abc",
+                    workspace=tmp_path,
+                    session_id="session-uuid",
+                    check_interval=0.0,
+                    staleness_threshold=600,
+                    restart_cooldown=0.0,
+                )
+
+            # Should have attempted twice despite first failure
+            assert start_attempts >= 2
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_daemon.py::TestHealthLoop -v`
+Expected: FAIL (signature mismatch or behavior difference)
+
+**Step 3: Write minimal implementation**
+
+Replace `health_loop` in `src/legion/daemon.py`:
+
+```python
+async def health_loop(
+    tmux_session: str,
+    project_id: str,
+    short: str,
+    workspace: Path,
+    session_id: str,
+    check_interval: float = 60.0,
+    staleness_threshold: int = 600,
+    restart_cooldown: float = 60.0,
+) -> None:
+    """Monitor controller health and restart if needed.
+
+    Never exits - always restarts controller on failure.
+    """
+    last_restart: float = 0.0
+    session_file = get_session_file_path(workspace, session_id)
+
+    while True:
+        await anyio.sleep(check_interval)
+
+        needs_restart = await controller_needs_restart(
+            tmux_session, session_file, staleness_threshold
+        )
+
+        if needs_restart:
+            # Enforce cooldown
+            elapsed = time.time() - last_restart
+            if elapsed < restart_cooldown:
+                wait_time = restart_cooldown - elapsed
+                print(f"Restart cooldown: waiting {wait_time:.0f}s")
+                await anyio.sleep(wait_time)
+
+            print("Restarting controller...")
+
+            # Kill existing session if it exists
+            if await tmux.session_exists(tmux_session):
+                await tmux.kill_session(tmux_session)
+
+            try:
+                await start_controller(
+                    tmux_session, project_id, short, workspace, session_id
+                )
+                last_restart = time.time()
+            except Exception as e:
+                print(f"Failed to start controller: {e}")
+                # Don't update last_restart - next iteration will try again
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_daemon.py::TestHealthLoop -v`
+Expected: PASS (3 tests)
+
+**Step 5: Commit**
+
+```bash
+jj desc -m "feat(daemon): update health_loop with restart logic"
+```
+
+---
+
+## Task 8: Update `start` function to use session IDs
+
+**Files:**
+- Modify: `src/legion/daemon.py:102-138`
+- Test: `tests/test_daemon.py`
+
+**Step 1: Write the failing test**
+
+Add to `tests/test_daemon.py`:
+
+```python
+class TestStart:
+    """Test daemon start function."""
+
+    @pytest.mark.anyio
+    async def test_computes_and_uses_session_id(self, tmp_path: Path) -> None:
+        """Start computes session ID and passes to start_controller."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / ".jj").mkdir()
+
+        captured_session_id = None
+
+        async def mock_start_controller(tmux_session, project_id, short, workspace, session_id):
+            nonlocal captured_session_id
+            captured_session_id = session_id
+
+        with (
+            mock.patch("legion.daemon.validate_workspace", new_callable=mock.AsyncMock),
+            mock.patch("legion.daemon.tmux.session_exists", new_callable=mock.AsyncMock, return_value=False),
+            mock.patch("legion.daemon.start_controller", side_effect=mock_start_controller),
+            mock.patch("legion.daemon.health_loop", new_callable=mock.AsyncMock),
+        ):
+            await daemon.start(
+                project_id="7b4f0862-b775-4cb0-9a67-85400c6f44a8",
+                workspace=workspace,
+                state_dir=tmp_path / "state",
+            )
+
+            # Session ID should be a valid UUID computed from project_id
+            assert captured_session_id is not None
+            import uuid
+            uuid.UUID(captured_session_id)  # Should not raise
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_daemon.py::TestStart -v`
+Expected: FAIL (start_controller called with wrong signature)
+
+**Step 3: Write minimal implementation**
+
+Update the import and `start` function in `src/legion/daemon.py`:
+
+```python
+from legion.state.types import compute_controller_session_id  # Add to imports
+
+async def start(project_id: str, workspace: Path, state_dir: Path) -> None:
+    """Start the Legion swarm."""
+    validate_project_id(project_id)
+    await validate_workspace(workspace)
+
+    short = get_short_id(project_id)
+    session = controller_session_name(short)
+    session_id = compute_controller_session_id(project_id)
+
+    if await tmux.session_exists(session):
+        raise RuntimeError(
+            f"Swarm already running for {project_id}. "
+            f"Use 'legion stop {project_id}' first."
+        )
+
+    print(f"Starting Legion for project: {project_id}")
+    print(f"Session ID: {short}")
+    print(f"Workspace: {workspace}")
+
+    # Create state directory
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    # Start controller directly (no need to create empty session first)
+    await start_controller(session, project_id, short, workspace, session_id)
+    print(f"Started controller in tmux session: {session}")
+
+    print()
+    print(f"To attach: tmux attach -t {session}")
+    print(f"To view:   tmux capture-pane -t {session}:main -p")
+    print()
+
+    # Run health loop
+    await health_loop(
+        tmux_session=session,
+        project_id=project_id,
+        short=short,
+        workspace=workspace,
+        session_id=session_id,
+    )
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_daemon.py::TestStart -v`
+Expected: PASS
+
+**Step 5: Run all tests**
+
+Run: `uv run pytest -v`
+Expected: All tests PASS
+
+**Step 6: Commit**
+
+```bash
+jj desc -m "feat(daemon): update start to use session IDs and new health_loop"
+```
+
+---
+
+## Task 9: Manual Integration Test
+
+**Step 1: Start daemon with test project**
+
+```bash
+# Create test directory
+mkdir -p /tmp/legion-test
+cd /tmp/legion-test
+jj git init
+
+# Start daemon
+cd /home/sami/legion/default
+uv run legion start 7b4f0862-b775-4cb0-9a67-85400c6f44a8
+```
+
+**Step 2: Verify tmux session created**
+
+```bash
+tmux list-sessions | grep legion
+```
+
+Expected: Session exists with name like `legion-XXXXX-controller`
+
+**Step 3: Kill controller and verify restart**
+
+```bash
+# Find and kill the controller session
+tmux kill-session -t legion-XXXXX-controller
+
+# Wait 60-120 seconds, verify it restarts
+sleep 120
+tmux list-sessions | grep legion
+```
+
+Expected: Session reappears after restart
+
+**Step 4: Stop daemon**
+
+```bash
+# Stop cleanly
+uv run legion stop 7b4f0862-b775-4cb0-9a67-85400c6f44a8
+```
+
+**Step 5: Final commit**
+
+```bash
+jj desc -m "feat: persistent controller daemon with session-based liveness
+
+- Add compute_controller_session_id for deterministic session IDs
+- Add session file path encoding matching Claude Code
+- Add get_newest_mtime for session + subagent liveness detection
+- Add controller_needs_restart logic
+- Update health_loop to restart stale/crashed controllers
+- Update start_controller to use --session-id or --resume
+- Add tmux.new_session for direct command execution
+- Add shlex escaping for all paths"
+```
+
+---
+
+Plan complete and saved to `docs/plans/2026-02-02-feat-persistent-controller-daemon-plan.md`. Two execution options:
+
+**1. Subagent-Driven (this session)** - I dispatch fresh subagent per task, review between tasks, fast iteration
+
+**2. Parallel Session (separate)** - Open new session with executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,30 @@ legion = "legion.cli:main"
 
 [dependency-groups]
 dev = [
+    "basedpyright>=1.29",
     "pytest>=8.0",
     "pytest-anyio>=0.0.0",
+    "ruff>=0.11",
 ]
 
 [build-system]
 requires = ["uv_build>=0.9.18,<0.10"]
 build-backend = "uv_build"
+
+[tool.basedpyright]
+pythonVersion = "3.13"
+failOnWarnings = false
+exclude = [
+  "**/.pytest_cache/**",
+  "**/.ruff_cache/**",
+  "**/.venv/**",
+  "docs",
+]
+reportAny = false
+reportExplicitAny = false
+reportUnusedCallResult = false
+reportImplicitStringConcatenation = false
+
+[[tool.basedpyright.executionEnvironments]]
+root = "tests"
+extraPaths = ["."]

--- a/skills/legion-worker/SKILL.md
+++ b/skills/legion-worker/SKILL.md
@@ -18,6 +18,41 @@ Required:
 2. **Use jj, not git** - changes auto-tracked
 3. **Signal completion** - add `worker-done` label when done (see routing table)
 
+## Session Lifecycle
+
+### Starting
+
+Sync with main and create a fresh commit on your branch:
+
+```bash
+jj git fetch
+jj rebase -d main
+jj new  # Fresh commit for this session
+```
+
+If you're resuming after user feedback, also read the Linear comments for the answer.
+
+### Blocking on User Input
+
+When you need human input that the oracle can't answer:
+
+1. Push your work: `jj git push`
+2. Post your question as a Linear comment: `mcp__linear__create_comment`
+3. Add `user-input-needed` label (see @references/linear-labels.md)
+4. Exit immediately
+
+The controller will resume your session when the user responds.
+
+### Exiting
+
+Always push before exiting:
+
+```bash
+jj git push
+```
+
+Then add `worker-done` label if your mode requires it (see routing table).
+
 ## Mode Routing
 
 | Mode | Workflow | Adds `worker-done` |
@@ -27,11 +62,11 @@ Required:
 | `implement` | @workflows/implement.md | No |
 | `review` | @workflows/review.md | Yes |
 | `retro` | @workflows/retro.md | Yes |
-| `finish` | @workflows/finish.md | No |
+| `merge` | @workflows/merge.md | No |
 
-**Lifecycle order:** architect → plan → implement → review → (implement if changes requested) → retro → finish
+**Lifecycle order:** architect → plan → implement → review → (implement if changes requested) → retro → merge
 
-Note: `retro` runs before `finish` because retro adds learnings to the workspace, and finish deletes it.
+Note: `retro` runs before `merge` because retro adds learnings to the workspace, and merge deletes it.
 
 ## Review Mode Signaling
 
@@ -41,13 +76,15 @@ Review signals outcome via PR draft status BEFORE `worker-done`:
 
 ## Research Sub-Skill
 
-Before using `AskUserQuestion`, workers should invoke the oracle:
+Before blocking on user input, workers should invoke the oracle to try to find the answer:
 
 | Sub-Skill | Workflow | Purpose |
 |-----------|----------|---------|
 | `oracle` | @workflows/oracle.md | Research before escalating |
 
 Usage: `/oracle [your question]`
+
+Only escalate to the user (via Linear comment + label) if the oracle cannot answer.
 
 ## Reference
 

--- a/skills/legion-worker/workflows/merge.md
+++ b/skills/legion-worker/workflows/merge.md
@@ -1,22 +1,21 @@
-# Finish Workflow
+# Merge Workflow
 
-Merge the PR into main and clean up the workspace.
+Merge the PR into main. The controller handles workspace cleanup after completion.
 
 ## Workflow
 
 ### 1. Rebase onto Main
 
 ```bash
-cd "$WORKSPACE_DIR"
-jj git fetch --repository "$WORKSPACE_DIR"
-jj rebase -d main --repository "$WORKSPACE_DIR"
+jj git fetch
+jj rebase -d main
 ```
 
 ### 2. Resolve Conflicts
 
 If rebase produces conflicts:
 
-1. Check status: `jj status --repository "$WORKSPACE_DIR"`
+1. Check status: `jj status`
 2. Open each conflicted file and resolve markers
 3. Verify no conflicts remain: `jj status` shows clean state
 
@@ -28,7 +27,7 @@ If rebase produces conflicts:
 ### 3. Push
 
 ```bash
-jj git push --repository "$WORKSPACE_DIR"
+jj git push
 ```
 
 ### 4. Wait for CI
@@ -52,17 +51,6 @@ Only escalate with `user-input-needed` if something has gone fundamentally wrong
 gh pr merge "$LINEAR_ISSUE_ID" --squash --delete-branch
 ```
 
-### 6. Clean Up Workspace
+### 6. Exit
 
-Fetch to sync the merge, then remove the workspace:
-
-```bash
-jj git fetch --repository "$LEGION_DIR"
-jj workspace forget "$LINEAR_ISSUE_ID" --force --cleanup --repository "$LEGION_DIR"
-```
-
-The `--cleanup` flag deletes the workspace directory. No manual `rm -rf` needed.
-
-### 7. Exit
-
-Exit without adding a label. The Linear issue auto-closes when the PR merges.
+Exit without adding a label. The Linear issue auto-closes when the PR merges. The controller will clean up the workspace.

--- a/skills/legion-worker/workflows/retro.md
+++ b/skills/legion-worker/workflows/retro.md
@@ -54,7 +54,7 @@ Check subagent completion before proceeding (you will be notified when backgroun
 ### 5. Push
 
 ```bash
-jj git push --repository "$WORKSPACE_DIR"
+jj git push
 ```
 
 ### 6. Signal Completion

--- a/src/legion/state/__init__.py
+++ b/src/legion/state/__init__.py
@@ -13,10 +13,14 @@ CLI usage:
         --project-id UUID --short-id abc123 --owner owner --repo repo
 """
 
-from legion.state.decision import ACTION_TO_MODE, build_collected_state, build_issue_state, suggest_action
+from legion.state.decision import (
+    ACTION_TO_MODE,
+    build_collected_state,
+    build_issue_state,
+    suggest_action,
+)
 from legion.state.fetch import (
     GitHubAPIError,
-    check_worker_blocked,
     fetch_all_issue_data,
     get_live_workers,
     get_pr_draft_status_batch,
@@ -53,7 +57,6 @@ __all__ = [
     "ACTION_TO_MODE",
     "build_collected_state",
     "build_issue_state",
-    "check_worker_blocked",
     "compute_session_id",
     "fetch_all_issue_data",
     "get_live_workers",

--- a/src/legion/state/cli.py
+++ b/src/legion/state/cli.py
@@ -6,7 +6,6 @@ import argparse
 import json
 import sys
 import uuid
-from pathlib import Path
 from typing import Any
 
 import anyio
@@ -31,7 +30,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--session-dir",
-        help="Claude session directory",
+        help="Claude session directory (for controller inspection)",
     )
     parser.add_argument(
         "--debug",
@@ -47,6 +46,7 @@ async def async_main() -> None:
 
     # Set up logging
     import logging
+
     level = logging.DEBUG if args.debug else logging.WARNING
     logging.basicConfig(
         level=level,
@@ -74,15 +74,10 @@ async def async_main() -> None:
         print(f"Error parsing Linear JSON: {e}", file=sys.stderr)
         sys.exit(1)
 
-    # Parse session dir
-    session_dir = Path(args.session_dir) if args.session_dir else None
-
     # Fetch all data
     issues_data = await fetch.fetch_all_issue_data(
         linear_issues=issues,
-        team_id=args.team_id,
         short_id=args.short_id,
-        session_dir=session_dir,
     )
 
     # Build and output state

--- a/src/legion/tmux.py
+++ b/src/legion/tmux.py
@@ -39,9 +39,9 @@ async def kill_session(session: str) -> None:
 
 async def list_windows(session: str) -> list[str]:
     """List window names in a session."""
-    stdout, _, rc = await run([
-        "tmux", "list-windows", "-t", session, "-F", "#{window_name}"
-    ])
+    stdout, _, rc = await run(
+        ["tmux", "list-windows", "-t", session, "-F", "#{window_name}"]
+    )
     if rc != 0:
         return []
     return [w for w in stdout.split("\n") if w]

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -48,7 +48,9 @@ class TestValidateProjectId:
         daemon.validate_project_id("my_project_123")  # Should not raise
 
     def test_valid_uuid(self) -> None:
-        daemon.validate_project_id("7b4f0862-b775-4cb0-9a67-85400c6f44a8")  # Should not raise
+        daemon.validate_project_id(
+            "7b4f0862-b775-4cb0-9a67-85400c6f44a8"
+        )  # Should not raise
 
     def test_invalid_spaces(self) -> None:
         with pytest.raises(ValueError, match="must contain only"):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -25,7 +25,7 @@ class TestSessionDataclass:
             metadata=None,
         )
         with pytest.raises(AttributeError):
-            sess.session_id = "changed"  # type: ignore[misc]
+            sess.session_id = "changed"  # pyright: ignore[reportAttributeAccessIssue]
 
     def test_session_fields(self) -> None:
         """Session should have all required fields."""
@@ -179,9 +179,7 @@ class TestFileSessionStorage:
         assert loaded.metadata == sample_session.metadata
 
     @pytest.mark.anyio
-    async def test_load_nonexistent(
-        self, storage: session.FileSessionStorage
-    ) -> None:
+    async def test_load_nonexistent(self, storage: session.FileSessionStorage) -> None:
         """Loading nonexistent session should return None."""
         loaded = await storage.load("nonexist")
         assert loaded is None

--- a/uv.lock
+++ b/uv.lock
@@ -33,6 +33,18 @@ wheels = [
 ]
 
 [[package]]
+name = "basedpyright"
+version = "1.37.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodejs-wheel-binaries" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/9f/aaaa202f2d7eaefaf5a4f297c80943d060c64db4753acb8003111d575c94/basedpyright-1.37.3.tar.gz", hash = "sha256:4cb4717a5686fba0c1e3156fe25e729d07e6912b68f9f67c33ea490d3f0d2a46", size = 25245208, upload-time = "2026-02-01T08:45:42.355Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/4f/b8fd24714cda878fd6b95e7ffc6051a864ac04bf2520d4622252df0abc9c/basedpyright-1.37.3-py3-none-any.whl", hash = "sha256:7064b2c811d9d79ebaa60ef65a2cdf292a9eb3c32dba9dee32660de2dbdd71e1", size = 12299378, upload-time = "2026-02-01T08:45:45.947Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -85,8 +97,10 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "basedpyright" },
     { name = "pytest" },
     { name = "pytest-anyio" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -100,8 +114,26 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "basedpyright", specifier = ">=1.29" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-anyio", specifier = ">=0.0.0" },
+    { name = "ruff", specifier = ">=0.11" },
+]
+
+[[package]]
+name = "nodejs-wheel-binaries"
+version = "24.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/f1/73182280e2c05f49a7c2c8dbd46144efe3f74f03f798fb90da67b4a93bbf/nodejs_wheel_binaries-24.13.0.tar.gz", hash = "sha256:766aed076e900061b83d3e76ad48bfec32a035ef0d41bd09c55e832eb93ef7a4", size = 8056, upload-time = "2026-01-14T11:05:33.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/dc/4d7548aa74a5b446d093f03aff4fb236b570959d793f21c9c42ab6ad870a/nodejs_wheel_binaries-24.13.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:356654baa37bfd894e447e7e00268db403ea1d223863963459a0fbcaaa1d9d48", size = 55133268, upload-time = "2026-01-14T11:05:05.335Z" },
+    { url = "https://files.pythonhosted.org/packages/24/8a/8a4454d28339487240dd2232f42f1090e4a58544c581792d427f6239798c/nodejs_wheel_binaries-24.13.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:92fdef7376120e575f8b397789bafcb13bbd22a1b4d21b060d200b14910f22a5", size = 55314800, upload-time = "2026-01-14T11:05:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/fb/46c600fcc748bd13bc536a735f11532a003b14f5c4dfd6865f5911672175/nodejs_wheel_binaries-24.13.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:3f619ac140e039ecd25f2f71d6e83ad1414017a24608531851b7c31dc140cdfd", size = 59666320, upload-time = "2026-01-14T11:05:12.369Z" },
+    { url = "https://files.pythonhosted.org/packages/85/47/d48f11fc5d1541ace5d806c62a45738a1db9ce33e85a06fe4cd3d9ce83f6/nodejs_wheel_binaries-24.13.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:dfb31ebc2c129538192ddb5bedd3d63d6de5d271437cd39ea26bf3fe229ba430", size = 60162447, upload-time = "2026-01-14T11:05:16.003Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/74/d285c579ae8157c925b577dde429543963b845e69cd006549e062d1cf5b6/nodejs_wheel_binaries-24.13.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fdd720d7b378d5bb9b2710457bbc880d4c4d1270a94f13fbe257198ac707f358", size = 61659994, upload-time = "2026-01-14T11:05:19.68Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/97/88b4254a2ff93ed2eaed725f77b7d3d2d8d7973bf134359ce786db894faf/nodejs_wheel_binaries-24.13.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9ad6383613f3485a75b054647a09f1cd56d12380d7459184eebcf4a5d403f35c", size = 62244373, upload-time = "2026-01-14T11:05:23.987Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c3/0e13a3da78f08cb58650971a6957ac7bfef84164b405176e53ab1e3584e2/nodejs_wheel_binaries-24.13.0-py2.py3-none-win_amd64.whl", hash = "sha256:605be4763e3ef427a3385a55da5a1bcf0a659aa2716eebbf23f332926d7e5f23", size = 41345528, upload-time = "2026-01-14T11:05:27.67Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/f1/0578d65b4e3dc572967fd702221ea1f42e1e60accfb6b0dd8d8f15410139/nodejs_wheel_binaries-24.13.0-py2.py3-none-win_arm64.whl", hash = "sha256:2e3431d869d6b2dbeef1d469ad0090babbdcc8baaa72c01dd3cc2c6121c96af5", size = 39054688, upload-time = "2026-01-14T11:05:30.739Z" },
 ]
 
 [[package]]
@@ -158,6 +190,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/00/44/a02e5877a671b0940f21a7a0d9704c22097b123ed5cdbcca9cab39f17acc/pytest-anyio-0.0.0.tar.gz", hash = "sha256:b41234e9e9ad7ea1dbfefcc1d6891b23d5ef7c9f07ccf804c13a9cc338571fd3", size = 1560, upload-time = "2021-06-29T22:57:30.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/25/bd6493ae85d0a281b6a0f248d0fdb1d9aa2b31f18bcd4a8800cf397d8209/pytest_anyio-0.0.0-py2.py3-none-any.whl", hash = "sha256:dc8b5c4741cb16ff90be37fddd585ca943ed12bbeb563de7ace6cd94441d8746", size = 1999, upload-time = "2021-06-29T22:57:29.158Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.14.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/06/f71e3a86b2df0dfa2d2f72195941cd09b44f87711cb7fa5193732cb9a5fc/ruff-0.14.14.tar.gz", hash = "sha256:2d0f819c9a90205f3a867dbbd0be083bee9912e170fd7d9704cc8ae45824896b", size = 4515732, upload-time = "2026-01-22T22:30:17.527Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/89/20a12e97bc6b9f9f68343952da08a8099c57237aef953a56b82711d55edd/ruff-0.14.14-py3-none-linux_armv6l.whl", hash = "sha256:7cfe36b56e8489dee8fbc777c61959f60ec0f1f11817e8f2415f429552846aed", size = 10467650, upload-time = "2026-01-22T22:30:08.578Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b1/c5de3fd2d5a831fcae21beda5e3589c0ba67eec8202e992388e4b17a6040/ruff-0.14.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6006a0082336e7920b9573ef8a7f52eec837add1265cc74e04ea8a4368cd704c", size = 10883245, upload-time = "2026-01-22T22:30:04.155Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7c/3c1db59a10e7490f8f6f8559d1db8636cbb13dccebf18686f4e3c9d7c772/ruff-0.14.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:026c1d25996818f0bf498636686199d9bd0d9d6341c9c2c3b62e2a0198b758de", size = 10231273, upload-time = "2026-01-22T22:30:34.642Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/6e/5e0e0d9674be0f8581d1f5e0f0a04761203affce3232c1a1189d0e3b4dad/ruff-0.14.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f666445819d31210b71e0a6d1c01e24447a20b85458eea25a25fe8142210ae0e", size = 10585753, upload-time = "2026-01-22T22:30:31.781Z" },
+    { url = "https://files.pythonhosted.org/packages/23/09/754ab09f46ff1884d422dc26d59ba18b4e5d355be147721bb2518aa2a014/ruff-0.14.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3c0f18b922c6d2ff9a5e6c3ee16259adc513ca775bcf82c67ebab7cbd9da5bc8", size = 10286052, upload-time = "2026-01-22T22:30:24.827Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/cc/e71f88dd2a12afb5f50733851729d6b571a7c3a35bfdb16c3035132675a0/ruff-0.14.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1629e67489c2dea43e8658c3dba659edbfd87361624b4040d1df04c9740ae906", size = 11043637, upload-time = "2026-01-22T22:30:13.239Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b2/397245026352494497dac935d7f00f1468c03a23a0c5db6ad8fc49ca3fb2/ruff-0.14.14-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:27493a2131ea0f899057d49d303e4292b2cae2bb57253c1ed1f256fbcd1da480", size = 12194761, upload-time = "2026-01-22T22:30:22.542Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/06/06ef271459f778323112c51b7587ce85230785cd64e91772034ddb88f200/ruff-0.14.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:01ff589aab3f5b539e35db38425da31a57521efd1e4ad1ae08fc34dbe30bd7df", size = 12005701, upload-time = "2026-01-22T22:30:20.499Z" },
+    { url = "https://files.pythonhosted.org/packages/41/d6/99364514541cf811ccc5ac44362f88df66373e9fec1b9d1c4cc830593fe7/ruff-0.14.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1cc12d74eef0f29f51775f5b755913eb523546b88e2d733e1d701fe65144e89b", size = 11282455, upload-time = "2026-01-22T22:29:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/71/37daa46f89475f8582b7762ecd2722492df26421714a33e72ccc9a84d7a5/ruff-0.14.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb8481604b7a9e75eff53772496201690ce2687067e038b3cc31aaf16aa0b974", size = 11215882, upload-time = "2026-01-22T22:29:57.032Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/10/a31f86169ec91c0705e618443ee74ede0bdd94da0a57b28e72db68b2dbac/ruff-0.14.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:14649acb1cf7b5d2d283ebd2f58d56b75836ed8c6f329664fa91cdea19e76e66", size = 11180549, upload-time = "2026-01-22T22:30:27.175Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1e/c723f20536b5163adf79bdd10c5f093414293cdf567eed9bdb7b83940f3f/ruff-0.14.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e8058d2145566510790eab4e2fad186002e288dec5e0d343a92fe7b0bc1b3e13", size = 10543416, upload-time = "2026-01-22T22:30:01.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/34/8a84cea7e42c2d94ba5bde1d7a4fae164d6318f13f933d92da6d7c2041ff/ruff-0.14.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e651e977a79e4c758eb807f0481d673a67ffe53cfa92209781dfa3a996cf8412", size = 10285491, upload-time = "2026-01-22T22:30:29.51Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ef/b7c5ea0be82518906c978e365e56a77f8de7678c8bb6651ccfbdc178c29f/ruff-0.14.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:cc8b22da8d9d6fdd844a68ae937e2a0adf9b16514e9a97cc60355e2d4b219fc3", size = 10733525, upload-time = "2026-01-22T22:30:06.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/aaf1dfbcc53a2811f6cc0a1759de24e4b03e02ba8762daabd9b6bd8c59e3/ruff-0.14.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:16bc890fb4cc9781bb05beb5ab4cd51be9e7cb376bf1dd3580512b24eb3fda2b", size = 11315626, upload-time = "2026-01-22T22:30:36.848Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/aa/9f89c719c467dfaf8ad799b9bae0df494513fb21d31a6059cb5870e57e74/ruff-0.14.14-py3-none-win32.whl", hash = "sha256:b530c191970b143375b6a68e6f743800b2b786bbcf03a7965b06c4bf04568167", size = 10502442, upload-time = "2026-01-22T22:30:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/87/44/90fa543014c45560cae1fffc63ea059fb3575ee6e1cb654562197e5d16fb/ruff-0.14.14-py3-none-win_amd64.whl", hash = "sha256:3dde1435e6b6fe5b66506c1dff67a421d0b7f6488d466f651c07f4cab3bf20fd", size = 11630486, upload-time = "2026-01-22T22:30:10.852Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6a/40fee331a52339926a92e17ae748827270b288a35ef4a15c9c8f2ec54715/ruff-0.14.14-py3-none-win_arm64.whl", hash = "sha256:56e6981a98b13a32236a72a8da421d7839221fa308b223b9283312312e5ac76c", size = 10920448, upload-time = "2026-01-22T22:30:15.417Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements the backlog management design from `docs/plans/2026-02-02-backlog-management-design.md`:

- **Renamed `finish` → `merge`** throughout codebase (worker mode, skill routing, workflow file)
- **Added new statuses**: Triage, Icebox, Backlog to the state machine
- **Added `architect` worker mode** for breaking down large/vague issues into spec-ready work
- **Made controller persistent** with continuous loop instead of exit-after-one-iteration
- **Added triage routing logic** - controller routes Triage items to Icebox/Backlog/Todo based on clarity/urgency
- **Added Icebox pull logic** - FIFO (oldest first), when capacity < 10 active workers
- **Updated daemon** to pass `LINEAR_TEAM_ID` instead of `LINEAR_PROJECT_ID`
- **Various improvements**: type safety, bug fixes, test coverage

## Status Flow

```
Triage ──┬──► Icebox ──► Backlog ──► Todo ──► In Progress ──► Needs Review ──► Retro ──► Done
         │                  ▲           ▲            ▲               │
         ├──────────────────┘           │            └───────────────┘
         │   (already spec-ready)       │            (changes requested)
         └──────────────────────────────┘
                    (urgent + clear)
```

## Test Plan

- [x] All 111 tests pass
- [x] Type checking passes
- [x] Stale reference search completed (no issues in active code)

🤖 Generated with [Claude Code](https://claude.ai/code)