### PR TITLE
LEG-127: remove redundant identity env vars from worker spawn

### DIFF
--- a/docs/solutions/daemon/worker-directory-fix.md
+++ b/docs/solutions/daemon/worker-directory-fix.md
@@ -1,0 +1,164 @@
+---
+title: "Worker Directory Fix: Explicit Directory Passing to OpenCode"
+date: 2026-02-15
+category: daemon
+tags: [opencode-sdk, jj-workspaces, worker-spawning, directory-resolution]
+related-issues: [LEG-125]
+---
+
+# Worker Directory Fix: Explicit Directory Passing to OpenCode
+
+## Problem
+
+Workers were spawning in the wrong project directory. When OpenCode resolved the project root through jj workspace `.git` symlinks, it would follow the symlink to the main repository instead of staying in the workspace directory.
+
+**Symptom:** Workers would operate on the main repo instead of their isolated jj workspace, causing:
+- Changes appearing in the wrong workspace
+- Confusion about which branch/workspace was active
+- Potential conflicts between workers
+
+**Root Cause:** The daemon spawned `opencode serve` processes with the correct working directory, but when creating OpenCode SDK sessions via `POST /session`, no explicit directory was passed. OpenCode's default project root resolution followed `.git` symlinks in jj workspaces, which point back to the main repo's `.jj/repo/store`.
+
+## Solution
+
+Pass the workspace directory explicitly to OpenCode via the `x-opencode-directory` header on session creation.
+
+### Key Changes
+
+1. **`x-opencode-directory` header** on `POST /session` — tells OpenCode which directory to use, bypassing its default resolution logic
+2. **`createWorkerClient(port, workspace)` helper** — centralized SDK client creation that wraps `createOpencodeClient({baseUrl, directory})`
+3. **`workspace` field in `WorkerEntry`** — stored in worker state so downstream call sites (status proxy, controller prompt) know the workspace
+4. **SDK client for controller prompt** — replaced raw fetch `prompt_async` with `client.session.promptAsync()`
+5. **Status proxy uses workspace** — `createWorkerClient(entry.port, entry.workspace)` instead of bare `createOpencodeClient`
+
+### Implementation Pattern
+
+```typescript
+// Before: OpenCode resolves directory itself (follows symlinks)
+const client = createOpencodeClient({ baseUrl: `http://127.0.0.1:${port}` });
+
+// After: Explicit directory passed via SDK
+const client = createOpencodeClient({ 
+  baseUrl: `http://127.0.0.1:${port}`,
+  directory: workspace 
+});
+```
+
+The SDK automatically adds the `x-opencode-directory` header when `directory` is provided.
+
+## Key Patterns
+
+### 1. Centralized Client Creation
+
+When spawning external processes that need directory context, create a helper that encapsulates both the connection details AND the directory:
+
+```typescript
+function createWorkerClient(port: number, workspace: string) {
+  return createOpencodeClient({
+    baseUrl: `http://127.0.0.1:${port}`,
+    directory: workspace,
+  });
+}
+```
+
+**Why:** Prevents call sites from forgetting to pass the directory. Every worker client automatically gets the right context.
+
+### 2. Store Context in State
+
+When spawning workers, store the workspace path in the worker entry:
+
+```typescript
+interface WorkerEntry {
+  port: number;
+  workspace: string;  // ← Add this
+  // ... other fields
+}
+```
+
+**Why:** Downstream operations (status checks, prompts, cleanup) need to know which workspace the worker is operating in. Storing it once at spawn time prevents re-deriving it or passing it through multiple layers.
+
+### 3. Explicit Directory Headers
+
+When working with tools that resolve project roots automatically, prefer explicit directory passing over relying on working directory + symlink resolution:
+
+```typescript
+// Fragile: relies on cwd + symlink resolution
+spawn("opencode", ["serve"], { cwd: workspace });
+
+// Robust: explicit directory via API
+client.session.create({ directory: workspace });
+```
+
+**Why:** Symlink resolution is environment-dependent and can follow unexpected paths. Explicit directory passing is deterministic.
+
+### 4. Replace Raw Fetch with SDK Clients
+
+When interacting with OpenCode's HTTP API, use the SDK instead of raw fetch:
+
+```typescript
+// Before: raw fetch
+const response = await fetch(`http://127.0.0.1:${port}/session/${sessionId}/prompt_async`, {
+  method: "POST",
+  body: JSON.stringify({ prompt }),
+});
+
+// After: SDK client
+const client = createWorkerClient(port, workspace);
+await client.session.promptAsync(sessionId, prompt);
+```
+
+**Why:** SDK handles headers (including `x-opencode-directory`), error handling, and type safety. Raw fetch is error-prone.
+
+## Gotchas
+
+### 1. Jj Workspace `.git` Symlinks
+
+Jj workspaces use `.git` symlinks that point to `.jj/repo/store` in the main repo. Tools that resolve project roots by walking up to `.git` will follow the symlink and end up in the main repo.
+
+**Solution:** Always pass explicit directory context when spawning processes in jj workspaces. Don't rely on tools' default project root resolution.
+
+### 2. OpenCode's Default Resolution
+
+OpenCode's default project root resolution is designed for typical git repos. In jj workspaces, this resolution follows symlinks and breaks isolation.
+
+**Solution:** Use the `x-opencode-directory` header (or SDK's `directory` option) to override default resolution.
+
+### 3. Worker State Must Include Workspace
+
+If you spawn workers with workspace context but don't store the workspace path in the worker entry, downstream operations won't know which workspace to use.
+
+**Solution:** Add `workspace: string` to `WorkerEntry` at spawn time. Every operation that touches a worker should use `entry.workspace`.
+
+### 4. Status Proxy Needs Workspace Too
+
+The status proxy (`/workers/:issueId/status`) forwards requests to worker processes. If it doesn't pass the workspace directory, the worker's responses may reflect the wrong directory.
+
+**Solution:** Status proxy must use `createWorkerClient(entry.port, entry.workspace)` to ensure the forwarded request includes directory context.
+
+### 5. Controller Prompts Need Workspace
+
+When the controller sends prompts to workers, it must use the SDK client with the workspace directory. Raw fetch won't include the `x-opencode-directory` header.
+
+**Solution:** Replace raw fetch with `createWorkerClient(port, workspace).session.promptAsync()`.
+
+## Related Patterns
+
+- **Process Spawning with Context** — when spawning external processes, store all context needed for future interactions (port, PID, workspace, session ID)
+- **SDK Over Raw HTTP** — prefer SDK clients over raw fetch for type safety and automatic header management
+- **Explicit Over Implicit** — when tools have "smart" defaults that break in edge cases, prefer explicit configuration
+
+## Testing
+
+After implementing this fix, verify:
+
+1. **Worker spawns in correct directory** — `jj status` in worker session shows the workspace, not main repo
+2. **Changes appear in correct workspace** — commits made by worker appear in the workspace's log, not main
+3. **Status proxy works** — `GET /workers/:issueId/status` returns correct directory info
+4. **Controller prompts work** — controller can send prompts to workers and get responses
+
+## References
+
+- PR: https://github.com/sjawhar/legion/pull/42
+- Issue: LEG-125
+- OpenCode SDK: `@opencode-ai/sdk`
+- Jj workspaces: https://martinvonz.github.io/jj/latest/working-copy/

--- a/docs/solutions/daemon/worker-directory-resolution.md
+++ b/docs/solutions/daemon/worker-directory-resolution.md
@@ -1,0 +1,73 @@
+---
+title: "Worker Directory Resolution via x-opencode-directory Header"
+date: 2026-02-15
+category: daemon
+tags: [opencode-sdk, jj-workspaces, session-management, worker-isolation]
+related-issues: [LEG-125]
+---
+
+# Worker Directory Resolution
+
+## Problem
+
+Workers spawned with `opencode serve --port X` and `cwd: /path/to/workspace` created sessions in the wrong directory. OpenCode followed jj workspace `.git` symlinks to resolve the project root, landing on the main repo (`/home/sami/legion/ce`) instead of the workspace (`/home/sami/legion/leg-122`).
+
+This broke worker isolation — multiple workers edited the same files in the main repo, causing conflicts.
+
+## Root Cause
+
+jj workspaces share a `.git` directory via symlinks:
+```
+/home/sami/legion/leg-122/.git → /home/sami/legion/default/.git/worktrees/leg-122
+```
+
+OpenCode's project resolution follows this chain to the main repo. Setting `cwd` on the subprocess is necessary but insufficient — OpenCode resolves the project root independently.
+
+## Solution
+
+Three-pronged fix:
+
+1. **`x-opencode-directory` header on session creation** — `initializeSession()` sends this header on `POST /session`, telling OpenCode which directory to use. Only needed at creation time; prompts inherit the session's directory.
+
+2. **`createWorkerClient(port, workspace)` helper** — Wraps `createOpencodeClient({baseUrl, directory})`. The SDK automatically sets `x-opencode-directory` on all requests. Used for status proxy and controller prompt.
+
+3. **`workspace` field in `WorkerEntry`** — Stores the workspace path so downstream call sites can construct workspace-aware SDK clients without re-deriving the path.
+
+## Key Patterns
+
+### SDK vs Raw Fetch Split
+
+The OpenCode SDK's `session.create()` doesn't accept a custom `id` parameter, but the daemon uses deterministic session IDs (`computeSessionId`). Solution: keep raw `fetch` for session creation (which needs `{id: sessionId}` in the body) but add the `x-opencode-directory` header manually. Use the SDK for everything else.
+
+**When to use raw fetch:** When the SDK's typed API doesn't expose a field the server accepts.
+**When to use SDK:** For all standard operations — the SDK handles headers automatically.
+
+### Centralized Client Construction
+
+Pattern: Create a helper that wraps `createOpencodeClient` with domain-specific parameters:
+```typescript
+export function createWorkerClient(port: number, workspace: string): OpencodeClient {
+  return createOpencodeClient({ baseUrl: `http://127.0.0.1:${port}`, directory: workspace });
+}
+```
+This ensures every call site gets the directory header without remembering to add it.
+
+### WorkerEntry as Source of Truth
+
+Adding `workspace` to `WorkerEntry` means any code with a worker reference can construct a properly-configured client. The workspace flows from `SpawnOptions` → `spawnServe` return → stored in `WorkerEntry` → available at status/prompt time.
+
+## Gotchas
+
+### Session directory is set at creation, not per-request
+
+The `x-opencode-directory` header only matters on `POST /session`. Subsequent `prompt_async` and status calls operate within the session's already-established directory context. Don't add the header to prompt calls — it's redundant and misleading.
+
+### SDK `session.create()` doesn't support custom IDs
+
+The SDK's TypeScript types for `session.create()` accept `{directory?, parentID?, title?, permission?}` — no `id` field. The daemon's deterministic session IDs (`computeSessionId`) require passing `{id: sessionId}` in the body, which only works via raw fetch.
+
+### jj working copy auto-commits are dangerous across sessions
+
+When resuming work in a new session, the previous session's changes have already been auto-committed by jj. Running `jj edit @-` changes what `@` points to, and a subsequent `jj abandon @` will destroy the commit with all your changes. Always use `jj new` to create fresh commits; never use `jj edit` + `jj abandon` to restructure.
+
+Recovery: `jj op log` shows all operations. `jj op restore <op-id>` can recover from any destructive operation.

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -241,11 +241,6 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
                 sessionId,
                 logDir: opts.logDir,
                 env: {
-                  LINEAR_ISSUE_ID: issueId,
-                  LINEAR_TEAM_ID: opts.teamId,
-                  LEGION_DIR: opts.legionDir,
-                  LEGION_SHORT_ID: opts.shortId,
-                  LEGION_DAEMON_PORT: String(server.port),
                   ...(env as Record<string, string> | undefined),
                 },
               });


### PR DESCRIPTION
Implements [LEG-127](https://linear.app/metrevals/issue/LEG-127/cleanup-remove-redundant-identity-env-vars-from-worker-spawn)

## Summary

Removes 5 redundant identity env vars (`LINEAR_ISSUE_ID`, `LINEAR_TEAM_ID`, `LEGION_DIR`, `LEGION_SHORT_ID`, `LEGION_DAEMON_PORT`) from the POST `/workers` handler in `server.ts`. Workers never read these — they get identity from the controller's prompt. Caller-provided `env` pass-through is preserved.

## Changes

- **`packages/daemon/src/daemon/server.ts`** — removed 5 identity env var lines from the `spawnServe()` call in the POST `/workers` handler

## Not Changed

- **`index.ts`** — controller spawn retains identity env vars (controller skill reads them)
- **`serve-manager.ts`** — pass-through only, no changes needed

## Verification

CI Results: tests ✅ | tsc ✅ | biome ✅