### PR TITLE
fix: use teams list query for team key resolution

### DIFF
--- a/packages/daemon/src/cli/__tests__/team-resolver.test.ts
+++ b/packages/daemon/src/cli/__tests__/team-resolver.test.ts
@@ -93,15 +93,15 @@ describe("resolveTeamId", () => {
     const mockFetch = mock(async (url: string, options?: RequestInit) => {
       expect(url).toBe("https://api.linear.app/graphql");
       expect(options?.method).toBe("POST");
-      const body = JSON.parse(options?.body as string);
-      expect(body.variables.key).toBe("LEG");
 
       return new Response(
         JSON.stringify({
           data: {
-            team: {
-              id: "fetched-uuid-1234",
-              name: "Legion Team",
+            teams: {
+              nodes: [
+                { id: "fetched-uuid-1234", key: "LEG", name: "Legion Team" },
+                { id: "other-uuid", key: "ENG", name: "Engineering" },
+              ],
             },
           },
         }),
@@ -114,22 +114,31 @@ describe("resolveTeamId", () => {
     const result = await resolveTeamId("LEG", testCacheDir);
     expect(result).toBe("fetched-uuid-1234");
     expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Verify cache was written
+    const cached = JSON.parse(fs.readFileSync(testCacheFile, "utf-8"));
+    expect(cached.LEG.id).toBe("fetched-uuid-1234");
+    expect(cached.ENG.id).toBe("other-uuid");
   });
 
-  test("throws error when API returns no team", async () => {
+  test("throws error when API returns no matching team", async () => {
     process.env.LINEAR_API_KEY = "test-api-key";
 
     globalThis.fetch = mock(async () => {
       return new Response(
         JSON.stringify({
-          data: {},
+          data: {
+            teams: {
+              nodes: [{ id: "some-uuid", key: "ENG", name: "Engineering" }],
+            },
+          },
         }),
         { status: 200 }
       );
     }) as any;
 
     await expect(resolveTeamId("NOTFOUND", testCacheDir)).rejects.toThrow(
-      "Team 'NOTFOUND' not found in Linear"
+      "Team 'NOTFOUND' not found. Available: ENG"
     );
   });
 

--- a/packages/daemon/src/cli/team-resolver.ts
+++ b/packages/daemon/src/cli/team-resolver.ts
@@ -42,7 +42,7 @@ export async function resolveTeamId(teamRef: string, cacheDir?: string): Promise
 
   const apiKey = process.env.LINEAR_API_KEY;
   if (apiKey) {
-    return await lookupTeamViaApi(teamRef, apiKey);
+    return await lookupTeamViaApi(teamRef, apiKey, resolvedCacheDir);
   }
 
   throw new Error(
@@ -54,20 +54,12 @@ export async function resolveTeamId(teamRef: string, cacheDir?: string): Promise
 /**
  * Look up team via Linear GraphQL API.
  */
-async function lookupTeamViaApi(teamRef: string, apiKey: string): Promise<string> {
-  const query = `
-    query GetTeam($key: String!) {
-      team(key: $key) {
-        id
-        name
-      }
-    }
-  `;
-
-  const payload = JSON.stringify({
-    query,
-    variables: { key: teamRef.toUpperCase() },
-  });
+async function lookupTeamViaApi(
+  teamRef: string,
+  apiKey: string,
+  cacheDir?: string
+): Promise<string> {
+  const query = `{ teams { nodes { id key name } } }`;
 
   try {
     const response = await fetch("https://api.linear.app/graphql", {
@@ -76,8 +68,8 @@ async function lookupTeamViaApi(teamRef: string, apiKey: string): Promise<string
         "Content-Type": "application/json",
         Authorization: apiKey,
       },
-      body: payload,
-      signal: AbortSignal.timeout(15_000), // 15s for external API
+      body: JSON.stringify({ query }),
+      signal: AbortSignal.timeout(15_000),
     });
 
     if (!response.ok) {
@@ -85,12 +77,28 @@ async function lookupTeamViaApi(teamRef: string, apiKey: string): Promise<string
     }
 
     const data = (await response.json()) as {
-      data?: { team?: { id: string; name: string } };
+      data?: { teams?: { nodes: Array<{ id: string; key: string; name: string }> } };
     };
-    const team = data?.data?.team;
+    const nodes = data?.data?.teams?.nodes;
+    if (!nodes) {
+      throw new Error("Unexpected Linear API response");
+    }
 
+    // Cache all teams for future lookups
+    const resolvedCacheDir = cacheDir ?? path.join(os.homedir(), ".legion");
+    fs.mkdirSync(resolvedCacheDir, { recursive: true });
+    const cache: TeamsCache = {};
+    for (const node of nodes) {
+      cache[node.key] = { id: node.id, name: node.name };
+    }
+    fs.writeFileSync(path.join(resolvedCacheDir, "teams.json"), JSON.stringify(cache, null, 2));
+
+    const keyUpper = teamRef.toUpperCase();
+    const team = nodes.find((n) => n.key === keyUpper);
     if (!team) {
-      throw new Error(`Team '${teamRef}' not found in Linear`);
+      throw new Error(
+        `Team '${teamRef}' not found. Available: ${nodes.map((n) => n.key).join(", ")}`
+      );
     }
 
     console.log(`Resolved: ${teamRef} → ${team.name} (${team.id})`);


### PR DESCRIPTION
## Summary
- The `team(key:)` GraphQL field doesn't exist in the Linear API, causing 400 errors when resolving team keys like `PLT`
- Switch to querying `teams { nodes { id key name } }` and filtering by key
- Cache all teams to `~/.legion/teams.json` on successful API lookup

## Test plan
- [x] All 245 tests pass
- [x] Manually verified `legion start PLT` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)