### PR TITLE
LEG-129: validate workspace is absolute path, document caching decision

### DIFF
--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -159,6 +159,21 @@ describe("daemon server", () => {
     expect(response.status).toBe(400);
   });
 
+  it("rejects relative workspace paths", async () => {
+    await startTestServer();
+    const response = await requestJson("/workers", {
+      method: "POST",
+      body: JSON.stringify({
+        issueId: "ENG-50",
+        mode: "implement",
+        workspace: "relative/path",
+      }),
+    });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("workspace must be an absolute path");
+  });
+
   it("creates workers", async () => {
     await startTestServer();
     const response = await requestJson("/workers", {

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -1,3 +1,4 @@
+import { isAbsolute } from "node:path";
 import { computeSessionId, WorkerMode, type WorkerModeLiteral } from "../state/types";
 import { createWorkerClient, type SpawnOptions, type WorkerEntry } from "./serve-manager";
 import {
@@ -172,6 +173,9 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
               typeof workspace !== "string"
             ) {
               return badRequest("missing_fields");
+            }
+            if (!isAbsolute(workspace)) {
+              return badRequest("workspace must be an absolute path");
             }
             const validModes = Object.values(WorkerMode);
             if (!validModes.includes(mode as WorkerModeLiteral)) {
@@ -363,6 +367,8 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
           }
 
           try {
+            // Client is lightweight (fetch wrapper); no caching needed at current
+            // polling frequency. Revisit if status endpoint becomes a hot path.
             const client = createWorkerClient(entry.port, entry.workspace);
             const result = await client.session.status();
             if (result.error || !result.data) {


### PR DESCRIPTION
Implements LEG-129

Addresses deferred review comments from PR #42:
- **P2**: Reject relative/empty workspace paths in `POST /workers` with `path.isAbsolute()` validation
- **P3**: Document why SDK client caching is premature for status proxy endpoint

## Changes
- `packages/daemon/src/daemon/server.ts`: Added `isAbsolute` import, workspace validation after typeof checks, caching decision comment
- `packages/daemon/src/daemon/__tests__/server.test.ts`: Added test for relative path rejection

## Verification
- tests ✅ (385 pass) | tsc ✅ | biome ✅