### PR TITLE
LEG-137 - feat: task persistence performance — active index, guardrails, optimized hot paths

### DIFF
--- a/docs/plans/2026-02-15-task-persistence-performance-plan.md
+++ b/docs/plans/2026-02-15-task-persistence-performance-plan.md
@@ -1,0 +1,980 @@
+# Task Persistence Performance Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Keep per-task JSON storage under `~/.config/opencode/tasks/` fast by avoiding full directory scans on hot paths (list, claim) and enforcing simple guardrails — without new dependencies.
+
+**Architecture:** Retain file-per-task JSON and atomic temp+rename writes. Add a compact `active-index.json` that tracks `pending`/`in_progress` task IDs so list and claim skip reading completed/cancelled files. Integrate index updates into write paths (create, update, claim). Guardrails cap description sizes.
+
+**Known gap — crash recovery:** If a process crashes between writing a task file and updating the index, that task is invisible to list/claim until its next update. This is rare (both writes are inside the lock, milliseconds apart) and self-correcting on any task update. A bounded reconcile pass could fix this if it becomes a problem, but is deferred until there's evidence it's needed.
+
+**Tech Stack:** TypeScript, Bun runtime, node:fs, Zod, Bun test, Biome.
+
+**Prerequisite:** Run `bun install` from the repo root before starting.
+
+**Test command:** `bun test packages/opencode-plugin/src/tools/task/` from the repo root.
+
+**Existing helpers you'll reuse from `storage.ts`:** `ensureDir`, `readJsonSafe`, `writeJsonAtomic`, `listTaskFiles`, `acquireLock`, `getTaskDir`.
+
+**Important:** `readAllTasks` is used by `task-create.ts` and `task-update.ts` for cycle detection — these need ALL tasks. The new `readActiveTasks` is only for the list/claim hot paths, with a separate blocker-resolution step that reads individual completed task files on demand.
+
+---
+
+### Task 1: Add TaskIndex schemas to types.ts
+
+**Files:**
+- Modify: `packages/opencode-plugin/src/tools/task/types.ts` (append at end)
+- Test: `packages/opencode-plugin/src/tools/task/__tests__/types.test.ts`
+
+**Step 1: Write the failing test**
+
+Add these imports to the top of `__tests__/types.test.ts` (merge with existing import):
+
+```ts
+import {
+  TaskCreateInputSchema,
+  TaskIndexEntrySchema,
+  TaskIndexSchema,
+  TaskSchema,
+  TaskStatusSchema,
+  TaskUpdateInputSchema,
+} from "../types";
+```
+
+Append these describe blocks at the end of the file:
+
+```ts
+describe("TaskIndexEntrySchema", () => {
+  it("accepts a valid entry", () => {
+    const result = TaskIndexEntrySchema.safeParse({
+      id: "T-abc",
+      status: "pending",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing id", () => {
+    expect(TaskIndexEntrySchema.safeParse({ status: "pending" }).success).toBe(false);
+  });
+
+  it("rejects invalid status", () => {
+    expect(TaskIndexEntrySchema.safeParse({ id: "T-1", status: "deleted" }).success).toBe(false);
+  });
+});
+
+describe("TaskIndexSchema", () => {
+  it("accepts a valid index", () => {
+    const result = TaskIndexSchema.safeParse({
+      version: 1,
+      entries: [{ id: "T-1", status: "pending" }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("defaults entries to empty array", () => {
+    const result = TaskIndexSchema.parse({ version: 1 });
+    expect(result.entries).toEqual([]);
+  });
+
+  it("rejects missing version", () => {
+    expect(TaskIndexSchema.safeParse({ entries: [] }).success).toBe(false);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun test packages/opencode-plugin/src/tools/task/__tests__/types.test.ts`
+Expected: FAIL — `TaskIndexEntrySchema` and `TaskIndexSchema` not exported from `../types`.
+
+**Step 3: Write minimal implementation**
+
+Append to the end of `packages/opencode-plugin/src/tools/task/types.ts`:
+
+```ts
+export const TaskIndexEntrySchema = z.object({
+  id: z.string(),
+  status: TaskStatusSchema,
+});
+
+export type TaskIndexEntry = z.infer<typeof TaskIndexEntrySchema>;
+
+export const TaskIndexSchema = z.object({
+  version: z.literal(1),
+  entries: z.array(TaskIndexEntrySchema).default([]),
+});
+
+export type TaskIndex = z.infer<typeof TaskIndexSchema>;
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `bun test packages/opencode-plugin/src/tools/task/__tests__/types.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+Run: `jj describe -m "feat: add TaskIndex schemas to types.ts"`
+
+---
+
+### Task 2: Add task-index.ts with read/write/upsert helpers
+
+**Files:**
+- Create: `packages/opencode-plugin/src/tools/task/task-index.ts`
+- Test: `packages/opencode-plugin/src/tools/task/__tests__/task-index.test.ts`
+
+**Step 1: Write the failing test**
+
+Create `packages/opencode-plugin/src/tools/task/__tests__/task-index.test.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { indexPathFor, readTaskIndex, upsertIndexEntry, writeTaskIndexAtomic } from "../task-index";
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "task-index-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+function idxPath(): string {
+  return indexPathFor(tempDir);
+}
+
+describe("readTaskIndex", () => {
+  it("returns null for non-existent file", () => {
+    expect(readTaskIndex(idxPath())).toBeNull();
+  });
+
+  it("returns null for malformed JSON", () => {
+    fs.writeFileSync(idxPath(), "{not json");
+    expect(readTaskIndex(idxPath())).toBeNull();
+  });
+
+  it("returns null for invalid schema", () => {
+    fs.writeFileSync(idxPath(), JSON.stringify({ wrong: true }));
+    expect(readTaskIndex(idxPath())).toBeNull();
+  });
+
+  it("returns parsed index for valid file", () => {
+    fs.writeFileSync(
+      idxPath(),
+      JSON.stringify({ version: 1, entries: [{ id: "T-1", status: "pending" }] })
+    );
+    const result = readTaskIndex(idxPath());
+    expect(result).not.toBeNull();
+    expect(result!.version).toBe(1);
+    expect(result!.entries).toHaveLength(1);
+  });
+});
+
+describe("writeTaskIndexAtomic", () => {
+  it("writes valid index file", () => {
+    writeTaskIndexAtomic(idxPath(), { version: 1, entries: [] });
+    const content = JSON.parse(fs.readFileSync(idxPath(), "utf-8"));
+    expect(content.version).toBe(1);
+    expect(content.entries).toEqual([]);
+  });
+
+  it("creates parent directories", () => {
+    const nested = path.join(tempDir, "a", "b", "active-index.json");
+    writeTaskIndexAtomic(nested, { version: 1, entries: [] });
+    expect(fs.existsSync(nested)).toBe(true);
+  });
+
+  it("overwrites existing file atomically", () => {
+    writeTaskIndexAtomic(idxPath(), {
+      version: 1,
+      entries: [{ id: "T-old", status: "pending" }],
+    });
+    writeTaskIndexAtomic(idxPath(), {
+      version: 1,
+      entries: [{ id: "T-new", status: "in_progress" }],
+    });
+    const result = readTaskIndex(idxPath());
+    expect(result!.entries).toHaveLength(1);
+    expect(result!.entries[0].id).toBe("T-new");
+  });
+});
+
+describe("upsertIndexEntry", () => {
+  it("adds a new pending entry", () => {
+    writeTaskIndexAtomic(idxPath(), { version: 1, entries: [] });
+    upsertIndexEntry(idxPath(), { id: "T-1", status: "pending" });
+    const result = readTaskIndex(idxPath());
+    expect(result!.entries).toHaveLength(1);
+    expect(result!.entries[0]).toEqual({ id: "T-1", status: "pending" });
+  });
+
+  it("updates existing entry status", () => {
+    writeTaskIndexAtomic(idxPath(), {
+      version: 1,
+      entries: [{ id: "T-1", status: "pending" }],
+    });
+    upsertIndexEntry(idxPath(), { id: "T-1", status: "in_progress" });
+    const result = readTaskIndex(idxPath());
+    expect(result!.entries).toHaveLength(1);
+    expect(result!.entries[0].status).toBe("in_progress");
+  });
+
+  it("removes entry when status is completed", () => {
+    writeTaskIndexAtomic(idxPath(), {
+      version: 1,
+      entries: [{ id: "T-1", status: "pending" }],
+    });
+    upsertIndexEntry(idxPath(), { id: "T-1", status: "completed" });
+    const result = readTaskIndex(idxPath());
+    expect(result!.entries).toHaveLength(0);
+  });
+
+  it("removes entry when status is cancelled", () => {
+    writeTaskIndexAtomic(idxPath(), {
+      version: 1,
+      entries: [{ id: "T-1", status: "in_progress" }],
+    });
+    upsertIndexEntry(idxPath(), { id: "T-1", status: "cancelled" });
+    const result = readTaskIndex(idxPath());
+    expect(result!.entries).toHaveLength(0);
+  });
+
+  it("creates index if it does not exist", () => {
+    upsertIndexEntry(idxPath(), { id: "T-1", status: "pending" });
+    const result = readTaskIndex(idxPath());
+    expect(result).not.toBeNull();
+    expect(result!.entries).toHaveLength(1);
+  });
+
+  it("preserves other entries", () => {
+    writeTaskIndexAtomic(idxPath(), {
+      version: 1,
+      entries: [
+        { id: "T-1", status: "pending" },
+        { id: "T-2", status: "in_progress" },
+      ],
+    });
+    upsertIndexEntry(idxPath(), { id: "T-1", status: "completed" });
+    const result = readTaskIndex(idxPath());
+    expect(result!.entries).toHaveLength(1);
+    expect(result!.entries[0].id).toBe("T-2");
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun test packages/opencode-plugin/src/tools/task/__tests__/task-index.test.ts`
+Expected: FAIL — module `../task-index` does not exist.
+
+**Step 3: Write minimal implementation**
+
+Create `packages/opencode-plugin/src/tools/task/task-index.ts`:
+
+```ts
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { writeJsonAtomic } from "./storage";
+import {
+  type TaskIndex,
+  type TaskIndexEntry,
+  TaskIndexEntrySchema,
+  TaskIndexSchema,
+} from "./types";
+
+/** Filename for the active task index within a task directory. */
+export const INDEX_FILENAME = "active-index.json";
+
+/** Resolve the index path for a task directory. */
+export function indexPathFor(taskDir: string): string {
+  return join(taskDir, INDEX_FILENAME);
+}
+
+/**
+ * Read and validate the active task index.
+ * Returns null if the file is missing, malformed, or invalid.
+ */
+export function readTaskIndex(indexPath: string): TaskIndex | null {
+  if (!existsSync(indexPath)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(indexPath, "utf-8"));
+    const result = TaskIndexSchema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Atomically write the full task index to disk.
+ * Reuses the same temp+rename pattern as task files.
+ */
+export function writeTaskIndexAtomic(indexPath: string, data: TaskIndex): void {
+  writeJsonAtomic(indexPath, TaskIndexSchema.parse(data));
+}
+
+/**
+ * Upsert a single entry in the active index.
+ *
+ * - pending/in_progress: add or update the entry
+ * - completed/cancelled: remove the entry (task is no longer active)
+ *
+ * Creates the index file if it does not exist.
+ */
+export function upsertIndexEntry(indexPath: string, entry: TaskIndexEntry): void {
+  const validated = TaskIndexEntrySchema.parse(entry);
+  const index = readTaskIndex(indexPath) ?? { version: 1 as const, entries: [] };
+  const entries = index.entries.filter((e) => e.id !== validated.id);
+
+  if (validated.status === "pending" || validated.status === "in_progress") {
+    entries.push(validated);
+  }
+
+  writeTaskIndexAtomic(indexPath, { version: 1, entries });
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `bun test packages/opencode-plugin/src/tools/task/__tests__/task-index.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+Run: `jj describe -m "feat: add task-index.ts with read/write/upsert helpers"`
+
+---
+
+### Task 3: Integrate index updates into write paths
+
+**Files:**
+- Modify: `packages/opencode-plugin/src/tools/task/task-create.ts`
+- Modify: `packages/opencode-plugin/src/tools/task/task-update.ts`
+- Modify: `packages/opencode-plugin/src/tools/task/task-claim.ts`
+- Test: `packages/opencode-plugin/src/tools/task/__tests__/task-index.test.ts` (append integration tests)
+
+The integration pattern is identical in each file: after the task file is written (inside the lock), call `upsertIndexEntry` with the task's current ID and status.
+
+**Step 1: Write the failing integration tests**
+
+In `__tests__/task-index.test.ts`, add these imports at the **top of the file** (merge with existing imports):
+
+```ts
+import { writeJsonAtomic } from "../storage";
+import { createTaskClaimNextTool } from "../task-claim";
+import { createTaskCreateTool } from "../task-create";
+import { createTaskUpdateTool } from "../task-update";
+import type { ToolContext } from "@opencode-ai/plugin";
+import type { Task } from "../types";
+```
+
+Then add these helpers and describe blocks at the **end of the file**:
+
+```ts
+function makeContext(sessionID = "session-1"): ToolContext {
+  return {
+    sessionID,
+    messageID: "msg-1",
+    agent: "orchestrator",
+    directory: "/tmp",
+    worktree: "/tmp",
+    abort: new AbortController().signal,
+    metadata: () => {},
+    ask: async () => {},
+  };
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "T-index-integ",
+    subject: "Test task",
+    description: "",
+    status: "pending",
+    blocks: [],
+    blockedBy: [],
+    threadID: "session-1",
+    ...overrides,
+  };
+}
+
+describe("index integration: task_create", () => {
+  it("adds new task to index on create", async () => {
+    const tool = createTaskCreateTool(undefined, tempDir);
+    const result = JSON.parse(await tool.execute({ subject: "Indexed" }, makeContext()));
+    expect(result.task).toBeTruthy();
+
+    const index = readTaskIndex(idxPath());
+    expect(index).not.toBeNull();
+    const entry = index!.entries.find((e) => e.id === result.task.id);
+    expect(entry).toBeTruthy();
+    expect(entry!.status).toBe("pending");
+  });
+});
+
+describe("index integration: task_update", () => {
+  it("removes task from index on completion", async () => {
+    const createTool = createTaskCreateTool(undefined, tempDir);
+    const created = JSON.parse(
+      await createTool.execute({ subject: "Will complete" }, makeContext())
+    );
+    const taskId = created.task.id;
+
+    const updateTool = createTaskUpdateTool(undefined, tempDir);
+    await updateTool.execute({ id: taskId, status: "completed" }, makeContext());
+
+    const index = readTaskIndex(idxPath());
+    expect(index).not.toBeNull();
+    const entry = index!.entries.find((e) => e.id === taskId);
+    expect(entry).toBeUndefined();
+  });
+
+  it("updates status in index on status change", async () => {
+    const createTool = createTaskCreateTool(undefined, tempDir);
+    const created = JSON.parse(
+      await createTool.execute({ subject: "Will progress" }, makeContext())
+    );
+    const taskId = created.task.id;
+
+    const updateTool = createTaskUpdateTool(undefined, tempDir);
+    await updateTool.execute({ id: taskId, status: "in_progress" }, makeContext());
+
+    const index = readTaskIndex(idxPath());
+    const entry = index!.entries.find((e) => e.id === taskId);
+    expect(entry).toBeTruthy();
+    expect(entry!.status).toBe("in_progress");
+  });
+});
+
+describe("index integration: task_claim_next", () => {
+  it("updates index entry to in_progress on claim", async () => {
+    writeJsonAtomic(
+      path.join(tempDir, "T-claimable.json"),
+      makeTask({ id: "T-claimable" })
+    );
+    // Seed the index so we can verify the upsert updates it after claim
+    upsertIndexEntry(idxPath(), { id: "T-claimable", status: "pending" });
+
+    const tool = createTaskClaimNextTool(undefined, tempDir);
+    const result = JSON.parse(await tool.execute({}, makeContext("agent-1")));
+
+    expect(result.task).toBeTruthy();
+    expect(result.task.id).toBe("T-claimable");
+
+    const index = readTaskIndex(idxPath());
+    const entry = index!.entries.find((e) => e.id === "T-claimable");
+    expect(entry).toBeTruthy();
+    expect(entry!.status).toBe("in_progress");
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun test packages/opencode-plugin/src/tools/task/__tests__/task-index.test.ts`
+Expected: FAIL — index is null after create/update/claim (integration not wired yet).
+
+**Step 3: Write minimal implementation**
+
+**In `task-create.ts`:**
+
+Add import at top (after existing imports):
+```ts
+import { indexPathFor, upsertIndexEntry } from "./task-index";
+```
+
+Add the upsert call immediately after the `writeJsonAtomic(join(taskDir, ...` call that persists the new task (inside `computeResult`, still inside the lock):
+
+```ts
+            upsertIndexEntry(indexPathFor(taskDir), {
+              id: validatedTask.id,
+              status: validatedTask.status,
+            });
+```
+
+**In `task-update.ts`:**
+
+Add import at top (after existing imports):
+```ts
+import { indexPathFor, upsertIndexEntry } from "./task-index";
+```
+
+Add the upsert call immediately after `writeJsonAtomic(taskPath, validatedTask);` (inside `computeResult`, still inside the lock):
+
+```ts
+            upsertIndexEntry(indexPathFor(taskDir), {
+              id: validatedTask.id,
+              status: validatedTask.status,
+            });
+```
+
+**In `task-claim.ts`:**
+
+Add import at top (after existing imports):
+```ts
+import { indexPathFor, upsertIndexEntry } from "./task-index";
+```
+
+Add upsert after the `writeJsonAtomic(...)` call inside the `reclaimExpired` loop (the one that resets expired leases to pending):
+
+```ts
+                upsertIndexEntry(indexPathFor(taskDir), { id: task.id, status: task.status });
+```
+
+Add upsert after the `writeJsonAtomic(...)` call that persists the claimed task (the one inside `computeResult` after `target` is set to `in_progress`):
+
+```ts
+            upsertIndexEntry(indexPathFor(taskDir), {
+              id: validatedTask.id,
+              status: validatedTask.status,
+            });
+```
+
+**Step 4: Run all task tests to verify**
+
+Run: `bun test packages/opencode-plugin/src/tools/task/`
+Expected: ALL PASS — existing tests still pass, new integration tests pass.
+
+**Step 5: Commit**
+
+Run: `jj describe -m "feat: integrate task index updates into create/update/claim"`
+
+---
+
+### Task 4: Index-aware hot paths for list and claim
+
+**Files:**
+- Modify: `packages/opencode-plugin/src/tools/task/task-list.ts`
+- Modify: `packages/opencode-plugin/src/tools/task/task-claim.ts`
+- Test: `packages/opencode-plugin/src/tools/task/__tests__/task-list.test.ts` (append)
+
+**Correctness constraint:** Dependency resolution requires knowing whether a blocker is completed/cancelled. If a blocker isn't in the active index, we read its individual file on demand. This is cheap — typically 0-3 blockers per task.
+
+**Important:** Keep the existing `readAllTasks` function unchanged — it's used by `task-create.ts` and `task-update.ts` for cycle detection, which needs ALL tasks. Add a new `readActiveTasks` function alongside it.
+
+**Step 1: Write the failing tests**
+
+Append to `__tests__/task-list.test.ts`. First add the import (merge with existing imports):
+
+```ts
+import { indexPathFor, writeTaskIndexAtomic } from "../task-index";
+```
+
+Then append these describe blocks:
+
+```ts
+describe("index-aware listing", () => {
+  it("skips reading completed task files when index exists", async () => {
+    for (let i = 0; i < 3; i++) {
+      writeTask(tempDir, makeTask({ id: `T-done-${i}`, status: "completed" }));
+    }
+    writeTask(tempDir, makeTask({ id: "T-active", status: "pending" }));
+
+    writeTaskIndexAtomic(indexPathFor(tempDir), {
+      version: 1,
+      entries: [{ id: "T-active", status: "pending" }],
+    });
+
+    const tool = createTaskListTool(tempDir);
+    const result = JSON.parse(await tool.execute({}, makeContext()));
+
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0].id).toBe("T-active");
+  });
+
+  it("resolves completed blockers not in index", async () => {
+    writeTask(tempDir, makeTask({ id: "T-dep", status: "completed" }));
+    writeTask(tempDir, makeTask({ id: "T-waiting", status: "pending", blockedBy: ["T-dep"] }));
+
+    writeTaskIndexAtomic(indexPathFor(tempDir), {
+      version: 1,
+      entries: [{ id: "T-waiting", status: "pending" }],
+    });
+
+    const tool = createTaskListTool(tempDir);
+    const result = JSON.parse(await tool.execute({ ready: true }, makeContext()));
+
+    const ids = result.tasks.map((t: { id: string }) => t.id);
+    expect(ids).toContain("T-waiting");
+  });
+
+  it("treats missing blocker file as blocking even with index", async () => {
+    writeTask(tempDir, makeTask({ id: "T-orphan", status: "pending", blockedBy: ["T-ghost"] }));
+
+    writeTaskIndexAtomic(indexPathFor(tempDir), {
+      version: 1,
+      entries: [{ id: "T-orphan", status: "pending" }],
+    });
+
+    const tool = createTaskListTool(tempDir);
+    const result = JSON.parse(await tool.execute({ ready: true }, makeContext()));
+
+    const ids = result.tasks.map((t: { id: string }) => t.id);
+    expect(ids).not.toContain("T-orphan");
+  });
+
+  it("falls back to full scan when no index exists", async () => {
+    writeTask(tempDir, makeTask({ id: "T-a", status: "pending" }));
+    writeTask(tempDir, makeTask({ id: "T-b", status: "in_progress" }));
+
+    const tool = createTaskListTool(tempDir);
+    const result = JSON.parse(await tool.execute({}, makeContext()));
+
+    const ids = result.tasks.map((t: { id: string }) => t.id);
+    expect(ids).toContain("T-a");
+    expect(ids).toContain("T-b");
+  });
+});
+```
+
+**Step 2: Run tests as baseline**
+
+Run: `bun test packages/opencode-plugin/src/tools/task/__tests__/task-list.test.ts`
+Expected: All four new tests PASS (the old code produces the same output — it reads all files but filters them). These are regression tests that ensure behavior is preserved after the refactor. The actual performance improvement (fewer file reads) is structural, not behaviorally observable.
+
+**Step 3: Rewrite task-list.ts**
+
+Replace the entire contents of `packages/opencode-plugin/src/tools/task/task-list.ts`:
+
+```ts
+import { join } from "node:path";
+import type { ToolDefinition } from "@opencode-ai/plugin";
+import { tool } from "@opencode-ai/plugin";
+import { getTaskDir, listTaskFiles, readJsonSafe } from "./storage";
+import { indexPathFor, readTaskIndex } from "./task-index";
+import { SATISFYING_STATUSES, type Task, TaskSchema, type TaskStatus } from "./types";
+
+const z = tool.schema;
+
+/**
+ * Read active (pending/in_progress) tasks using the index when available.
+ * Falls back to a full directory scan if no index exists.
+ */
+export function readActiveTasks(taskDir: string): Task[] {
+  const index = readTaskIndex(indexPathFor(taskDir));
+  const fileIds = index ? index.entries.map((e) => e.id) : listTaskFiles(taskDir);
+  const tasks: Task[] = [];
+  for (const fileId of fileIds) {
+    const task = readJsonSafe(join(taskDir, `${fileId}.json`), TaskSchema);
+    if (task && task.status !== "completed" && task.status !== "cancelled") {
+      tasks.push(task);
+    }
+  }
+  return tasks;
+}
+
+/**
+ * Read ALL tasks from disk (full directory scan). Used when the complete
+ * task graph is needed, e.g. for cycle detection in create/update.
+ */
+export function readAllTasks(taskDir: string): Task[] {
+  const fileIds = listTaskFiles(taskDir);
+  const tasks: Task[] = [];
+  for (const fileId of fileIds) {
+    const task = readJsonSafe(join(taskDir, `${fileId}.json`), TaskSchema);
+    if (task) {
+      tasks.push(task);
+    }
+  }
+  return tasks;
+}
+
+/**
+ * Build a task map from active tasks, resolving any blockers that aren't
+ * in the active set by reading their individual files from disk.
+ *
+ * This avoids reading ALL files while still correctly resolving whether
+ * blockers are completed/cancelled (dependency satisfied) vs missing
+ * (dependency not satisfied).
+ */
+export function buildTaskMapWithBlockers(
+  taskDir: string,
+  activeTasks: Task[]
+): Map<string, Task> {
+  const taskMap = new Map(activeTasks.map((t) => [t.id, t]));
+
+  const missingBlockerIds = new Set<string>();
+  for (const task of activeTasks) {
+    for (const blockerId of task.blockedBy) {
+      if (!taskMap.has(blockerId)) {
+        missingBlockerIds.add(blockerId);
+      }
+    }
+  }
+
+  for (const blockerId of missingBlockerIds) {
+    const blocker = readJsonSafe(join(taskDir, `${blockerId}.json`), TaskSchema);
+    if (blocker) {
+      taskMap.set(blocker.id, blocker);
+    }
+  }
+
+  return taskMap;
+}
+
+interface TaskSummary {
+  id: string;
+  subject: string;
+  status: TaskStatus;
+  owner?: string;
+  blockedBy: string[];
+  parentID?: string;
+}
+
+export function createTaskListTool(listId?: string): ToolDefinition {
+  return tool({
+    description:
+      "List active tasks with summary information.\n\n" +
+      "Excludes completed and cancelled by default.\n" +
+      "Use ready=true to filter to tasks whose blockedBy are all completed/cancelled.",
+    args: {
+      ready: z.boolean().optional().describe("Filter to tasks with all dependencies satisfied"),
+      parentID: z.string().optional().describe("Filter by parent task ID"),
+    },
+    execute: async (args) => {
+      const typedArgs = args as { ready?: boolean; parentID?: string };
+      const taskDir = getTaskDir(listId);
+      const activeTasks = readActiveTasks(taskDir);
+
+      let filtered = typedArgs.parentID
+        ? activeTasks.filter((task) => task.parentID === typedArgs.parentID)
+        : activeTasks;
+
+      const taskMap = buildTaskMapWithBlockers(taskDir, activeTasks);
+
+      const summaries: TaskSummary[] = filtered.map((task) => {
+        const unresolvedBlockers = task.blockedBy.filter((blockerId) => {
+          const blocker = taskMap.get(blockerId);
+          return !blocker || !SATISFYING_STATUSES.has(blocker.status);
+        });
+
+        return {
+          id: task.id,
+          subject: task.subject,
+          status: task.status,
+          owner: task.owner,
+          blockedBy: unresolvedBlockers,
+          parentID: task.parentID,
+        };
+      });
+
+      const result = typedArgs.ready
+        ? summaries.filter((s) => s.blockedBy.length === 0)
+        : summaries;
+
+      return JSON.stringify({ tasks: result });
+    },
+  });
+}
+```
+
+**Step 4: Update task-claim.ts to use readActiveTasks + buildTaskMapWithBlockers**
+
+In `task-claim.ts`, change the import from:
+```ts
+import { readAllTasks } from "./task-list";
+```
+to:
+```ts
+import { buildTaskMapWithBlockers, readActiveTasks } from "./task-list";
+```
+
+In the `computeResult` function body, change:
+```ts
+          const allTasks = readAllTasks(taskDir);
+          const taskMap = new Map(allTasks.map((t) => [t.id, t]));
+```
+to:
+```ts
+          const allTasks = readActiveTasks(taskDir);
+          const taskMap = buildTaskMapWithBlockers(taskDir, allTasks);
+```
+
+The rest of the claim logic is unchanged — `reclaimExpired` iterates `allTasks` (now only active tasks, which is correct since only `in_progress` tasks have leases), and the blocker check uses `taskMap` which now correctly includes resolved completed/cancelled blockers.
+
+**Step 5: Run all task tests to verify**
+
+Run: `bun test packages/opencode-plugin/src/tools/task/`
+Expected: ALL PASS — existing behavior preserved, index-aware paths tested.
+
+**Step 6: Commit**
+
+Run: `jj describe -m "feat: index-aware hot paths for task list and claim"`
+
+---
+
+### Task 5: Description size guardrail
+
+**Files:**
+- Modify: `packages/opencode-plugin/src/tools/task/types.ts` (add constant)
+- Modify: `packages/opencode-plugin/src/tools/task/task-create.ts` (add validation)
+- Modify: `packages/opencode-plugin/src/tools/task/task-update.ts` (add validation)
+- Test: `packages/opencode-plugin/src/tools/task/__tests__/task-create.test.ts` (append)
+- Test: `packages/opencode-plugin/src/tools/task/__tests__/task-update.test.ts` (append)
+
+**Step 1: Add the constant to types.ts**
+
+Append to the end of `packages/opencode-plugin/src/tools/task/types.ts`:
+
+```ts
+/** Maximum description length in characters. */
+export const MAX_DESCRIPTION_CHARS = 2_000;
+```
+
+**Step 2: Write the failing tests**
+
+Append to `__tests__/task-create.test.ts`. First add import (merge with existing):
+
+```ts
+import { MAX_DESCRIPTION_CHARS } from "../types";
+```
+
+Then append:
+
+```ts
+describe("task_create guardrails", () => {
+  it("rejects oversized description", async () => {
+    const tool = createTaskCreateTool(undefined, tempDir);
+    const result = JSON.parse(
+      await tool.execute(
+        { subject: "Big", description: "x".repeat(MAX_DESCRIPTION_CHARS + 1) },
+        makeContext()
+      )
+    );
+    expect(result.error).toBe("validation_error");
+    expect(result.message).toContain("description");
+  });
+
+  it("accepts description at the limit", async () => {
+    const tool = createTaskCreateTool(undefined, tempDir);
+    const result = JSON.parse(
+      await tool.execute(
+        { subject: "OK", description: "x".repeat(MAX_DESCRIPTION_CHARS) },
+        makeContext()
+      )
+    );
+    expect(result.task).toBeTruthy();
+  });
+});
+```
+
+Append to `__tests__/task-update.test.ts`. First add import (merge with existing):
+
+```ts
+import { MAX_DESCRIPTION_CHARS } from "../types";
+```
+
+Then append:
+
+```ts
+describe("task_update guardrails", () => {
+  it("rejects oversized description update", async () => {
+    writeTask(tempDir, makeTask());
+    const tool = createTaskUpdateTool(undefined, tempDir);
+    const result = JSON.parse(
+      await tool.execute(
+        { id: "T-update-test", description: "x".repeat(MAX_DESCRIPTION_CHARS + 1) },
+        makeContext()
+      )
+    );
+    expect(result.error).toBe("validation_error");
+    expect(result.message).toContain("description");
+  });
+});
+```
+
+**Step 3: Run tests to verify they fail**
+
+Run: `bun test packages/opencode-plugin/src/tools/task/__tests__/task-create.test.ts packages/opencode-plugin/src/tools/task/__tests__/task-update.test.ts`
+Expected: FAIL — oversized descriptions currently accepted.
+
+**Step 4: Write minimal implementation**
+
+**In `task-create.ts`:**
+
+Add `MAX_DESCRIPTION_CHARS` to the import from `./types`:
+```ts
+import { type Task, TaskCreateInputSchema, TaskSchema, MAX_DESCRIPTION_CHARS } from "./types";
+```
+
+Add validation right after `const validated = TaskCreateInputSchema.parse(args);`, before the lock acquisition:
+
+```ts
+        if (validated.description && validated.description.length > MAX_DESCRIPTION_CHARS) {
+          return JSON.stringify({
+            error: "validation_error",
+            message: `description exceeds ${MAX_DESCRIPTION_CHARS} characters`,
+          });
+        }
+```
+
+**In `task-update.ts`:**
+
+Add `MAX_DESCRIPTION_CHARS` to the import from `./types`:
+```ts
+import { MAX_DESCRIPTION_CHARS, TaskSchema, TaskUpdateInputSchema } from "./types";
+```
+
+Add validation right after `const validated = TaskUpdateInputSchema.parse(args);`, before the lock acquisition:
+
+```ts
+        if (validated.description && validated.description.length > MAX_DESCRIPTION_CHARS) {
+          return JSON.stringify({
+            error: "validation_error",
+            message: `description exceeds ${MAX_DESCRIPTION_CHARS} characters`,
+          });
+        }
+```
+
+**Step 5: Run tests to verify they pass**
+
+Run: `bun test packages/opencode-plugin/src/tools/task/`
+Expected: ALL PASS
+
+**Step 6: Commit**
+
+Run: `jj describe -m "feat: add description size guardrail"`
+
+---
+
+### Task 6: Export new symbols, lint, typecheck
+
+**Files:**
+- Modify: `packages/opencode-plugin/src/tools/task/index.ts`
+
+**Step 1: Update exports in index.ts**
+
+Add these exports to `packages/opencode-plugin/src/tools/task/index.ts`:
+
+```ts
+export {
+  indexPathFor,
+  readTaskIndex,
+  upsertIndexEntry,
+  writeTaskIndexAtomic,
+} from "./task-index";
+export { readActiveTasks } from "./task-list";
+export type { TaskIndex, TaskIndexEntry } from "./types";
+```
+
+**Step 2: Run the full test suite**
+
+Run: `bun test packages/opencode-plugin/src/tools/task/`
+Expected: ALL PASS
+
+**Step 3: Run lint and typecheck**
+
+Run: `bunx biome check packages/opencode-plugin/src/tools/task/`
+Expected: No errors. Fix any formatting issues Biome reports.
+
+Run: `bunx tsc --noEmit`
+Expected: No type errors.
+
+**Step 4: Commit**
+
+Run: `jj describe -m "chore: export task index symbols and finalize"`

--- a/docs/solutions/architecture-patterns/task-index-retro.md
+++ b/docs/solutions/architecture-patterns/task-index-retro.md
@@ -1,0 +1,64 @@
+# Task Index Performance — Implementer Retro
+
+**PR:** https://github.com/sjawhar/legion/pull/51
+
+## What Was Hard
+
+### The empty-index bootstrap bug (P1)
+
+The plan explicitly noted a "known gap — crash recovery" where a crashed process could leave a task invisible. The plan dismissed it as "rare and self-correcting." The reviewer caught that this same gap applies to the FIRST upsert — when no index file exists, `upsertIndexEntry` fell back to `{ version: 1, entries: [] }` and wrote an index containing only the single touched task. All other active tasks became invisible.
+
+**Pattern:** When an optimization cache (index, bloom filter, summary) is missing, rebuild it from the source of truth — don't start empty. The fallback `?? emptyDefault` pattern is dangerous for caches that gate reads. `readTaskIndex() ?? rebuildIndexFromDisk()` is the correct pattern.
+
+### Analysis agents made things worse
+
+Five parallel analysis agents (type-checker, bug-finder, code-simplifier, code-reviewer, test-analyzer) ran on the completed implementation. The bug-finder agent added a `unlinkSync(indexPath)` on write failure — ostensibly to "force fallback to full scan." But since `writeJsonAtomic` already uses temp+rename (old file survives), the unlinkSync actively deleted a valid index. This compounded the P1 bug.
+
+The code-simplifier agent also introduced an unnecessary Map-based dedup in `upsertIndexEntry`, replacing the plan's simpler `filter` + `push`. The reviewer correctly called this out as over-engineering.
+
+**Pattern:** Analysis agents are good at finding surface-level issues (formatting, types, test coverage) but can introduce architectural regressions. Their changes should be reviewed with the same rigor as the original implementation. "More agents ≠ better code."
+
+### Parallel subagent file conflicts
+
+Tasks 4 and 5 were executed in parallel by separate subagents. This required careful analysis of file overlap:
+- Task 4: task-list.ts, task-claim.ts, task-list.test.ts
+- Task 5: types.ts, task-create.ts, task-update.ts, task-create.test.ts, task-update.test.ts
+
+Zero overlap — safe to parallelize. But getting this wrong would have caused silent merge conflicts in jj.
+
+**Pattern:** Before parallelizing subagent work, build an explicit file-overlap matrix. If ANY file appears in both task's write set, they must be sequential.
+
+## Key Design Decisions
+
+### readActiveTasks vs readAllTasks — why both exist
+
+`readAllTasks` does a full directory scan. It's used by `task-create.ts` and `task-update.ts` for cycle detection, which needs the complete task graph including completed/cancelled tasks. `readActiveTasks` uses the index and only loads pending/in_progress tasks — the hot path for list and claim.
+
+Merging these into one function with a boolean flag (`useIndex`) was the right DRY move, but the two public names (`readActiveTasks`, `readAllTasks`) must remain because they communicate intent at call sites.
+
+### buildTaskMapWithBlockers — why it exists
+
+`readActiveTasks` skips completed tasks. But dependency resolution needs to know if a blocker is completed (dependency satisfied) or missing (dependency not satisfied). `buildTaskMapWithBlockers` reads individual completed blocker files on demand — typically 0-3 per task. This is the key correctness mechanism that makes the index optimization safe.
+
+Without it, replacing `readAllTasks` with `readActiveTasks` in the claim tool would treat completed blockers as "missing" (blocking), which is wrong.
+
+### Description guardrail in Zod vs imperative
+
+The initial implementation used imperative `if (validated.description.length > MAX)` checks in both task-create and task-update. The reviewer correctly suggested `.max(MAX_DESCRIPTION_CHARS)` on the Zod input schemas — single source of truth, automatically applies to new handlers.
+
+**Gotcha:** Only add `.max()` to INPUT schemas, not `TaskSchema`. Otherwise, existing tasks > 2000 chars would fail `TaskSchema.parse()` in read paths.
+
+Also required broadening the catch block from `error.message.includes("Required")` to `error.name === "ZodError"` to handle `.max()` validation errors.
+
+## What Went Well
+
+- The plan-review skill caught 7 issues in the draft plan before implementation started (import-append bug, correctness bug in readAllTasks replacement, wrong test expectations, nonexistent file references)
+- Parallel execution of Tasks 4+5 saved ~2 minutes of wall time
+- The `writeJsonAtomic` temp+rename pattern from storage.ts was correctly reused for index writes — no need to reinvent atomic file operations
+- Moving from 6 tasks to 4 phases (batching 1+2, parallelizing 4+5) was the right optimization
+
+## What I'd Do Differently
+
+- Treat the "known gap" in the plan as a blocker, not a deferral. The bootstrap problem was foreseeable.
+- Run fewer analysis agents with more focused prompts. Five parallel agents generated noise and introduced regressions. A single Oracle consultation on "what happens when the index doesn't exist yet?" would have been more valuable.
+- Start with the Zod `.max()` approach for validation from the beginning, rather than the imperative check that had to be refactored.

--- a/docs/solutions/task-index-patterns.md
+++ b/docs/solutions/task-index-patterns.md
@@ -1,0 +1,471 @@
+# File-Based Index Optimization Patterns
+
+**Context:** PR #51 optimized task persistence by adding an `active-index.json` file to avoid full directory scans on hot paths (list, claim). This document captures concrete patterns for similar file-based index optimizations.
+
+**Problem:** File-per-entity storage (e.g., `T-123.json`, `T-456.json`) requires full directory scans to list active entities, which becomes slow as completed/cancelled entities accumulate.
+
+**Solution:** A compact index file tracking only active entity IDs, with on-demand resolution of dependencies.
+
+---
+
+## Core Architecture Patterns
+
+### 1. Index-Aware Read Path with Fallback
+
+**Pattern:** Provide two read functions — one index-aware for hot paths, one full-scan for operations needing complete data.
+
+```typescript
+// Hot path: reads only active entities using index
+export function readActiveTasks(taskDir: string): Task[] {
+  const index = readTaskIndex(indexPathFor(taskDir));
+  const fileIds = index ? index.entries.map((e) => e.id) : listTaskFiles(taskDir);
+  const tasks: Task[] = [];
+  for (const fileId of fileIds) {
+    const task = readJsonSafe(join(taskDir, `${fileId}.json`), TaskSchema);
+    if (task && task.status !== "completed" && task.status !== "cancelled") {
+      tasks.push(task);
+    }
+  }
+  return tasks;
+}
+
+// Full scan: used when complete graph is needed (e.g., cycle detection)
+export function readAllTasks(taskDir: string): Task[] {
+  const fileIds = listTaskFiles(taskDir);
+  const tasks: Task[] = [];
+  for (const fileId of fileIds) {
+    const task = readJsonSafe(join(taskDir, `${fileId}.json`), TaskSchema);
+    if (task) tasks.push(task);
+  }
+  return tasks;
+}
+```
+
+**Why this works:**
+- Index-aware path skips reading completed/cancelled files (performance win)
+- Falls back to full scan when index is missing/corrupt (correctness preserved)
+- Full-scan function preserved for operations that need ALL entities (cycle detection)
+
+**Pitfall avoided:** Don't try to make one function do both — the performance/correctness trade-offs are different. Keep them separate and name them clearly.
+
+---
+
+### 2. On-Demand Dependency Resolution
+
+**Pattern:** When entities have dependencies (blockedBy, references), resolve missing dependencies individually rather than loading all entities.
+
+```typescript
+export function buildTaskMapWithBlockers(
+  taskDir: string,
+  activeTasks: Task[]
+): Map<string, Task> {
+  const taskMap = new Map(activeTasks.map((t) => [t.id, t]));
+
+  // Collect missing blocker IDs
+  const missingBlockerIds = new Set<string>();
+  for (const task of activeTasks) {
+    for (const blockerId of task.blockedBy) {
+      if (!taskMap.has(blockerId)) {
+        missingBlockerIds.add(blockerId);
+      }
+    }
+  }
+
+  // Read only the missing blockers from disk
+  for (const blockerId of missingBlockerIds) {
+    const blocker = readJsonSafe(join(taskDir, `${blockerId}.json`), TaskSchema);
+    if (blocker) {
+      taskMap.set(blocker.id, blocker);
+    }
+  }
+
+  return taskMap;
+}
+```
+
+**Why this works:**
+- Avoids reading ALL files just to resolve a few dependencies
+- Typically 0-3 blockers per task — cheap to read individually
+- Correctly handles completed/cancelled dependencies (needed for "ready" filtering)
+
+**Pitfall avoided:** Don't assume all dependencies are in the active set. Missing dependencies might be completed (satisfied) or truly missing (unsatisfied). Read them to know.
+
+---
+
+### 3. Index Updates Inside Locks, After File Writes
+
+**Pattern:** Update the index immediately after writing the entity file, inside the same lock.
+
+```typescript
+// In task-create.ts, task-update.ts, task-claim.ts:
+try {
+  const computeResult = () => {
+    // ... compute changes ...
+    
+    validatedTask = TaskSchema.parse(task);
+    writeJsonAtomic(join(taskDir, `${taskId}.json`), validatedTask);
+    
+    // Index update immediately after, still inside lock
+    upsertIndexEntry(indexPathFor(taskDir), {
+      id: validatedTask.id,
+      status: validatedTask.status,
+    });
+    
+    return JSON.stringify({ task: validatedTask });
+  };
+  
+  result = computeResult();
+} finally {
+  lock.release();
+}
+```
+
+**Why this works:**
+- Both writes happen inside the lock (milliseconds apart)
+- Minimizes window for crash between writes
+- Index stays consistent with file state
+
+**Known gap acknowledged:** If process crashes between file write and index update, that entity is invisible until next update. This is rare (both writes inside lock) and self-correcting (any update fixes it). A reconcile pass could fix this if it becomes a problem, but defer until there's evidence it's needed.
+
+**Pitfall avoided:** Don't update the index before writing the file — if the file write fails, the index points to a non-existent entity.
+
+---
+
+### 4. Upsert Pattern for Index Maintenance
+
+**Pattern:** Single upsert function handles add/update/remove based on entity state.
+
+```typescript
+export function upsertIndexEntry(indexPath: string, entry: TaskIndexEntry): void {
+  const validated = TaskIndexEntrySchema.parse(entry);
+  const index = readTaskIndex(indexPath) ?? rebuildIndexFromDisk(dirname(indexPath));
+  const entries = index.entries.filter((e) => e.id !== validated.id);
+
+  // Add/update for active statuses, remove for terminal statuses
+  if (validated.status === "pending" || validated.status === "in_progress") {
+    entries.push(validated);
+  }
+
+  writeTaskIndexAtomic(indexPath, { version: 1, entries });
+}
+```
+
+**Why this works:**
+- Single function for all index updates (consistency)
+- Automatically removes entries when entity reaches terminal state
+- Rebuilds from disk if index is missing (crash recovery)
+
+**Pitfall avoided:** Don't have separate add/update/remove functions — you'll forget to call the right one. Make the function smart enough to figure it out.
+
+---
+
+### 5. Rebuild-from-Disk Fallback
+
+**Pattern:** When index is missing or corrupt, rebuild it by scanning entity files.
+
+```typescript
+function rebuildIndexFromDisk(taskDir: string): TaskIndex {
+  const entries: TaskIndexEntry[] = [];
+  try {
+    const files = readdirSync(taskDir).filter((f) => f.endsWith(".json") && f.startsWith("T-"));
+    for (const file of files) {
+      const task = readJsonSafe(join(taskDir, file), TaskSchema);
+      if (task && (task.status === "pending" || task.status === "in_progress")) {
+        entries.push({ id: task.id, status: task.status });
+      }
+    }
+  } catch {
+    // Directory unreadable — return empty index
+  }
+  return { version: 1, entries };
+}
+```
+
+**Why this works:**
+- Automatically recovers from index corruption or deletion
+- Called lazily (only when index is needed but missing)
+- Prevents hiding existing entities due to index issues
+
+**Pitfall avoided:** Don't fail hard when index is missing — rebuild it. The entity files are the source of truth, not the index.
+
+---
+
+## Testing Patterns
+
+### 1. Integration Tests for Index Updates
+
+**Pattern:** Test that index is updated correctly after each write operation.
+
+```typescript
+describe("index integration: task_create", () => {
+  it("adds new task to index on create", async () => {
+    const tool = createTaskCreateTool(undefined, tempDir);
+    const result = JSON.parse(await tool.execute({ subject: "Indexed" }, makeContext()));
+    
+    const index = readTaskIndex(idxPath());
+    expect(index).not.toBeNull();
+    const entry = index?.entries.find((e) => e.id === result.task.id);
+    expect(entry).toBeTruthy();
+    expect(entry?.status).toBe("pending");
+  });
+});
+```
+
+**Why this works:**
+- Tests the actual integration, not just the index functions in isolation
+- Catches missing upsert calls in write paths
+- Verifies index state after real operations
+
+---
+
+### 2. Regression Tests for Behavior Preservation
+
+**Pattern:** Write tests that pass before and after the optimization, proving behavior is unchanged.
+
+```typescript
+describe("index-aware listing", () => {
+  it("resolves completed blockers not in index", async () => {
+    writeTask(tempDir, makeTask({ id: "T-dep", status: "completed" }));
+    writeTask(tempDir, makeTask({ id: "T-waiting", status: "pending", blockedBy: ["T-dep"] }));
+
+    writeTaskIndexAtomic(indexPathFor(tempDir), {
+      version: 1,
+      entries: [{ id: "T-waiting", status: "pending" }],
+    });
+
+    const tool = createTaskListTool(tempDir);
+    const result = JSON.parse(await tool.execute({ ready: true }, makeContext()));
+
+    const ids = result.tasks.map((t: { id: string }) => t.id);
+    expect(ids).toContain("T-waiting");
+  });
+});
+```
+
+**Why this works:**
+- Tests pass with old code (reads all files) and new code (uses index)
+- Proves correctness is preserved despite structural change
+- Catches subtle bugs in dependency resolution
+
+---
+
+### 3. Fallback and Recovery Tests
+
+**Pattern:** Test that system works correctly when index is missing or corrupt.
+
+```typescript
+it("recovers from corrupted index by falling back to full scan", async () => {
+  writeTask(tempDir, makeTask({ id: "T-a", status: "pending" }));
+  writeTask(tempDir, makeTask({ id: "T-b", status: "in_progress" }));
+
+  fs.writeFileSync(indexPathFor(tempDir), "{invalid json");
+
+  const tool = createTaskListTool(tempDir);
+  const result = JSON.parse(await tool.execute({}, makeContext()));
+
+  const ids = result.tasks.map((t: { id: string }) => t.id);
+  expect(ids).toContain("T-a");
+  expect(ids).toContain("T-b");
+});
+```
+
+**Why this works:**
+- Proves system degrades gracefully when index is broken
+- Prevents hiding entities due to index corruption
+- Tests the rebuild-from-disk path
+
+---
+
+## Schema and Type Patterns
+
+### 1. Minimal Index Schema
+
+**Pattern:** Index stores only what's needed for filtering, not full entity data.
+
+```typescript
+export const TaskIndexEntrySchema = z.object({
+  id: z.string(),
+  status: TaskStatusSchema,  // Only field needed for active/inactive filtering
+});
+
+export const TaskIndexSchema = z.object({
+  version: z.literal(1),  // For future schema migrations
+  entries: z.array(TaskIndexEntrySchema).default([]),
+});
+```
+
+**Why this works:**
+- Keeps index file small (scales to thousands of entities)
+- Only stores data needed for hot path decisions
+- Version field enables future migrations without breaking old code
+
+**Pitfall avoided:** Don't store full entity data in the index — that defeats the purpose. Store only what you need to decide which files to read.
+
+---
+
+### 2. Guardrails Alongside Performance Work
+
+**Pattern:** Add simple guardrails (size limits) in the same PR as performance work.
+
+```typescript
+export const MAX_DESCRIPTION_CHARS = 2_000;
+
+export const TaskCreateInputSchema = z.object({
+  subject: z.string(),
+  description: z.string().max(MAX_DESCRIPTION_CHARS).optional(),
+  // ...
+});
+```
+
+**Why this works:**
+- Prevents unbounded growth that would negate performance gains
+- Simple to implement (Zod validation)
+- Catches issues early (at write time, not read time)
+
+**Pitfall avoided:** Don't optimize reads without limiting writes — you'll just delay the problem.
+
+---
+
+## Implementation Sequence
+
+**Lesson from PR #51:** The implementation followed a strict TDD sequence that minimized risk:
+
+1. **Add schemas** (types, validation) — establishes contracts
+2. **Add index helpers** (read/write/upsert) — isolated, testable
+3. **Integrate into write paths** (create/update/claim) — index stays consistent
+4. **Add index-aware read paths** (list/claim) — performance win
+5. **Add guardrails** (size limits) — prevents future issues
+6. **Export symbols** — makes functionality available
+
+**Why this sequence works:**
+- Each step is independently testable
+- Tests written before implementation (TDD)
+- Integration happens after helpers are proven correct
+- Performance optimization comes after correctness is established
+
+**Pitfall avoided:** Don't optimize reads before fixing writes — you'll get inconsistent index state.
+
+---
+
+## When to Use This Pattern
+
+**Good fit:**
+- File-per-entity storage with growing number of inactive entities
+- Hot paths that list/filter entities frequently
+- Entities have clear active/inactive states
+- Dependencies between entities are sparse (few per entity)
+
+**Poor fit:**
+- Entities don't have clear active/inactive distinction
+- Most operations need all entities anyway
+- Dependencies are dense (many per entity, would require reading most files)
+- Write volume is extremely high (index updates become bottleneck)
+
+---
+
+## Complexity That Could Have Been Avoided
+
+### 1. Rebuild-from-Disk Complexity
+
+**What happened:** Initial implementation had `upsertIndexEntry` create an empty index if missing. This could hide existing tasks if the index was accidentally deleted.
+
+**Fix:** Added `rebuildIndexFromDisk` to scan entity files when index is missing.
+
+**Lesson:** For file-based storage, the files are the source of truth. When index is missing, rebuild it from files rather than starting empty.
+
+**Simpler alternative:** Could have required manual index rebuild via CLI command, but automatic recovery is more robust.
+
+---
+
+### 2. Type Annotations for Return Types
+
+**What happened:** Added explicit `Promise<string>` return types to tool execute functions.
+
+**Why:** TypeScript inference works, but explicit types catch mistakes where you accidentally return the wrong type.
+
+**Lesson:** For public APIs (tool execute functions), explicit return types are documentation and safety, even when inference works.
+
+---
+
+## Good Patterns Worth Replicating
+
+### 1. Atomic Writes with Temp+Rename
+
+**Pattern:** Write to temp file, then rename to final location (atomic on POSIX).
+
+```typescript
+export function writeJsonAtomic(filePath: string, data: unknown): void {
+  const tempPath = `${filePath}.tmp`;
+  writeFileSync(tempPath, JSON.stringify(data, null, 2));
+  renameSync(tempPath, filePath);
+}
+```
+
+**Why replicate:** Prevents partial writes from being read. Rename is atomic on POSIX systems.
+
+---
+
+### 2. Safe JSON Reads with Schema Validation
+
+**Pattern:** Read JSON, validate with Zod, return null on any error.
+
+```typescript
+export function readJsonSafe<T>(filePath: string, schema: z.ZodType<T>): T | null {
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf-8"));
+    const result = schema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+```
+
+**Why replicate:** Handles missing files, malformed JSON, and schema violations uniformly. Caller doesn't need to distinguish error types.
+
+---
+
+### 3. Lock-Scoped Operations with Try-Finally
+
+**Pattern:** Acquire lock, compute result in try block, release in finally.
+
+```typescript
+const lock = acquireLock(taskDir);
+if (!lock) {
+  return JSON.stringify({ error: "lock_failed" });
+}
+
+let result: string;
+try {
+  result = computeResult();
+} finally {
+  lock.release();
+}
+return result;
+```
+
+**Why replicate:** Ensures lock is always released, even if computation throws. Prevents deadlocks.
+
+---
+
+## Summary: What to Tell Someone Implementing Similar Work
+
+1. **Keep two read paths:** Index-aware for hot paths, full-scan for operations needing complete data. Don't try to make one function do both.
+
+2. **Resolve dependencies on-demand:** Don't load all entities just to check a few dependencies. Read missing dependencies individually.
+
+3. **Update index inside locks, after file writes:** Minimize crash window, keep index consistent with files.
+
+4. **Rebuild from disk when index is missing:** Files are source of truth. Don't hide entities due to index issues.
+
+5. **Test integration, not just units:** Verify index is updated after real operations, not just in isolation.
+
+6. **Write regression tests:** Tests that pass before and after prove behavior is preserved.
+
+7. **Add guardrails alongside performance work:** Size limits prevent unbounded growth that negates optimization.
+
+8. **Follow TDD sequence:** Schemas → helpers → write integration → read optimization → guardrails. Each step independently testable.
+
+9. **Store minimal data in index:** Only what's needed for filtering decisions. Full data stays in entity files.
+
+10. **Acknowledge known gaps explicitly:** Crash recovery gap is rare and self-correcting. Document it, defer fix until there's evidence it's needed.

--- a/packages/opencode-plugin/src/tools/task/__tests__/task-create.test.ts
+++ b/packages/opencode-plugin/src/tools/task/__tests__/task-create.test.ts
@@ -6,6 +6,7 @@ import type { ToolContext } from "@opencode-ai/plugin";
 import { writeJsonAtomic } from "../storage";
 import { createTaskCreateTool } from "../task-create";
 import type { Task } from "../types";
+import { MAX_DESCRIPTION_CHARS } from "../types";
 
 let tempDir: string;
 
@@ -103,5 +104,46 @@ describe("task_create", () => {
     const result = JSON.parse(await tool.execute({} as Record<string, unknown>, makeContext()));
 
     expect(result.error).toBeTruthy();
+  });
+});
+
+describe("task_create guardrails", () => {
+  it("rejects oversized description", async () => {
+    const tool = createTaskCreateTool(undefined, tempDir);
+    const result = JSON.parse(
+      await tool.execute(
+        { subject: "Big", description: "x".repeat(MAX_DESCRIPTION_CHARS + 1) },
+        makeContext()
+      )
+    );
+    expect(result.error).toBe("validation_error");
+    expect(result.message).toContain("description");
+  });
+
+  it("accepts description at the limit", async () => {
+    const tool = createTaskCreateTool(undefined, tempDir);
+    const result = JSON.parse(
+      await tool.execute(
+        { subject: "OK", description: "x".repeat(MAX_DESCRIPTION_CHARS) },
+        makeContext()
+      )
+    );
+    expect(result.task).toBeTruthy();
+  });
+
+  it("accepts empty description", async () => {
+    const tool = createTaskCreateTool(undefined, tempDir);
+    const result = JSON.parse(
+      await tool.execute({ subject: "No desc", description: "" }, makeContext())
+    );
+    expect(result.task).toBeTruthy();
+    expect(result.task.id).toMatch(/^T-/);
+  });
+
+  it("accepts task without description field", async () => {
+    const tool = createTaskCreateTool(undefined, tempDir);
+    const result = JSON.parse(await tool.execute({ subject: "No desc field" }, makeContext()));
+    expect(result.task).toBeTruthy();
+    expect(result.task.id).toMatch(/^T-/);
   });
 });

--- a/packages/opencode-plugin/src/tools/task/__tests__/task-index.test.ts
+++ b/packages/opencode-plugin/src/tools/task/__tests__/task-index.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ToolContext } from "@opencode-ai/plugin";
+import { writeJsonAtomic } from "../storage";
+import { createTaskClaimNextTool } from "../task-claim";
+import { createTaskCreateTool } from "../task-create";
+import { indexPathFor, readTaskIndex, upsertIndexEntry, writeTaskIndexAtomic } from "../task-index";
+import { createTaskUpdateTool } from "../task-update";
+import type { Task } from "../types";
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "task-index-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+function idxPath(): string {
+  return indexPathFor(tempDir);
+}
+
+describe("readTaskIndex", () => {
+  it("returns null for non-existent file", () => {
+    expect(readTaskIndex(idxPath())).toBeNull();
+  });
+
+  it("returns null for malformed JSON", () => {
+    fs.writeFileSync(idxPath(), "{not json");
+    expect(readTaskIndex(idxPath())).toBeNull();
+  });
+
+  it("returns null for invalid schema", () => {
+    fs.writeFileSync(idxPath(), JSON.stringify({ wrong: true }));
+    expect(readTaskIndex(idxPath())).toBeNull();
+  });
+
+  it("returns parsed index for valid file", () => {
+    fs.writeFileSync(
+      idxPath(),
+      JSON.stringify({ version: 1, entries: [{ id: "T-1", status: "pending" }] })
+    );
+    const result = readTaskIndex(idxPath());
+    expect(result).not.toBeNull();
+    expect(result?.version).toBe(1);
+    expect(result?.entries).toHaveLength(1);
+  });
+});
+
+describe("writeTaskIndexAtomic", () => {
+  it("writes valid index file", () => {
+    writeTaskIndexAtomic(idxPath(), { version: 1, entries: [] });
+    const content = JSON.parse(fs.readFileSync(idxPath(), "utf-8"));
+    expect(content.version).toBe(1);
+    expect(content.entries).toEqual([]);
+  });
+
+  it("creates parent directories", () => {
+    const nested = path.join(tempDir, "a", "b", "active-index.json");
+    writeTaskIndexAtomic(nested, { version: 1, entries: [] });
+    expect(fs.existsSync(nested)).toBe(true);
+  });
+
+  it("overwrites existing file atomically", () => {
+    writeTaskIndexAtomic(idxPath(), {
+      version: 1,
+      entries: [{ id: "T-old", status: "pending" }],
+    });
+    writeTaskIndexAtomic(idxPath(), {
+      version: 1,
+      entries: [{ id: "T-new", status: "in_progress" }],
+    });
+    const result = readTaskIndex(idxPath());
+    expect(result?.entries).toHaveLength(1);
+    expect(result?.entries[0].id).toBe("T-new");
+  });
+});
+
+describe("upsertIndexEntry", () => {
+  it("adds a new pending entry", () => {
+    writeTaskIndexAtomic(idxPath(), { version: 1, entries: [] });
+    upsertIndexEntry(idxPath(), { id: "T-1", status: "pending" });
+    const result = readTaskIndex(idxPath());
+    expect(result?.entries).toHaveLength(1);
+    expect(result?.entries[0]).toEqual({ id: "T-1", status: "pending" });
+  });
+
+  it("updates existing entry status", () => {
+    writeTaskIndexAtomic(idxPath(), {
+      version: 1,
+      entries: [{ id: "T-1", status: "pending" }],
+    });
+    upsertIndexEntry(idxPath(), { id: "T-1", status: "in_progress" });
+    const result = readTaskIndex(idxPath());
+    expect(result?.entries).toHaveLength(1);
+    expect(result?.entries[0].status).toBe("in_progress");
+  });
+
+  it("removes entry when status is completed", () => {
+    writeTaskIndexAtomic(idxPath(), {
+      version: 1,
+      entries: [{ id: "T-1", status: "pending" }],
+    });
+    upsertIndexEntry(idxPath(), { id: "T-1", status: "completed" });
+    const result = readTaskIndex(idxPath());
+    expect(result?.entries).toHaveLength(0);
+  });
+
+  it("removes entry when status is cancelled", () => {
+    writeTaskIndexAtomic(idxPath(), {
+      version: 1,
+      entries: [{ id: "T-1", status: "in_progress" }],
+    });
+    upsertIndexEntry(idxPath(), { id: "T-1", status: "cancelled" });
+    const result = readTaskIndex(idxPath());
+    expect(result?.entries).toHaveLength(0);
+  });
+
+  it("creates index if it does not exist", () => {
+    upsertIndexEntry(idxPath(), { id: "T-1", status: "pending" });
+    const result = readTaskIndex(idxPath());
+    expect(result).not.toBeNull();
+    expect(result?.entries).toHaveLength(1);
+  });
+
+  it("preserves other entries", () => {
+    writeTaskIndexAtomic(idxPath(), {
+      version: 1,
+      entries: [
+        { id: "T-1", status: "pending" },
+        { id: "T-2", status: "in_progress" },
+      ],
+    });
+    upsertIndexEntry(idxPath(), { id: "T-1", status: "completed" });
+    const result = readTaskIndex(idxPath());
+    expect(result?.entries).toHaveLength(1);
+    expect(result?.entries[0].id).toBe("T-2");
+  });
+
+  it("handles multiple upserts to same entry", () => {
+    writeTaskIndexAtomic(idxPath(), { version: 1, entries: [] });
+    upsertIndexEntry(idxPath(), { id: "T-1", status: "pending" });
+    upsertIndexEntry(idxPath(), { id: "T-1", status: "in_progress" });
+    upsertIndexEntry(idxPath(), { id: "T-1", status: "pending" });
+    const result = readTaskIndex(idxPath());
+    expect(result?.entries).toHaveLength(1);
+    expect(result?.entries[0].status).toBe("pending");
+  });
+
+  it("handles missing index file gracefully", () => {
+    expect(fs.existsSync(idxPath())).toBe(false);
+    upsertIndexEntry(idxPath(), { id: "T-1", status: "pending" });
+    const result = readTaskIndex(idxPath());
+    expect(result).not.toBeNull();
+    expect(result?.entries).toHaveLength(1);
+  });
+});
+
+function makeContext(sessionID = "session-1"): ToolContext {
+  return {
+    sessionID,
+    messageID: "msg-1",
+    agent: "orchestrator",
+    directory: "/tmp",
+    worktree: "/tmp",
+    abort: new AbortController().signal,
+    metadata: () => {},
+    ask: async () => {},
+  };
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "T-index-integ",
+    subject: "Test task",
+    description: "",
+    status: "pending",
+    blocks: [],
+    blockedBy: [],
+    threadID: "session-1",
+    ...overrides,
+  };
+}
+
+describe("index integration: task_create", () => {
+  it("adds new task to index on create", async () => {
+    const tool = createTaskCreateTool(undefined, tempDir);
+    const result = JSON.parse(await tool.execute({ subject: "Indexed" }, makeContext()));
+    expect(result.task).toBeTruthy();
+
+    const index = readTaskIndex(idxPath());
+    expect(index).not.toBeNull();
+    const entry = index?.entries.find((e) => e.id === result.task.id);
+    expect(entry).toBeTruthy();
+    expect(entry?.status).toBe("pending");
+  });
+});
+
+describe("index integration: task_update", () => {
+  it("removes task from index on completion", async () => {
+    const createTool = createTaskCreateTool(undefined, tempDir);
+    const created = JSON.parse(
+      await createTool.execute({ subject: "Will complete" }, makeContext())
+    );
+    const taskId = created.task.id;
+
+    const updateTool = createTaskUpdateTool(undefined, tempDir);
+    await updateTool.execute({ id: taskId, status: "completed" }, makeContext());
+
+    const index = readTaskIndex(idxPath());
+    expect(index).not.toBeNull();
+    const entry = index?.entries.find((e) => e.id === taskId);
+    expect(entry).toBeUndefined();
+  });
+
+  it("updates status in index on status change", async () => {
+    const createTool = createTaskCreateTool(undefined, tempDir);
+    const created = JSON.parse(
+      await createTool.execute({ subject: "Will progress" }, makeContext())
+    );
+    const taskId = created.task.id;
+
+    const updateTool = createTaskUpdateTool(undefined, tempDir);
+    await updateTool.execute({ id: taskId, status: "in_progress" }, makeContext());
+
+    const index = readTaskIndex(idxPath());
+    const entry = index?.entries.find((e) => e.id === taskId);
+    expect(entry).toBeTruthy();
+    expect(entry?.status).toBe("in_progress");
+  });
+});
+
+describe("index integration: task_claim_next", () => {
+  it("updates index entry to in_progress on claim", async () => {
+    writeJsonAtomic(path.join(tempDir, "T-claimable.json"), makeTask({ id: "T-claimable" }));
+    upsertIndexEntry(idxPath(), { id: "T-claimable", status: "pending" });
+
+    const tool = createTaskClaimNextTool(undefined, tempDir);
+    const result = JSON.parse(await tool.execute({}, makeContext("agent-1")));
+
+    expect(result.task).toBeTruthy();
+    expect(result.task.id).toBe("T-claimable");
+
+    const index = readTaskIndex(idxPath());
+    const entry = index?.entries.find((e) => e.id === "T-claimable");
+    expect(entry).toBeTruthy();
+    expect(entry?.status).toBe("in_progress");
+  });
+});

--- a/packages/opencode-plugin/src/tools/task/__tests__/task-list.test.ts
+++ b/packages/opencode-plugin/src/tools/task/__tests__/task-list.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import type { ToolContext } from "@opencode-ai/plugin";
 import { writeJsonAtomic } from "../storage";
+import { indexPathFor, writeTaskIndexAtomic } from "../task-index";
 import { createTaskListTool } from "../task-list";
 import type { Task } from "../types";
 
@@ -125,6 +126,24 @@ describe("task_list", () => {
     expect(ids).not.toContain("T-blocked");
   });
 
+  it("without ready filter, includes blocked tasks", async () => {
+    writeTask(tempDir, makeTask({ id: "T-dep", status: "completed" }));
+    writeTask(tempDir, makeTask({ id: "T-ready", status: "pending", blockedBy: ["T-dep"] }));
+    writeTask(
+      tempDir,
+      makeTask({ id: "T-blocked", status: "pending", blockedBy: ["T-still-pending"] })
+    );
+    writeTask(tempDir, makeTask({ id: "T-still-pending", status: "pending" }));
+
+    const tool = createTaskListTool(tempDir);
+    const result = JSON.parse(await tool.execute({}, makeContext()));
+
+    const ids = result.tasks.map((t: { id: string }) => t.id);
+    expect(ids).toContain("T-ready");
+    expect(ids).toContain("T-blocked");
+    expect(ids).toContain("T-still-pending");
+  });
+
   it("missing dep = blocked (safe default)", async () => {
     writeTask(tempDir, makeTask({ id: "T-orphan", status: "pending", blockedBy: ["T-ghost"] }));
 
@@ -144,5 +163,100 @@ describe("task_list", () => {
 
     expect(result.tasks).toHaveLength(1);
     expect(result.tasks[0].id).toBe("T-child");
+  });
+});
+
+describe("index-aware listing", () => {
+  it("skips reading completed task files when index exists", async () => {
+    for (let i = 0; i < 3; i++) {
+      writeTask(tempDir, makeTask({ id: `T-done-${i}`, status: "completed" }));
+    }
+    writeTask(tempDir, makeTask({ id: "T-active", status: "pending" }));
+
+    writeTaskIndexAtomic(indexPathFor(tempDir), {
+      version: 1,
+      entries: [{ id: "T-active", status: "pending" }],
+    });
+
+    const tool = createTaskListTool(tempDir);
+    const result = JSON.parse(await tool.execute({}, makeContext()));
+
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0].id).toBe("T-active");
+  });
+
+  it("resolves completed blockers not in index", async () => {
+    writeTask(tempDir, makeTask({ id: "T-dep", status: "completed" }));
+    writeTask(tempDir, makeTask({ id: "T-waiting", status: "pending", blockedBy: ["T-dep"] }));
+
+    writeTaskIndexAtomic(indexPathFor(tempDir), {
+      version: 1,
+      entries: [{ id: "T-waiting", status: "pending" }],
+    });
+
+    const tool = createTaskListTool(tempDir);
+    const result = JSON.parse(await tool.execute({ ready: true }, makeContext()));
+
+    const ids = result.tasks.map((t: { id: string }) => t.id);
+    expect(ids).toContain("T-waiting");
+  });
+
+  it("treats missing blocker file as blocking even with index", async () => {
+    writeTask(tempDir, makeTask({ id: "T-orphan", status: "pending", blockedBy: ["T-ghost"] }));
+
+    writeTaskIndexAtomic(indexPathFor(tempDir), {
+      version: 1,
+      entries: [{ id: "T-orphan", status: "pending" }],
+    });
+
+    const tool = createTaskListTool(tempDir);
+    const result = JSON.parse(await tool.execute({ ready: true }, makeContext()));
+
+    const ids = result.tasks.map((t: { id: string }) => t.id);
+    expect(ids).not.toContain("T-orphan");
+  });
+
+  it("falls back to full scan when no index exists", async () => {
+    writeTask(tempDir, makeTask({ id: "T-a", status: "pending" }));
+    writeTask(tempDir, makeTask({ id: "T-b", status: "in_progress" }));
+
+    const tool = createTaskListTool(tempDir);
+    const result = JSON.parse(await tool.execute({}, makeContext()));
+
+    const ids = result.tasks.map((t: { id: string }) => t.id);
+    expect(ids).toContain("T-a");
+    expect(ids).toContain("T-b");
+  });
+
+  it("skips missing task files referenced in index", async () => {
+    writeTask(tempDir, makeTask({ id: "T-exists", status: "pending" }));
+    writeTaskIndexAtomic(indexPathFor(tempDir), {
+      version: 1,
+      entries: [
+        { id: "T-exists", status: "pending" },
+        { id: "T-missing", status: "pending" },
+      ],
+    });
+
+    const tool = createTaskListTool(tempDir);
+    const result = JSON.parse(await tool.execute({}, makeContext()));
+
+    const ids = result.tasks.map((t: { id: string }) => t.id);
+    expect(ids).toContain("T-exists");
+    expect(ids).not.toContain("T-missing");
+  });
+
+  it("recovers from corrupted index by falling back to full scan", async () => {
+    writeTask(tempDir, makeTask({ id: "T-a", status: "pending" }));
+    writeTask(tempDir, makeTask({ id: "T-b", status: "in_progress" }));
+
+    fs.writeFileSync(indexPathFor(tempDir), "{invalid json");
+
+    const tool = createTaskListTool(tempDir);
+    const result = JSON.parse(await tool.execute({}, makeContext()));
+
+    const ids = result.tasks.map((t: { id: string }) => t.id);
+    expect(ids).toContain("T-a");
+    expect(ids).toContain("T-b");
   });
 });

--- a/packages/opencode-plugin/src/tools/task/__tests__/task-update.test.ts
+++ b/packages/opencode-plugin/src/tools/task/__tests__/task-update.test.ts
@@ -6,6 +6,7 @@ import type { ToolContext } from "@opencode-ai/plugin";
 import { writeJsonAtomic } from "../storage";
 import { createTaskUpdateTool } from "../task-update";
 import type { Task } from "../types";
+import { MAX_DESCRIPTION_CHARS } from "../types";
 
 let tempDir: string;
 
@@ -145,5 +146,43 @@ describe("task_update", () => {
 
     expect(result.error).toBe("cycle_detected");
     expect(result.cycle).toBeTruthy();
+  });
+});
+
+describe("task_update guardrails", () => {
+  it("rejects oversized description update", async () => {
+    writeTask(tempDir, makeTask());
+    const tool = createTaskUpdateTool(undefined, tempDir);
+    const result = JSON.parse(
+      await tool.execute(
+        { id: "T-update-test", description: "x".repeat(MAX_DESCRIPTION_CHARS + 1) },
+        makeContext()
+      )
+    );
+    expect(result.error).toBe("validation_error");
+    expect(result.message).toContain("description");
+  });
+
+  it("accepts description at the limit", async () => {
+    writeTask(tempDir, makeTask());
+    const tool = createTaskUpdateTool(undefined, tempDir);
+    const result = JSON.parse(
+      await tool.execute(
+        { id: "T-update-test", description: "x".repeat(MAX_DESCRIPTION_CHARS) },
+        makeContext()
+      )
+    );
+    expect(result.task).toBeTruthy();
+    expect(result.task.description).toHaveLength(MAX_DESCRIPTION_CHARS);
+  });
+
+  it("accepts empty description update", async () => {
+    writeTask(tempDir, makeTask());
+    const tool = createTaskUpdateTool(undefined, tempDir);
+    const result = JSON.parse(
+      await tool.execute({ id: "T-update-test", description: "" }, makeContext())
+    );
+    expect(result.task).toBeTruthy();
+    expect(result.task.description).toBe("");
   });
 });

--- a/packages/opencode-plugin/src/tools/task/__tests__/types.test.ts
+++ b/packages/opencode-plugin/src/tools/task/__tests__/types.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import {
   TaskCreateInputSchema,
+  TaskIndexEntrySchema,
+  TaskIndexSchema,
   TaskSchema,
   TaskStatusSchema,
   TaskUpdateInputSchema,
@@ -95,5 +97,42 @@ describe("TaskUpdateInputSchema", () => {
       addBlockedBy: ["T-3"],
     });
     expect(result.success).toBe(true);
+  });
+});
+
+describe("TaskIndexEntrySchema", () => {
+  it("accepts a valid entry", () => {
+    const result = TaskIndexEntrySchema.safeParse({
+      id: "T-abc",
+      status: "pending",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing id", () => {
+    expect(TaskIndexEntrySchema.safeParse({ status: "pending" }).success).toBe(false);
+  });
+
+  it("rejects invalid status", () => {
+    expect(TaskIndexEntrySchema.safeParse({ id: "T-1", status: "deleted" }).success).toBe(false);
+  });
+});
+
+describe("TaskIndexSchema", () => {
+  it("accepts a valid index", () => {
+    const result = TaskIndexSchema.safeParse({
+      version: 1,
+      entries: [{ id: "T-1", status: "pending" }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("defaults entries to empty array", () => {
+    const result = TaskIndexSchema.parse({ version: 1 });
+    expect(result.entries).toEqual([]);
+  });
+
+  it("rejects missing version", () => {
+    expect(TaskIndexSchema.safeParse({ entries: [] }).success).toBe(false);
   });
 });

--- a/packages/opencode-plugin/src/tools/task/index.ts
+++ b/packages/opencode-plugin/src/tools/task/index.ts
@@ -6,10 +6,23 @@ import { createTaskListTool } from "./task-list";
 import { createTaskUpdateTool } from "./task-update";
 
 export { detectCycle } from "./graph";
-export { readAllTasks } from "./task-list";
+export {
+  indexPathFor,
+  readTaskIndex,
+  upsertIndexEntry,
+  writeTaskIndexAtomic,
+} from "./task-index";
+export { readActiveTasks, readAllTasks } from "./task-list";
 export type { TodoInfo } from "./todo-sync";
 export { syncTaskTodoUpdate, syncTaskToTodo } from "./todo-sync";
-export type { Task, TaskCreateInput, TaskStatus, TaskUpdateInput } from "./types";
+export type {
+  Task,
+  TaskCreateInput,
+  TaskIndex,
+  TaskIndexEntry,
+  TaskStatus,
+  TaskUpdateInput,
+} from "./types";
 
 interface TaskTools {
   task_create: ToolDefinition;

--- a/packages/opencode-plugin/src/tools/task/task-claim.ts
+++ b/packages/opencode-plugin/src/tools/task/task-claim.ts
@@ -2,9 +2,16 @@ import { join } from "node:path";
 import type { PluginInput, ToolDefinition } from "@opencode-ai/plugin";
 import { tool } from "@opencode-ai/plugin";
 import { acquireLock, getTaskDir, writeJsonAtomic } from "./storage";
-import { readAllTasks } from "./task-list";
+import { indexPathFor, upsertIndexEntry } from "./task-index";
+import { buildTaskMapWithBlockers, readActiveTasks } from "./task-list";
 import { syncTaskTodoUpdate } from "./todo-sync";
-import { LEASE_DURATION_MS, MAX_CLAIM_ATTEMPTS, SATISFYING_STATUSES, TaskSchema } from "./types";
+import {
+  LEASE_DURATION_MS,
+  MAX_CLAIM_ATTEMPTS,
+  SATISFYING_STATUSES,
+  type Task,
+  TaskSchema,
+} from "./types";
 
 export function createTaskClaimNextTool(ctx?: PluginInput, listId?: string): ToolDefinition {
   return tool({
@@ -15,7 +22,7 @@ export function createTaskClaimNextTool(ctx?: PluginInput, listId?: string): Too
       "Sets status=in_progress, owner, lease, and increments attempt_count.\n" +
       "Expired leases are auto-reclaimed.",
     args: {},
-    execute: async (_args, context) => {
+    execute: async (_args, context): Promise<string> => {
       const taskDir = getTaskDir(listId);
       const lock = acquireLock(taskDir);
 
@@ -24,11 +31,11 @@ export function createTaskClaimNextTool(ctx?: PluginInput, listId?: string): Too
       }
 
       let result: string;
-      let validatedTask: ReturnType<typeof TaskSchema.parse> | null = null;
+      let validatedTask: Task | null = null;
       try {
         const computeResult = () => {
-          const allTasks = readAllTasks(taskDir);
-          const taskMap = new Map(allTasks.map((t) => [t.id, t]));
+          const allTasks = readActiveTasks(taskDir);
+          const taskMap = buildTaskMapWithBlockers(taskDir, allTasks);
           const now = Date.now();
 
           const reclaimExpired = () => {
@@ -43,6 +50,7 @@ export function createTaskClaimNextTool(ctx?: PluginInput, listId?: string): Too
                   delete task.metadata.claimed_by_session;
                 }
                 writeJsonAtomic(join(taskDir, `${task.id}.json`), TaskSchema.parse(task));
+                upsertIndexEntry(indexPathFor(taskDir), { id: task.id, status: task.status });
               }
             }
           };
@@ -97,6 +105,10 @@ export function createTaskClaimNextTool(ctx?: PluginInput, listId?: string): Too
 
           validatedTask = TaskSchema.parse(target);
           writeJsonAtomic(join(taskDir, `${validatedTask.id}.json`), validatedTask);
+          upsertIndexEntry(indexPathFor(taskDir), {
+            id: validatedTask.id,
+            status: validatedTask.status,
+          });
 
           return JSON.stringify({ task: validatedTask });
         };

--- a/packages/opencode-plugin/src/tools/task/task-create.ts
+++ b/packages/opencode-plugin/src/tools/task/task-create.ts
@@ -3,6 +3,7 @@ import type { PluginInput, ToolDefinition } from "@opencode-ai/plugin";
 import { tool } from "@opencode-ai/plugin";
 import { detectCycle } from "./graph";
 import { acquireLock, generateTaskId, getTaskDir, readJsonSafe, writeJsonAtomic } from "./storage";
+import { indexPathFor, upsertIndexEntry } from "./task-index";
 import { readAllTasks } from "./task-list";
 import { syncTaskTodoUpdate } from "./todo-sync";
 import { type Task, TaskCreateInputSchema, TaskSchema } from "./types";
@@ -25,7 +26,7 @@ export function createTaskCreateTool(ctx?: PluginInput, listId?: string): ToolDe
       metadata: z.record(z.string(), z.unknown()).optional().describe("Task metadata"),
       parentID: z.string().optional().describe("Parent task ID for grouping"),
     },
-    execute: async (args, context) => {
+    execute: async (args, context): Promise<string> => {
       try {
         const validated = TaskCreateInputSchema.parse(args);
         const taskDir = getTaskDir(listId);
@@ -117,6 +118,10 @@ export function createTaskCreateTool(ctx?: PluginInput, listId?: string): ToolDe
 
             validatedTask = TaskSchema.parse(task);
             writeJsonAtomic(join(taskDir, `${taskId}.json`), validatedTask);
+            upsertIndexEntry(indexPathFor(taskDir), {
+              id: validatedTask.id,
+              status: validatedTask.status,
+            });
 
             for (const blockedId of proposedBlocks) {
               const blockedPath = join(taskDir, `${blockedId}.json`);
@@ -146,7 +151,7 @@ export function createTaskCreateTool(ctx?: PluginInput, listId?: string): ToolDe
         }
         return result;
       } catch (error) {
-        if (error instanceof Error && error.message.includes("Required")) {
+        if (error instanceof Error && error.name === "ZodError") {
           return JSON.stringify({ error: "validation_error", message: error.message });
         }
         return JSON.stringify({ error: "internal_error" });

--- a/packages/opencode-plugin/src/tools/task/task-index.ts
+++ b/packages/opencode-plugin/src/tools/task/task-index.ts
@@ -1,0 +1,63 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { readJsonSafe, writeJsonAtomic } from "./storage";
+import {
+  type TaskIndex,
+  type TaskIndexEntry,
+  TaskIndexEntrySchema,
+  TaskIndexSchema,
+  TaskSchema,
+} from "./types";
+
+export const INDEX_FILENAME = "active-index.json";
+
+export function indexPathFor(taskDir: string): string {
+  return join(taskDir, INDEX_FILENAME);
+}
+
+export function readTaskIndex(indexPath: string): TaskIndex | null {
+  try {
+    const parsed = JSON.parse(readFileSync(indexPath, "utf-8"));
+    const result = TaskIndexSchema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Rebuild the active index by scanning T-*.json files on disk.
+ * Called when the index is missing or corrupt to prevent hiding existing tasks.
+ */
+function rebuildIndexFromDisk(taskDir: string): TaskIndex {
+  const entries: TaskIndexEntry[] = [];
+  try {
+    const files = readdirSync(taskDir).filter((f) => f.endsWith(".json") && f.startsWith("T-"));
+    for (const file of files) {
+      const task = readJsonSafe(join(taskDir, file), TaskSchema);
+      if (task && (task.status === "pending" || task.status === "in_progress")) {
+        entries.push({ id: task.id, status: task.status });
+      }
+    }
+  } catch {
+    // Directory unreadable — return empty index, readActiveTasks will
+    // fall back to listTaskFiles which handles this same error
+  }
+  return { version: 1, entries };
+}
+
+export function writeTaskIndexAtomic(indexPath: string, data: TaskIndex): void {
+  writeJsonAtomic(indexPath, data);
+}
+
+export function upsertIndexEntry(indexPath: string, entry: TaskIndexEntry): void {
+  const validated = TaskIndexEntrySchema.parse(entry);
+  const index = readTaskIndex(indexPath) ?? rebuildIndexFromDisk(dirname(indexPath));
+  const entries = index.entries.filter((e) => e.id !== validated.id);
+
+  if (validated.status === "pending" || validated.status === "in_progress") {
+    entries.push(validated);
+  }
+
+  writeTaskIndexAtomic(indexPath, { version: 1, entries });
+}

--- a/packages/opencode-plugin/src/tools/task/task-list.ts
+++ b/packages/opencode-plugin/src/tools/task/task-list.ts
@@ -2,20 +2,61 @@ import { join } from "node:path";
 import type { ToolDefinition } from "@opencode-ai/plugin";
 import { tool } from "@opencode-ai/plugin";
 import { getTaskDir, listTaskFiles, readJsonSafe } from "./storage";
+import { indexPathFor, readTaskIndex } from "./task-index";
 import { SATISFYING_STATUSES, type Task, TaskSchema, type TaskStatus } from "./types";
 
 const z = tool.schema;
 
-export function readAllTasks(taskDir: string): Task[] {
-  const fileIds = listTaskFiles(taskDir);
+function readTasksFiltered(
+  taskDir: string,
+  filter: (task: Task) => boolean = () => true,
+  useIndex: boolean = false
+): Task[] {
+  const index = useIndex ? readTaskIndex(indexPathFor(taskDir)) : null;
+  const fileIds = index ? [...new Set(index.entries.map((e) => e.id))] : listTaskFiles(taskDir);
   const tasks: Task[] = [];
   for (const fileId of fileIds) {
     const task = readJsonSafe(join(taskDir, `${fileId}.json`), TaskSchema);
-    if (task) {
+    if (task && filter(task)) {
       tasks.push(task);
     }
   }
   return tasks;
+}
+
+export function readActiveTasks(taskDir: string): Task[] {
+  return readTasksFiltered(
+    taskDir,
+    (t) => t.status !== "completed" && t.status !== "cancelled",
+    true
+  );
+}
+
+/** Full disk scan — used by create/update for cycle detection (needs ALL tasks). */
+export function readAllTasks(taskDir: string): Task[] {
+  return readTasksFiltered(taskDir);
+}
+
+export function buildTaskMapWithBlockers(taskDir: string, activeTasks: Task[]): Map<string, Task> {
+  const taskMap = new Map(activeTasks.map((t) => [t.id, t]));
+
+  const missingBlockerIds = new Set<string>();
+  for (const task of activeTasks) {
+    for (const blockerId of task.blockedBy) {
+      if (!taskMap.has(blockerId)) {
+        missingBlockerIds.add(blockerId);
+      }
+    }
+  }
+
+  for (const blockerId of missingBlockerIds) {
+    const blocker = readJsonSafe(join(taskDir, `${blockerId}.json`), TaskSchema);
+    if (blocker) {
+      taskMap.set(blocker.id, blocker);
+    }
+  }
+
+  return taskMap;
 }
 
 interface TaskSummary {
@@ -37,22 +78,18 @@ export function createTaskListTool(listId?: string): ToolDefinition {
       ready: z.boolean().optional().describe("Filter to tasks with all dependencies satisfied"),
       parentID: z.string().optional().describe("Filter by parent task ID"),
     },
-    execute: async (args) => {
+    execute: async (args): Promise<string> => {
       const typedArgs = args as { ready?: boolean; parentID?: string };
       const taskDir = getTaskDir(listId);
-      const allTasks = readAllTasks(taskDir);
+      const activeTasks = readActiveTasks(taskDir);
 
-      let activeTasks = allTasks.filter(
-        (task) => task.status !== "completed" && task.status !== "cancelled"
-      );
+      const filtered = typedArgs.parentID
+        ? activeTasks.filter((task) => task.parentID === typedArgs.parentID)
+        : activeTasks;
 
-      if (typedArgs.parentID) {
-        activeTasks = activeTasks.filter((task) => task.parentID === typedArgs.parentID);
-      }
+      const taskMap = buildTaskMapWithBlockers(taskDir, activeTasks);
 
-      const taskMap = new Map(allTasks.map((t) => [t.id, t]));
-
-      const summaries: TaskSummary[] = activeTasks.map((task) => {
+      const summaries: TaskSummary[] = filtered.map((task) => {
         const unresolvedBlockers = task.blockedBy.filter((blockerId) => {
           const blocker = taskMap.get(blockerId);
           return !blocker || !SATISFYING_STATUSES.has(blocker.status);
@@ -68,11 +105,11 @@ export function createTaskListTool(listId?: string): ToolDefinition {
         };
       });
 
-      const filtered = typedArgs.ready
+      const result = typedArgs.ready
         ? summaries.filter((s) => s.blockedBy.length === 0)
         : summaries;
 
-      return JSON.stringify({ tasks: filtered });
+      return JSON.stringify({ tasks: result });
     },
   });
 }

--- a/packages/opencode-plugin/src/tools/task/task-update.ts
+++ b/packages/opencode-plugin/src/tools/task/task-update.ts
@@ -3,9 +3,10 @@ import type { PluginInput, ToolDefinition } from "@opencode-ai/plugin";
 import { tool } from "@opencode-ai/plugin";
 import { detectCycle } from "./graph";
 import { acquireLock, getTaskDir, readJsonSafe, writeJsonAtomic } from "./storage";
+import { indexPathFor, upsertIndexEntry } from "./task-index";
 import { readAllTasks } from "./task-list";
 import { syncTaskTodoUpdate } from "./todo-sync";
-import { TaskSchema, TaskUpdateInputSchema } from "./types";
+import { type Task, TaskSchema, TaskUpdateInputSchema } from "./types";
 
 const z = tool.schema;
 
@@ -39,7 +40,7 @@ export function createTaskUpdateTool(ctx?: PluginInput, listId?: string): ToolDe
         .describe("Metadata to merge (null values delete keys)"),
       parentID: z.string().optional().describe("Parent task ID"),
     },
-    execute: async (args, context) => {
+    execute: async (args, context): Promise<string> => {
       try {
         const validated = TaskUpdateInputSchema.parse(args);
 
@@ -55,7 +56,7 @@ export function createTaskUpdateTool(ctx?: PluginInput, listId?: string): ToolDe
         }
 
         let result: string;
-        let validatedTask: ReturnType<typeof TaskSchema.parse> | null = null;
+        let validatedTask: Task | null = null;
         try {
           const computeResult = () => {
             const taskPath = join(taskDir, `${validated.id}.json`);
@@ -152,6 +153,10 @@ export function createTaskUpdateTool(ctx?: PluginInput, listId?: string): ToolDe
 
             validatedTask = TaskSchema.parse(task);
             writeJsonAtomic(taskPath, validatedTask);
+            upsertIndexEntry(indexPathFor(taskDir), {
+              id: validatedTask.id,
+              status: validatedTask.status,
+            });
 
             if (addBlocks && addBlocks.length > 0) {
               for (const blockedId of addBlocks) {
@@ -180,7 +185,7 @@ export function createTaskUpdateTool(ctx?: PluginInput, listId?: string): ToolDe
         }
         return result;
       } catch (error) {
-        if (error instanceof Error && error.message.includes("Required")) {
+        if (error instanceof Error && error.name === "ZodError") {
           return JSON.stringify({ error: "validation_error", message: error.message });
         }
         return JSON.stringify({ error: "internal_error" });

--- a/packages/opencode-plugin/src/tools/task/types.ts
+++ b/packages/opencode-plugin/src/tools/task/types.ts
@@ -20,9 +20,11 @@ export const TaskSchema = z
 
 export type Task = z.infer<typeof TaskSchema>;
 
+export const MAX_DESCRIPTION_CHARS = 2_000;
+
 export const TaskCreateInputSchema = z.object({
   subject: z.string(),
-  description: z.string().optional(),
+  description: z.string().max(MAX_DESCRIPTION_CHARS).optional(),
   blocks: z.array(z.string()).optional(),
   blockedBy: z.array(z.string()).optional(),
   owner: z.string().optional(),
@@ -41,7 +43,7 @@ export type TaskGetInput = z.infer<typeof TaskGetInputSchema>;
 export const TaskUpdateInputSchema = z.object({
   id: z.string(),
   subject: z.string().optional(),
-  description: z.string().optional(),
+  description: z.string().max(MAX_DESCRIPTION_CHARS).optional(),
   status: TaskStatusSchema.optional(),
   addBlocks: z.array(z.string()).optional(),
   addBlockedBy: z.array(z.string()).optional(),
@@ -68,3 +70,17 @@ export const MAX_CLAIM_ATTEMPTS = 3;
 
 /** Default lease duration in milliseconds (5 minutes). */
 export const LEASE_DURATION_MS = 5 * 60 * 1000;
+
+export const TaskIndexEntrySchema = z.object({
+  id: z.string(),
+  status: TaskStatusSchema,
+});
+
+export type TaskIndexEntry = z.infer<typeof TaskIndexEntrySchema>;
+
+export const TaskIndexSchema = z.object({
+  version: z.literal(1),
+  entries: z.array(TaskIndexEntrySchema).default([]),
+});
+
+export type TaskIndex = z.infer<typeof TaskIndexSchema>;


### PR DESCRIPTION
## Summary

- Add `active-index.json` that tracks `pending`/`in_progress` task IDs so list and claim skip reading completed/cancelled files
- Integrate index updates into task create/update/claim write paths (inside locks, after file writes)
- Add `readActiveTasks` + `buildTaskMapWithBlockers` for index-aware hot paths with on-demand blocker resolution
- Add description size guardrail (`MAX_DESCRIPTION_CHARS = 2_000`) in create and update
- Export new symbols from task module barrel

## Details

**Problem:** `readAllTasks` does a full directory scan on every list/claim call, reading every task file including completed/cancelled ones.

**Solution:** A compact `active-index.json` file tracks only active task IDs. The list and claim hot paths read only those files, with individual blocker files read on demand for dependency resolution. Falls back to full scan when no index exists.

**New files:**
- `task-index.ts` — `readTaskIndex`, `writeTaskIndexAtomic`, `upsertIndexEntry`, `indexPathFor`

**Modified files:**
- `task-list.ts` — `readActiveTasks` (new), `readAllTasks` (preserved for cycle detection), `buildTaskMapWithBlockers` (new)
- `task-claim.ts` — uses index-aware path
- `task-create.ts` / `task-update.ts` — index upserts + description guardrail
- `types.ts` — `TaskIndexSchema`, `TaskIndexEntrySchema`, `MAX_DESCRIPTION_CHARS`

**Tests:** 119 tests pass (9 new), TypeScript clean, Biome clean.