### PR TITLE
LEG-135: prevent killWorker from crashing the daemon

### DIFF
--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -265,7 +265,11 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
               await opts.serveManager.initializeSession(port, sessionId, workspace);
               entry = { ...entry, status: "running" };
             } catch (error) {
-              await opts.serveManager.killWorker(entry);
+              try {
+                await opts.serveManager.killWorker(entry);
+              } catch {
+                // killWorker failure must not crash the daemon
+              }
               opts.portAllocator.release(port);
               return serverError(`Failed to initialize session: ${(error as Error).message}`);
             }


### PR DESCRIPTION
## Summary

Wrap `killWorker` call in POST /workers error handler with try/catch so it can't crash the daemon.

## Root Cause

When `initializeSession` times out, the error handler calls `killWorker(entry)`. `killWorker` sends `process.kill(entry.pid, 'SIGKILL')` as a fallback. But `entry.pid` is the Bun.spawn wrapper PID, not the actual opencode child PID. If that PID has been reused, SIGKILL kills the wrong process — potentially the daemon itself.

## Fix

Defensive try/catch around `killWorker` in the POST /workers error handler. The proper fix (stop using PIDs, use dispose only) is tracked separately in LEG-135.