### PR TITLE
feat: add stuck-state detection and graceful GitHub API error handling

### DIFF
--- a/skills/legion-controller/SKILL.md
+++ b/skills/legion-controller/SKILL.md
@@ -71,8 +71,17 @@ State transitions (always remove `worker-done` after):
 | In Progress + worker-done | → Needs Review, dispatch reviewer |
 | Needs Review + worker-done (PR ready) | → Retro, resume implementer |
 | Needs Review + worker-done (PR draft) | Keep status, resume implementer for changes |
+| Needs Review + worker-done (no PR) | `investigate_no_pr` - see below |
 | Retro + worker-done | Dispatch merger |
 | `remove_worker_active_and_redispatch` | Remove worker-active label, then dispatch |
+
+**Handling `investigate_no_pr`:** Worker marked done but no PR exists. Likely causes:
+1. Worker crashed before creating PR
+2. PR creation failed silently
+3. Issue moved to wrong status manually
+4. Linear attachment wasn't added
+
+**Action:** Investigate, then consider moving back to In Progress and re-dispatching implementer. May also just wait and check again next iteration.
 
 ### 4. Route Triage
 


### PR DESCRIPTION
## Summary

Adds stuck-state detection to distinguish "no PR linked" from "couldn't check PR status" in the Legion state module.

### Key Changes

- **New action type**: `investigate_no_pr` for NEEDS_REVIEW issues with `worker-done` but no PR attachment
- **New field**: `has_pr: bool` on `FetchedIssueData` to track PR presence separately from draft status
- **Graceful degradation**: GitHub API failures now set `pr_is_draft=None` instead of propagating errors
- **Type improvements**: Fixed `SessionEntry` discriminated union, removed unused TypedDicts

### Behavior

| Scenario | `has_pr` | `pr_is_draft` | Action |
|----------|----------|---------------|--------|
| No PR attachment | `False` | `None` | `investigate_no_pr` |
| PR exists, API failed | `True` | `None` | `skip` (retry later) |
| PR exists, is draft | `True` | `True` | `resume_implementer_for_changes` |
| PR exists, ready | `True` | `False` | `transition_to_retro` |

### Testing

- 109 tests passing (up from 90)
- Added tests for stuck-state detection, session ID computation, and GitHub API failure handling
- All quality checks pass (ruff, basedpyright)

🤖 Generated with [Claude Code](https://claude.ai/code)