### PR TITLE
refine legion skills: CI ownership, triage ambition, operational guardrails

### DIFF
--- a/.opencode/skills/legion-controller/SKILL.md
+++ b/.opencode/skills/legion-controller/SKILL.md
@@ -136,56 +136,50 @@ GitHub API connectivity.
 ### Implement → Review Handoff
 
 The implementer does **not** use `worker-done`. Instead:
-1. Implementer opens a **draft PR** and exits
+1. Implementer opens a **draft PR**, verifies CI passes, and exits
 2. The issue transitions to Needs Review (Linear auto-transition, or controller transitions explicitly for GitHub)
 3. State machine sees: Needs Review, no `worker-done`, no live worker → `dispatch_reviewer`
-4. Controller runs the quality gate (below), then dispatches the reviewer
-
-### Quality Gate (Controller Policy)
-
-Before dispatching a reviewer, the controller independently verifies code quality. This is a controller-level policy, not signaled by the state machine.
-
-**When to run:** Whenever about to execute a `dispatch_reviewer` action.
-
-**Trust but verify:** The implement workflow self-enforces checks before PR (step 4). The controller independently verifies.
-
+4. Controller dispatches the reviewer
+**Before dispatching reviewer, verify CI is passing:**
 ```bash
-WORKSPACES_DIR=$(dirname "$LEGION_DIR")
-ISSUE_LOWER=$(echo "$ISSUE_IDENTIFIER" | tr '[:upper:]' '[:lower:]')
-WORKSPACE_PATH="$WORKSPACES_DIR/$ISSUE_LOWER"
-
-cd "$WORKSPACE_PATH"
-bun test 2>&1
-TST_EXIT=$?
-bunx tsc --noEmit 2>&1
-TSC_EXIT=$?
-bunx biome check 2>&1
-BIOME_EXIT=$?
+gh pr checks "$LEGION_ISSUE_ID"
+```
+If any checks are failing, do NOT dispatch the reviewer. Instead:
+1. Move issue back to In Progress
+2. Re-dispatch an implementer with the CI failure output:
+```bash
+legion dispatch "$ISSUE_IDENTIFIER" implement \
+  --prompt "Invoke the /legion-worker skill for implement mode. CI is failing: [paste failure summary]. Fix and push. ($BACKEND_SUFFIX)"
 ```
 
-**If all pass** (exit codes 0): Proceed with dispatching the reviewer.
-
-**If any fail:** Do NOT dispatch reviewer. Instead:
-1. Move issue back to In Progress
-2. Dispatch a fresh implementer with the failure output
-3. The implementer will fix, re-open/update the PR, and exit — issue transitions back to Needs Review
+**CI is the implementer's responsibility.** The implement workflow requires passing CI before
+signaling completion. If CI is failing when the controller sees a PR, the implementer didn't
+finish — re-dispatch an implementer with the CI failure output. The reviewer should also check
+CI status and include it in the review.
 
 ### 4. Route Triage
+
+**Be ambitious. Prioritize user value. Keep work moving.**
+
+No issue is "too big" for Legion — that's what the architect phase is for. Large or complex
+issues go to Backlog where the architect breaks them down. Only route to Icebox if the issue
+is genuinely unclear (missing context, ambiguous requirements, needs user clarification).
 
 Controller routes Triage issues directly (no worker needed):
 
 | Assessment | Route To |
 |------------|----------|
 | Urgent AND clear requirements | Todo (dispatch planner) |
-| Clear but not urgent | Backlog |
-| Vague OR large OR needs breakdown | Icebox |
+| Clear requirements, any size | Backlog (architect breaks down if large) |
+| Ambiguous or missing context | Icebox (needs clarification) |
 
 ### 5. Pull from Icebox
 
 **If active workers < 10:**
-1. Get oldest Icebox item (FIFO)
-2. Move to Backlog
-3. Dispatch architect
+1. Check for Icebox items that have been clarified: look for `user-feedback-given` label OR new comments added since the issue was moved to Icebox
+2. If no clarified items exist, skip — leave Icebox items until users respond
+3. Move the oldest clarified item to Backlog
+4. Dispatch architect
 
 ### 6. Cleanup Done
 
@@ -241,17 +235,21 @@ from the issue identifier:
 
 ### Dispatch (New Worker)
 
+**Always use skill invocation (`/skill-name`), not file paths.** Workers load skills via the
+skill system. Pointing them at file paths bypasses skill loading and risks the worker not
+getting the full skill content.
+
 ```bash
 # GitHub example:
 legion dispatch "$ISSUE_IDENTIFIER" "$MODE" \
-  --prompt "/legion-worker $MODE mode for $ISSUE_IDENTIFIER (github backend, repo: $OWNER/$REPO)"
+  --prompt "Invoke the /legion-worker skill for $MODE mode for $ISSUE_IDENTIFIER (github backend, repo: $OWNER/$REPO)"
 
 # Linear example:
 legion dispatch "$ISSUE_IDENTIFIER" "$MODE" \
-  --prompt "/legion-worker $MODE mode for $ISSUE_IDENTIFIER (linear backend)"
+  --prompt "Invoke the /legion-worker skill for $MODE mode for $ISSUE_IDENTIFIER (linear backend)"
 ```
 
-The `dispatch` command handles: workspace creation (jj workspace add), daemon API call (POST /workers), initial prompt (/legion-worker), and prints worker info.
+The `dispatch` command handles: workspace creation (jj workspace add), daemon API call (POST /workers), initial prompt, and prints worker info.
 
 For custom prompts, still include the backend suffix:
 ```bash
@@ -264,15 +262,11 @@ legion dispatch "$ISSUE_IDENTIFIER" "$MODE" \
 ```bash
 # User feedback relay (GitHub):
 legion prompt "$ISSUE_IDENTIFIER" \
-  "Check issue comments for user feedback (github backend, repo: $OWNER/$REPO)"
+  "Invoke the /legion-worker skill. Check issue comments for user feedback. (github backend, repo: $OWNER/$REPO)"
 
-# User feedback relay (Linear):
-legion prompt "$ISSUE_IDENTIFIER" \
-  "Check issue comments for user feedback (linear backend)"
-
-# PR changes requested (GitHub):
+# PR changes requested — tell them to invoke the skill, not give step-by-step fix instructions:
 legion prompt "$ISSUE_IDENTIFIER" --mode implement \
-  "Address PR review comments (github backend, repo: $OWNER/$REPO)"
+  "Invoke the /legion-worker skill for implement mode. CI is failing on your PR — check the failures and fix. (github backend, repo: $OWNER/$REPO)"
 ```
 
 If multiple workers exist for the same issue (different modes), specify mode with `--mode`.
@@ -283,14 +277,16 @@ Use resume for: user feedback relay, PR changes requested, retro after review ap
 
 Retro is triggered by resuming the **implement worker's existing session** — this preserves the implementer's full context. The retro skill handles spawning a fresh subagent for an outside perspective.
 
+**Use skill invocation for retro too:**
+
 ```bash
 # GitHub:
 legion prompt "$ISSUE_IDENTIFIER" --mode implement \
-  "/legion-retro (github backend, repo: $OWNER/$REPO)"
+  "Invoke the /legion-retro skill. (github backend, repo: $OWNER/$REPO)"
 
 # Linear:
 legion prompt "$ISSUE_IDENTIFIER" --mode implement \
-  "/legion-retro (linear backend)"
+  "Invoke the /legion-retro skill. (linear backend)"
 ```
 
 **If the implement worker died** (action `dispatch_implementer_for_retro`), a fresh worker is dispatched in `implement` mode. This loses the implementer's perspective — both retro analyses will be from a fresh viewpoint.
@@ -309,6 +305,27 @@ curl -s http://127.0.0.1:$LEGION_DAEMON_PORT/workers/$WORKER_ID/status | jq '.'
 
 The state machine reports `hasLiveWorker`, `workerMode`, and `workerStatus` for each issue.
 Use these signals — don't independently verify worker liveness.
+
+### Forcing a Fresh Session
+
+Session IDs are **deterministic** — `computeSessionId(teamId, issueId, mode)` uses UUID v5.
+Same inputs always produce the same session ID. If the serve still has that session in
+memory, re-dispatching with the same issue ID and mode re-attaches to the existing session
+(the serve returns 409 DuplicateIDError, which the daemon treats as "reuse").
+
+This is normally desirable — it's how workers resume across prompts. If you genuinely
+need a fresh session, the daemon will need a session version incrementer (planned).
+
+### Don't Delete a Workspace While Workers May Resume
+
+**A worker whose workspace has been deleted cannot respond to prompts.** Every tool call
+fails because the working directory no longer exists. The session appears "busy" but
+produces no output — it looks like the worker is stalled, but the root cause is the
+missing workspace.
+
+This applies to both active workers AND idle workers you might want to resume later
+(e.g., for retro). Only delete workspaces during Cleanup Done (step 6) — after the
+issue is fully complete and no further prompts will be sent.
 
 ## Observability Rules
 
@@ -357,9 +374,12 @@ If you catch yourself thinking any of these, STOP. You're about to make a mistak
 | "Let me construct the JSON for the state machine" | POST tracker output to `/state/collect` directly — no hand-crafting |
 | "I know the label/status from last iteration" | Fetch fresh from the tracker. State goes stale between iterations. |
 | "The changes are lost" | Check local commits (`jj log`), open PRs (`gh pr list`), and worker workspaces before concluding anything is lost |
-| "I'll give the worker specific instructions" | State the mode, issue ID, and backend. Let the workflow guide the worker. |
+| "I'll give the worker specific instructions" | State the mode, issue ID, and backend. Invoke the skill. Let the workflow guide the worker. |
 | "Let me check the worker's port directly" | Use the daemon API (`/workers`, `/workers/:id/status`). The state machine reports liveness. |
 | "I'll accumulate these changes into the existing PR" | One issue = one workspace = one branch = one PR. |
+| "This issue is too big/complex" | No issue is too big. That's what the architect phase is for. Route to Backlog. |
+| "The worker is busy, I'll wait" | Check the transcript. If the worker received prompts but produced no response, the workspace may have been deleted. A worker cannot function without its workspace. |
+| "CI can be fixed later" | CI is the implementer's responsibility. If CI is failing, the implementer isn't done — re-dispatch. |
 
 ## Common Mistakes
 
@@ -370,8 +390,11 @@ If you catch yourself thinking any of these, STOP. You're about to make a mistak
 | Plan Triage items directly | Route first (to Icebox/Backlog/Todo), then workers act |
 | Exit after processing all issues | **Never exit** - loop forever with 30s sleep |
 | Process issue with live worker | Skip it - worker is already handling |
-| Give workers step-by-step fix instructions | State the mode, issue ID, and backend only. Let the workflow guide the worker. |
-| Forget to remove `worker-done` after processing | Always remove `worker-done` label after acting on it. Otherwise the state machine re-triggers on the next loop. |
+| Give workers step-by-step fix instructions | Invoke the skill. State the mode, issue ID, and backend only. |
+| Forget to remove `worker-done` after processing | Always remove `worker-done` label after acting on it. |
+| Classify issues as "too big" | Route to Backlog for architect breakdown. No issue is too big for Legion. |
+| Advance pipeline with CI failing | Re-dispatch implementer with CI failure output. Don't dispatch reviewer until CI passes. |
+| Delete a workspace to "reset" a worker | **Never delete a workspace while the worker might be resumed.** A deleted workspace silently kills the worker — prompts arrive but every tool call fails. Only delete during Cleanup Done. |
 
 ## Status Flow
 

--- a/.opencode/skills/legion-retro/SKILL.md
+++ b/.opencode/skills/legion-retro/SKILL.md
@@ -17,16 +17,33 @@ A fresh subagent provides the outside perspective (see step 2).
 
 - **NO rebasing** - unlike other workflows, do not rebase before starting
 - **Two perspectives** - fresh subagent (context-free) + you (full context)
+- **Skip if nothing learned** - small mechanical changes (find-and-replace, formatting fixes, dependency bumps) with no real learnings don't need docs. Post a brief "no significant learnings" comment on the issue and signal completion.
 
 ## Workflow
 
-### 1. Get PR URL
+### 1. Assess Whether a Retro Doc is Warranted
+
+Not every PR needs documentation. Ask:
+- Did anything surprising happen during implementation?
+- Were there decisions that aren't obvious from the code?
+- Did patterns emerge that would help future work?
+- Were there gotchas that someone else would hit?
+
+If the answer to all of these is no, skip to step 6 (post a brief summary comment) and step 7 (signal completion).
+
+**If skipping (no significant learnings), use this brief comment template for step 6:**
+```bash
+gh issue comment $ISSUE_NUMBER --body "## Retro Complete
+
+No significant learnings — mechanical change (find-and-replace / formatting / dependency bump)." -R $OWNER/$REPO
+```
+For Linear, use `linear_linear(action="comment", ...)` with the same body.
+
+### 2. Get PR URL and Launch Background Subagent
 
 ```bash
 PR_URL=$(gh pr view "$LEGION_ISSUE_ID" --json url --jq '.url')
 ```
-
-### 2. Launch Background Subagent (Parallel)
 
 Use `background_task` tool to spawn a fresh subagent:
 
@@ -40,39 +57,61 @@ Use `background_task` tool to spawn a fresh subagent:
 > PR: $PR_URL
 >
 > 1. Fetch the PR diff and description via gh pr view and gh pr diff
-> 2. Invoke /compound-engineering/workflows/compound to document learnings
-> 3. Write output to docs/solutions/ in the current directory
+> 2. Analyze: what patterns emerged, what was hard, what would help future implementations
+> 3. Return your analysis as structured output (don't write files)
 >
 > Focus on patterns that would help future implementations.
 
-### 3. Do Your Own Compound (In Parallel)
+### 3. Do Your Own Analysis (In Parallel)
 
-While the subagent runs in background, invoke `/compound-engineering/workflows/compound` yourself.
-
-You have full implementation context - capture:
+While the subagent runs, capture your own perspective:
 - What was hard
 - What you would do differently
 - What patterns emerged
 - Decisions that weren't obvious from the code
 
-Write to `docs/solutions/`.
+### 4. Integrate Both Perspectives
 
-### 4. Wait for Subagent
+When the subagent completes, review its suggestions alongside your own analysis.
 
-Check subagent completion before proceeding (you will be notified when background task completes).
+**You are the integrator.** The subagent provides an outside view, but you have the
+implementation context. Push back on suggestions that miss context, and incorporate
+the ones that add genuine value.
+
+Write the integrated learnings to `docs/solutions/`. Optimize for **discoverability**:
+- Organize by topic, not by PR — a future agent should find these via YAML frontmatter
+- If there are learnings about different parts of the system (e.g., one about Docker and
+  one about Python testing), write separate docs so each can be found independently
+- If all learnings are about one topic, write one doc
+- Don't write multiple docs just because there are multiple bullet points
 
 ### 5. Commit and Push Learnings
 
-Ensure all `docs/solutions/` files are committed and pushed:
+Push to the **existing PR branch** — do NOT create a new branch or bookmark.
+The implementer already created the branch when opening the PR.
 
 ```bash
 jj describe -m "$LEGION_ISSUE_ID: retro learnings"
-jj git push
+jj git push  # Pushes to the existing tracked branch
 ```
+
+**If jj says there's no tracked branch:** The implementer should have created this branch.
+Verify whether the bookmark exists:
+```bash
+jj bookmark list  # Should see a bookmark matching $LEGION_ISSUE_ID
+```
+- **If the bookmark exists:** move it to the current change and push:
+  ```bash
+  jj bookmark set "$LEGION_ISSUE_ID" -r @
+  jj git push
+  ```
+- **If the bookmark does NOT exist:** something went wrong — the implementer should have
+  created it. Do not create a new branch. Instead, post a comment on the issue noting the
+  missing branch and add `user-input-needed`, then exit.
 
 ### 6. Post Summary to Issue
 
-Post a brief summary to the issue so learnings are discoverable without checking the repo:
+Post a brief summary so learnings are discoverable without checking the repo:
 
 **GitHub:**
 
@@ -104,3 +143,7 @@ Add `worker-done` label to the issue, then exit:
 
 - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "worker-done" -R $OWNER/$REPO`
 - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current + "worker-done"])`
+
+Then remove `worker-active`:
+- **GitHub:** `gh issue edit $ISSUE_NUMBER --remove-label "worker-active" -R $OWNER/$REPO`
+- **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current labels without "worker-active"])`

--- a/.opencode/skills/legion-worker/SKILL.md
+++ b/.opencode/skills/legion-worker/SKILL.md
@@ -27,8 +27,13 @@ Use the **backend** from your prompt to choose GitHub CLI or Linear MCP commands
    - **GitHub:** `gh issue view $ISSUE_NUMBER --json title,body,labels,comments,state -R $OWNER/$REPO`
    - **Linear:** `linear_linear(action="get", id="$LEGION_ISSUE_ID")`
 2. **Use jj, not git** - changes auto-tracked (see jj safety rules below)
-3. **Signal completion** - add `worker-done` label when done (see routing table)
-4. **Clean up on exit** - remove `worker-active` label when exiting (done or blocked)
+3. **Only the implementer creates branches** - the implement workflow creates the branch and
+   opens the PR. Reviewers, retro, and closers push to the existing branch. Never create new
+   branches or bookmarks in review, retro, or merge workflows.
+   **Exception:** The retro workflow has a recovery fallback for when the tracked branch is
+   lost — it may re-create the bookmark in that narrow case. See the retro SKILL.md for details.
+4. **Signal completion** - add `worker-done` label when done (see routing table)
+5. **Clean up on exit** - remove `worker-active` label when exiting (done or blocked)
 
 ## Skill Discipline
 

--- a/.opencode/skills/legion-worker/resources/strategies/cleanup-deletion.md
+++ b/.opencode/skills/legion-worker/resources/strategies/cleanup-deletion.md
@@ -1,0 +1,22 @@
+# Strategy: Cleanup & Deletion PRs
+
+When deleting deprecated code, stale docs, or consolidating references.
+
+## When deleting a CLI command, check all four:
+
+1. Implementation file(s)
+2. `package.json` / `pyproject.toml` script entry
+3. All project documentation references (AGENTS.md or equivalent — check command tables AND section headings)
+4. Wrapper scripts or CI jobs that invoke it
+
+## project doc headings are documentation too
+
+When updating a command reference, grep for the section heading and update it in the same commit. Headings that reference specific paths (`## Foo (meta/bar/)`) go stale when paths change.
+
+## Deletion PRs should be almost entirely deletions
+
+Resist opportunistic refactors. If the diff has significant additions, the scope has crept. The value of a cleanup PR is its tight, reviewable scope.
+
+## Complete the deletion chain
+
+If a feature has implementation + CLI wrapper + package.json entry + docs, remove all of them together. Partial deletion leaves broken references.

--- a/.opencode/skills/legion-worker/resources/strategies/systematic-rename.md
+++ b/.opencode/skills/legion-worker/resources/strategies/systematic-rename.md
@@ -1,0 +1,19 @@
+# Strategy: Systematic Rename
+
+When a repo, package, or URL is renamed across a codebase.
+
+## Checklist
+
+1. **Scope by file type** — grep all text-bearing extensions, not just the obvious ones:
+   - Source code (`.ts`, `.js`, `.py`, `.sh`) — functional, must update
+   - CI/CD configs (`.yml`, `.yaml`) — functional, must update
+   - Documentation (`.md`) — correctness, should update
+   - Config files (`.json`, `.toml`) — check but may be immutable
+
+2. **Classify matches as mutable vs immutable** — historical records (transcripts, test snapshots, progress logs) must NOT be modified. Changing them falsifies history.
+
+3. **Check comments for semantic context** — a comment mentioning the old name may still be correct in intent. Update the name but preserve the reasoning.
+
+4. **Verify with grep before AND after** — capture pre-edit state as a baseline for comparison.
+
+5. **Use `jj diff --git`** for verification — plain `jj diff` without color concatenates old/new text confusingly (e.g., `old-nameNEW-name` without color codes).

--- a/.opencode/skills/legion-worker/workflows/architect.md
+++ b/.opencode/skills/legion-worker/workflows/architect.md
@@ -168,6 +168,10 @@ linear_linear(action="update",
 
 **Cross-family review requirement:** Before adding `worker-done` to any issue or sub-issue, the architect output must pass cross-family review (Section 4). This ensures acceptance criteria are testable, sub-issues are properly scoped, and nothing is missing from the original requirements.
 
+**Label cleanup:** After signaling completion, remove `worker-active`:
+- **GitHub:** `gh issue edit $ISSUE_NUMBER --remove-label "worker-active" -R $OWNER/$REPO`
+- **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current labels without "worker-active"])`
+
 ## Common Mistakes
 
 | Mistake | Correction |

--- a/.opencode/skills/legion-worker/workflows/implement.md
+++ b/.opencode/skills/legion-worker/workflows/implement.md
@@ -70,6 +70,33 @@ When the plan contains independent tasks (annotated with parallelism information
 - Tasks are small enough that parallelism overhead isn't worth it
 - Tasks share the same files (merge conflict risk)
 
+#### Wave-Based Parallelism
+
+When a plan has both independent AND dependent tasks, group them into **waves**:
+
+```
+Wave 1 (parallel): T1 (jj.py), T2 (task_state.py), T3 (source_detection.py)
+  ↓ all complete
+Wave 2 (parallel): T4 (task_commands.py), T5 (merge_utils.py)
+  ↓ all complete  
+Wave 3 (parallel): T6 (tests), T7 (integration)
+```
+
+**The critical rule: never dispatch multiple subagents that edit the same file.**
+Concurrent edits to the same file cause silent overwrites — the last writer wins and
+earlier agents' work is lost. If two tasks both need to modify `task_commands.py`,
+they must be in the same wave (sequential) or one must `blockedBy` the other.
+
+**Grouping into waves:**
+1. List all tasks and which files they create or modify
+2. Tasks that touch disjoint files can run in parallel (same wave)
+3. Tasks that share a file must be sequential (different waves, with dependency edges)
+4. Within a wave, all tasks must complete before the next wave starts
+
+**Wave failure handling:** If a task in a wave fails, it follows the existing retry
+policy (3 attempts before escalation). Other tasks in the wave continue independently.
+The next wave does NOT start until all tasks in the current wave are completed or cancelled.
+
 ### 3. Analyze
 
 Invoke `/analyze` to run cleanup agents.
@@ -84,17 +111,20 @@ bunx tsc --noEmit # No type errors
 bunx biome check  # No lint/format issues
 ```
 
+**For Python code**, also run the project's Python checks:
+```bash
+cd meta/trajectory_labs  # or relevant Python package
+uv run ruff check --fix src/ tests/
+uv run ruff format src/ tests/
+uv run pytest
+```
+
 If any check fails:
 1. Fix the issues
 2. Re-run all checks
 3. Only proceed to Ship when all pass
 
 Do NOT create a PR if any check fails — fix first.
-
-Record the results as evidence for the controller's quality gate verification. Include in your issue comment:
-```
-CI Results: tests ✅ | tsc ✅ | biome ✅
-```
 
 ### 5. Cross-Family Review
 
@@ -145,7 +175,21 @@ gh pr create --draft \
 
 The issue ID in the branch/title preserves traceability for the controller.
 
-### 7. Exit
+### 7. Wait for CI
+
+After pushing, wait for CI to complete:
+```bash
+gh pr checks "$LEGION_ISSUE_ID" --watch
+```
+
+**If CI fails:** Read the failure logs, fix the issues, push again, and re-check.
+Do NOT exit with failing CI — it's your job to get CI green before the reviewer sees the PR.
+
+**Note:** Some repositories suppress CI on draft PRs. If `gh pr checks --watch` hangs
+with no checks reported, convert the PR to ready (`gh pr ready`), wait for CI, then
+convert back to draft (`gh pr ready --undo`) if needed.
+
+### 8. Exit
 
 Exit without adding labels. The controller handles state transitions explicitly.
 
@@ -195,6 +239,15 @@ Fix any failures before pushing.
 ```bash
 jj git push
 ```
+
+### 4.5. Wait for CI
+
+```bash
+gh pr checks "$LEGION_ISSUE_ID" --watch
+```
+
+**If CI fails:** Read the failure logs, fix the issues, push again, and re-check.
+Do NOT reply to comments or exit with failing CI.
 
 ### 5. Reply to Comments
 

--- a/.opencode/skills/legion-worker/workflows/plan.md
+++ b/.opencode/skills/legion-worker/workflows/plan.md
@@ -191,6 +191,10 @@ Add `worker-done` label to the issue, then exit:
 - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "worker-done" -R $OWNER/$REPO`
 - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current + "worker-done"])`
 
+Then remove `worker-active`:
+- **GitHub:** `gh issue edit $ISSUE_NUMBER --remove-label "worker-active" -R $OWNER/$REPO`
+- **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current labels without "worker-active"])`
+
 **CRITICAL:** Only add `worker-done` after successfully posting the plan. Never add this label if:
 - Requirements were unclear and could not be resolved (use `user-input-needed` instead)
 - Plan review failed and was not resolved

--- a/.opencode/skills/legion-worker/workflows/review.md
+++ b/.opencode/skills/legion-worker/workflows/review.md
@@ -47,6 +47,17 @@ Pass the context gathered in step 1. The review skill will:
 - Check against requirements
 - Identify issues by severity (CRITICAL/P1, IMPORTANT/P2, MINOR/P3)
 
+### 2.5. Check CI Status
+
+Check whether CI is passing on the PR:
+```bash
+gh pr checks "$LEGION_ISSUE_ID"
+```
+
+Include the CI status in your review summary (step 3). If CI is failing, note which
+checks are failing and treat it as a P1 issue — the implementer should have fixed this
+before opening the PR.
+
 ### 3. Post Summary Comment
 
 Post a top-level PR comment with the review summary:
@@ -99,3 +110,7 @@ Add `worker-done` to the issue, then exit:
 
 - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "worker-done" -R $OWNER/$REPO`
 - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current + "worker-done"])`
+
+Then remove `worker-active`:
+- **GitHub:** `gh issue edit $ISSUE_NUMBER --remove-label "worker-active" -R $OWNER/$REPO`
+- **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current labels without "worker-active"])`


### PR DESCRIPTION
## Summary

Batch of skill improvements from running the swarm in production. Three themes:

1. **CI ownership shifts to the implementer** — the controller's quality gate is removed. Implementers now wait for CI green before exiting, and reviewers check CI status as part of review. This eliminates the controller bottleneck and puts responsibility where the context is.

2. **More ambitious triage routing** — no issue is "too big" for Legion. Large/complex issues route to Backlog where the architect phase breaks them down. Only genuinely ambiguous issues go to Icebox.

3. **Operational guardrails** — documents hard-won lessons: don't delete workspaces while workers may resume (silently kills them), session IDs are deterministic (same inputs = same session), always use skill invocation instead of file paths for dispatch prompts.

### Changes by file

- **Controller skill**: Remove quality gate, ambitious triage, skill invocation enforcement, workspace deletion + session determinism docs
- **Worker skill**: Only-implementer-creates-branches rule, wave-based parallelism strategy, Python check guidance, CI wait step
- **Retro skill**: Skip trivial retros, integrator role (not just merge), push to existing branch
- **Review workflow**: CI status check step
- **New strategy docs**: `cleanup-deletion.md`, `systematic-rename.md`