### PR TITLE
feat: add behavioral testing gate between implement and review

### DIFF
--- a/.opencode/skills/AGENTS.md
+++ b/.opencode/skills/AGENTS.md
@@ -32,6 +32,7 @@ skills/
     │   ├── architect.md   # Break down vague issues into spec-ready sub-issues
     │   ├── plan.md        # Create executable implementation plans (with review iterations)
     │   ├── implement.md   # TDD-driven coding, PR creation
+    │   ├── test.md        # Behavioral testing against running infrastructure
     │   ├── review.md      # Deep PR review with line-level comments
     │   └── merge.md       # Merge PR, handle CI, cleanup workspace
     └── references/

--- a/.opencode/skills/legion-controller/SKILL.md
+++ b/.opencode/skills/legion-controller/SKILL.md
@@ -97,7 +97,7 @@ about what to do:
 
 | suggestedAction | Signals | Controller should... |
 |-----------------|---------|---------------------|
-| `skip` | `hasPr: true`, status: In Progress | PR opened; wait for auto-transition to Needs Review (or transition explicitly if using GitHub backend) |
+| `skip` | `hasPr: true`, status: In Progress | PR opened but no `worker-done` yet; wait for implementer to finish and add `worker-done` (which triggers testing gate) |
 | `skip` | `workerStatus: "dead"` | Dead worker blocking progress; clean up and re-evaluate |
 | `retry_pr_check` | `prIsDraft: null` | GitHub API flaked; try again next iteration |
 
@@ -133,18 +133,47 @@ don't dispatch a worker, don't transition status. The next loop iteration will r
 which will retry the GitHub API call. If this persists across multiple iterations, investigate the
 GitHub API connectivity.
 
-### Implement → Review Handoff
+### Implement → Testing → Review Handoff
 
-The implementer does **not** use `worker-done`. Instead:
-1. Implementer opens a **draft PR**, verifies CI passes, and exits
-2. The issue transitions to Needs Review (Linear auto-transition, or controller transitions explicitly for GitHub)
-3. State machine sees: Needs Review, no `worker-done`, no live worker → `dispatch_reviewer`
-4. Controller dispatches the reviewer
-**Before dispatching reviewer, verify CI is passing:**
+The implementer adds `worker-done` when finished:
+1. Implementer opens a **draft PR**, verifies CI passes, adds `worker-done`, and exits
+2. State machine sees: In Progress + `worker-done` → `transition_to_testing`
+3. Controller transitions issue to Testing status
+4. Controller runs the quality gate (below)
+5. If quality gate passes: dispatch tester
+6. If quality gate fails: move back to In Progress, dispatch fresh implementer with failure output
+
+After the tester runs:
+- **Test passed** (`test-passed` label): Controller removes `worker-done` and `test-passed` labels, transitions to Needs Review, dispatches reviewer (no additional quality gate needed)
+- **Test failed** (`test-failed` label): Controller removes `test-failed` and `worker-done` labels, transitions back to In Progress, resumes implementer session with test failure report from the PR comment
+
+### Review → Re-implementation → Testing Loop
+
+When the reviewer requests changes, the implementer's fixes **must go through testing again**:
+
+1. Reviewer converts PR to draft, adds `worker-done`
+2. State machine: `resume_implementer_for_changes`
+3. Controller **transitions issue to In Progress**, removes `worker-done`
+4. Controller resumes the implementer session with "Address PR review comments"
+5. Implementer fixes, pushes, adds `worker-done`
+6. State machine: In Progress + `worker-done` → `transition_to_testing`
+7. Tester verifies the fixes
+8. If tester passes → Needs Review → reviewer runs again
+
+**Critical:** The controller MUST transition to In Progress before resuming the implementer. If the issue stays in Needs Review and the implementer adds `worker-done`, the state machine will see `prIsDraft + worker-done` and suggest `resume_implementer_for_changes` again (infinite loop).
+
+### Quality Gate (Controller Policy)
+
+Before dispatching a tester, the controller independently verifies code quality. This is a controller-level policy, not signaled by the state machine.
+
+**When to run:** Whenever about to execute a `dispatch_tester` action.
+
+**Before dispatching tester, verify CI is passing:**
 ```bash
 gh pr checks "$LEGION_ISSUE_ID"
 ```
-If any checks are failing, do NOT dispatch the reviewer. Instead:
+
+If any checks are failing, do NOT dispatch the tester. Instead:
 1. Move issue back to In Progress
 2. Re-dispatch an implementer with the CI failure output:
 ```bash
@@ -154,7 +183,7 @@ legion dispatch "$ISSUE_IDENTIFIER" implement \
 
 **CI is the implementer's responsibility.** The implement workflow requires passing CI before
 signaling completion. If CI is failing when the controller sees a PR, the implementer didn't
-finish — re-dispatch an implementer with the CI failure output. The reviewer should also check
+finish — re-dispatch an implementer with the CI failure output. The tester should also check
 CI status and include it in the review.
 
 ### 4. Route Triage
@@ -364,6 +393,8 @@ it impossible to track what's merged.
 | `user-feedback-given` | Human responded, controller resumes |
 | `needs-approval` | Architect done, waiting for human approval |
 | `human-approved` | Human approved, controller advances to planner |
+| `test-passed` | Tester verified behavior, controller advances to Needs Review |
+| `test-failed` | Tester found issues, controller returns to implementer |
 
 ## Red Flags — STOP and Verify
 
@@ -399,7 +430,7 @@ If you catch yourself thinking any of these, STOP. You're about to make a mistak
 ## Status Flow
 
 ```
-Triage ─┬─► Icebox ─► Backlog ─► Todo ─► In Progress ─► Needs Review ─► Retro ─► Done
-        ├─► Backlog ──────────────┘                          │
-        └─► Todo ─────────────────────────────────────────────┘
+Triage ─┬─► Icebox ─► Backlog ─► Todo ─► In Progress ─► Testing ─► Needs Review ─► Retro ─► Done
+        ├─► Backlog ──────────────┘           │                        │
+        └─► Todo ─────────────────────────────┴────────────────────────┘
 ```

--- a/.opencode/skills/legion-worker/SKILL.md
+++ b/.opencode/skills/legion-worker/SKILL.md
@@ -132,11 +132,12 @@ Then update labels:
 |------|----------|-------------------|
 | `architect` | @workflows/architect.md | Yes (or on children) |
 | `plan` | @workflows/plan.md | Yes |
-| `implement` | @workflows/implement.md | No |
+| `implement` | @workflows/implement.md | Yes |
+| `test` | @workflows/test.md | Yes |
 | `review` | @workflows/review.md | Yes |
 | `merge` | @workflows/merge.md | No |
 
-**Lifecycle order:** architect → plan → implement → review → (implement if changes requested) → retro → merge
+**Lifecycle order:** architect → plan → implement → test → review → (implement → test if changes requested) → retro → merge
 
 **Retro** is not a mode — the controller resumes the implement worker's session with `/legion-retro`, preserving full implementation context. See the `legion-retro` skill.
 

--- a/.opencode/skills/legion-worker/workflows/architect.md
+++ b/.opencode/skills/legion-worker/workflows/architect.md
@@ -101,6 +101,34 @@ Acceptance criteria must be **testable** - a human or CI can verify pass/fail.
 
 Each criterion should answer: "How will we know this is done?"
 
+Each criterion should also be **behaviorally verifiable** — a tester should be able to verify it by interacting with the running application, not just by reading code or running unit tests.
+
+## Testing Infrastructure Assessment
+
+After defining acceptance criteria, assess whether they can be verified against running infrastructure. Add a "Testing Infrastructure" section to your output:
+
+**For each acceptance criterion, evaluate:**
+- Can this be verified against a running application?
+- What infrastructure is needed? (local server, browser, database, seed data)
+- What's missing? (no docker-compose, no seed script, README doesn't explain how to run locally)
+
+**Example output:**
+
+```
+### Testing Infrastructure
+
+**Available:**
+- Local dev server via `bun run dev`
+- Seed data script at `scripts/seed.sh`
+
+**Gaps:**
+- No browser test harness (Playwright not configured)
+- README missing instructions for local database setup
+- No health check endpoint to verify server is ready
+```
+
+Flag gaps clearly so the user can address them before planning begins. If the project has no way to run locally at all, note this prominently.
+
 ## Sub-Issue Creation
 
 **GitHub:**

--- a/.opencode/skills/legion-worker/workflows/implement.md
+++ b/.opencode/skills/legion-worker/workflows/implement.md
@@ -126,6 +126,18 @@ If any check fails:
 
 Do NOT create a PR if any check fails — fix first.
 
+### 4.5. Documentation
+
+For any user-facing behavior change, update relevant documentation before creating the PR:
+
+- **README** — if the feature changes setup, usage, or configuration
+- **Usage guides** — if the feature adds new user-facing functionality
+- **API docs** — if the feature changes or adds API endpoints
+- **Inline help** — if the feature adds CLI commands or options
+
+Documentation should explain **how to use** the feature, not just what changed in the code. A user reading only the docs should be able to understand and use the new functionality.
+
+Skip this step if the change is purely internal (refactoring, bug fix with no behavior change, test-only changes).
 ### 5. Cross-Family Review
 
 After all checks pass, spawn a cross-family review session before creating the PR.
@@ -191,7 +203,19 @@ convert back to draft (`gh pr ready --undo`) if needed.
 
 ### 8. Exit
 
-Exit without adding labels. The controller handles state transitions explicitly.
+Add `worker-done` label to signal the controller to transition to the Testing phase.
+
+**GitHub:**
+```
+gh issue edit $ISSUE_NUMBER --add-label "worker-done" --remove-label "worker-active" -R $OWNER/$REPO
+```
+
+**Linear:**
+```
+issue = linear_linear(action="get", id=$LEGION_ISSUE_ID)
+current_labels = [l.name for l in issue.labels if l.name != "worker-active"]
+linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "worker-done"])
+```
 
 ---
 
@@ -255,4 +279,16 @@ Reply in PR comment threads acknowledging fixes. Reference specific changes made
 
 ### 6. Exit
 
-Exit without adding labels. Issue stays in Needs Review; controller will dispatch reviewer.
+Add `worker-done` label to signal the controller. The controller has already transitioned the issue to In Progress before resuming you, so `worker-done` will trigger the testing gate — your fixes get behaviorally verified before the reviewer sees them again.
+
+**GitHub:**
+```
+gh issue edit $ISSUE_NUMBER --add-label "worker-done" --remove-label "worker-active" -R $OWNER/$REPO
+```
+
+**Linear:**
+```
+issue = linear_linear(action="get", id=$LEGION_ISSUE_ID)
+current_labels = [l.name for l in issue.labels if l.name != "worker-active"]
+linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "worker-done"])
+```

--- a/.opencode/skills/legion-worker/workflows/plan.md
+++ b/.opencode/skills/legion-worker/workflows/plan.md
@@ -150,6 +150,42 @@ The implementer will use these annotations to create a task graph with `blockedB
 - Minimize dependency chains — prefer wide, shallow graphs over deep sequential chains
 - When in doubt, mark as independent (the implementer can add dependencies if needed)
 
+#### Testing Plan
+
+After creating executable tasks, add a **Testing Plan** section to the plan output. The tester agent will use this to verify the implementation works end-to-end.
+
+**Required sections:**
+
+```
+## Testing Plan
+
+### Setup
+- [Concrete commands to boot the environment]
+- [e.g., `bun install && bun run dev`, `docker-compose up -d`]
+
+### Health Check
+- [How to verify the environment is ready]
+- [e.g., `curl -s http://localhost:3000/health` returns 200]
+- [Include timeout: retry for 30s before declaring failure]
+
+### Verification Steps
+For each acceptance criterion:
+1. **[Criterion name]**
+   - Action: [What to do — navigate to URL, run command, etc.]
+   - Expected: [What should happen — page shows X, API returns Y]
+   - Tool: [Playwright / curl / CLI]
+
+### Tools Needed
+- [List of tools the tester should use]
+- [e.g., Playwright for browser, curl for API, CLI for commands]
+```
+
+**Guidelines:**
+- Setup commands must be copy-pasteable — no placeholders the tester would need to figure out
+- Health checks should have a timeout (e.g., "retry for 30s")
+- Verification steps should be specific enough that a fresh agent with no implementation context can follow them
+- If infrastructure doesn't exist yet (architect flagged gaps), note what the implementer needs to create
+
 ### 4. Review with /plan-review
 
 After creating the executable plan, invoke `/plan-review` with the plan file path.

--- a/.opencode/skills/legion-worker/workflows/test.md
+++ b/.opencode/skills/legion-worker/workflows/test.md
@@ -1,0 +1,216 @@
+# Test Workflow
+
+Behavioral verification of implemented features against running infrastructure.
+
+You are a fresh agent with no prior context about the implementation. Your job is to verify that the feature works by exercising it against real running infrastructure — not by reading code or running unit tests.
+
+## Rebase First
+
+```bash
+jj git fetch
+jj rebase -d main
+```
+
+Resolve any conflicts before proceeding.
+
+## Workflow
+
+### 1. Fetch Context
+
+**GitHub:**
+
+```
+gh issue view $ISSUE_NUMBER --json title,body,labels,comments,state -R $OWNER/$REPO
+```
+
+**Linear:**
+
+```
+linear_linear(action="get", id=$LEGION_ISSUE_ID)
+```
+
+Extract:
+- Acceptance criteria from the issue body
+- Testing plan from issue comments (look for `## Testing Plan` section posted by planner)
+- PR number from issue comments or linked PRs
+
+Then fetch PR metadata and check out the branch:
+
+**GitHub:**
+
+```
+gh pr list --search "$LEGION_ISSUE_ID" --json number,title,body,files,headRefName -R $OWNER/$REPO
+gh pr view $PR_NUMBER --json title,body,files,headRefName -R $OWNER/$REPO
+```
+
+Check out the PR branch so you're testing the actual changes:
+
+```bash
+jj new $PR_BRANCH  # Use the headRefName from the PR metadata
+```
+
+**If no testing plan is found:** Construct one from the acceptance criteria using this structure:
+- Setup: look at README or package.json scripts for how to run the app
+- Health check: look for health endpoints or process readiness signals
+- Verification: map each acceptance criterion to a concrete action + expected outcome
+
+Note the missing plan in your results — the planner workflow should have produced one.
+
+### 2. Spec Compliance Check
+
+Before booting anything, verify the code even attempts to address the spec. Dispatch a spec compliance subagent using the template from `/superpowers/subagent-driven-development` (spec-reviewer-prompt.md):
+
+- **What Was Requested:** the acceptance criteria from the issue
+- **What Implementer Claims They Built:** the PR title and body
+- **Code to inspect:** the workspace (already checked out)
+
+The subagent reads the actual diff and verifies each acceptance criterion has corresponding code. It checks for:
+- Missing requirements (criterion has no code addressing it)
+- Extra/unneeded work (code that wasn't requested)
+- Misunderstandings (right feature, wrong approach)
+
+**If ✅ spec compliant:** proceed to step 3.
+
+**If ❌ issues found:** include the findings in your test results and **fail immediately** — skip booting the environment. There's no point smoke-testing code that doesn't even attempt to implement the spec.
+
+### 3. Read the Documentation
+
+Before doing anything else, try to understand the feature from the repo's documentation alone.
+
+- Read the README, usage guides, and any docs the implementer updated in the PR
+- Try to understand what the feature does and how to use it from docs only
+- Note any gaps, confusion, or missing information
+
+This is intentional — your first experience mirrors a real user's experience. Documentation quality feedback is part of your output.
+
+### 4. Boot the Environment
+
+Follow the testing plan's setup instructions:
+
+1. Run the setup commands from the testing plan
+2. Run the health check to verify the environment is ready (retry for up to 30s)
+3. If the environment fails to boot, that is a test failure — skip to step 6 with the boot error as evidence
+
+```bash
+# Example — use the actual health check from the testing plan, not this literal URL
+for i in $(seq 1 30); do
+  curl -s http://localhost:PORT/health && break
+  sleep 1
+done
+```
+
+### 5. Execute Acceptance Criteria
+
+Work through each criterion from the testing plan. Use appropriate tools:
+
+- **Playwright / agent-browser** for web UIs (navigate, click, fill forms, verify results)
+- **curl / HTTP requests** for APIs (hit endpoints, verify responses)
+- **CLI commands** for command-line tools (run commands, verify output)
+- **Subprocess execution** for scripts, build tools
+
+For each criterion, capture concrete evidence:
+- Screenshots (for UI tests)
+- Command output (for CLI/API tests)
+- Log excerpts (for backend behavior)
+
+Do NOT accept "it looks like it works" — capture actual artifacts.
+
+### 6. Post Results to PR
+
+Post a structured comment on the PR:
+
+**GitHub:**
+
+```
+gh pr comment $PR_NUMBER --body "## Behavioral Test Results
+
+### Summary
+[PASS/FAIL] — [N/M] acceptance criteria verified
+
+### Results
+| Criterion | Status | Evidence |
+|-----------|--------|----------|
+| [criterion 1] | ✅/❌ | [output/screenshot] |
+
+### Documentation Feedback
+- [Was it easy to understand the feature from docs?]
+- [Were setup instructions accurate?]
+- [What was missing or confusing?]
+
+### Observations
+- [UX issues, error messages, edge cases noticed]" -R $OWNER/$REPO
+```
+
+**Linear:**
+
+**Linear** (posts to issue — Linear doesn't have PR-level comments):
+```
+linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="## Behavioral Test Results
+
+### Summary
+[PASS/FAIL] — [N/M] acceptance criteria verified
+
+### Results
+| Criterion | Status | Evidence |
+|-----------|--------|----------|
+| [criterion 1] | ✅/❌ | [output/screenshot] |
+
+### Documentation Feedback
+- [Was it easy to understand the feature from docs?]
+- [Were setup instructions accurate?]
+- [What was missing or confusing?]
+
+### Observations
+- [UX issues, error messages, edge cases noticed]")
+```
+
+### 7. Signal Completion
+
+**If all criteria pass:**
+
+**GitHub:**
+```
+gh issue edit $ISSUE_NUMBER --add-label "worker-done" --add-label "test-passed" --remove-label "worker-active" -R $OWNER/$REPO
+```
+
+**Linear:**
+```
+issue = linear_linear(action="get", id=$LEGION_ISSUE_ID)
+current_labels = [l.name for l in issue.labels if l.name != "worker-active"]
+linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "worker-done", "test-passed"])
+```
+
+**If any criterion fails:**
+
+**GitHub:**
+```
+gh issue edit $ISSUE_NUMBER --add-label "worker-done" --add-label "test-failed" --remove-label "worker-active" -R $OWNER/$REPO
+```
+
+**Linear:**
+```
+issue = linear_linear(action="get", id=$LEGION_ISSUE_ID)
+current_labels = [l.name for l in issue.labels if l.name != "worker-active"]
+linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "worker-done", "test-failed"])
+```
+
+Exit immediately after signaling.
+
+## Blocking on User Input
+
+If the testing plan is ambiguous or infrastructure is fundamentally missing (not a bug — e.g., no way to run the app at all), try `/legion-oracle [your question]` first. If still blocked, follow the escalation pattern from SKILL.md: push, post comment, add `user-input-needed`, remove `worker-active`, exit.
+
+Do NOT escalate for test failures — those are expected outcomes, not blockers.
+
+## Common Mistakes
+
+| Mistake | Correction |
+|---------|------------|
+| Trusting unit test results instead of running the app | Boot the environment and exercise actual behavior |
+| Skipping documentation review | Always read docs first — you're the first "user" |
+| Accepting "it works" without evidence | Capture screenshots, command output, log excerpts |
+| Adding `test-passed` AND `test-failed` | Only one — pass or fail, never both |
+| Continuing after boot failure | Boot failure is a test failure — report and exit |
+| Testing on main instead of the PR branch | Check out the PR branch first |
+| Escalating when tests fail | Test failures are expected outcomes, not blockers |
+| Booting the app when spec compliance failed | If the code doesn't attempt to implement the spec, fail immediately |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ controller skill, not the TypeScript.
 - **Controller skill** — the customization point: reads suggested actions + raw signals,
   executes transitions, runs quality gates, handles edge cases. Users who want different
   workflows edit this file.
-- **Worker skills** — execute specific workflow phases (architect, plan, implement, review,
+- **Worker skills** — execute specific workflow phases (architect, plan, implement, test, review,
   merge). Retro runs via `/legion-retro` on the implement worker session.
 
 Skills invoke TypeScript via: HTTP API (`/workers`, `/state/collect`), and environment variables (controller only). Workers receive all context via dispatch prompts. TypeScript never calls skills directly.
@@ -33,7 +33,7 @@ Skills invoke TypeScript via: HTTP API (`/workers`, `/state/collect`), and envir
 bun install                   # Setup
 bunx biome check src/         # Lint
 bunx tsc --noEmit             # Type check
-bun test                      # Test (172 tests)
+bun test                      # Test (640 tests)
 ```
 
 ```bash
@@ -57,14 +57,14 @@ legion attach <team> <issue>  # Attach to worker
 
 | Task | Location | Notes |
 |------|----------|-------|
-| Add CLI command | `src/cli/index.ts` | citty `defineCommand` pattern |
-| Change HTTP API | `src/daemon/server.ts` | See @src/daemon/AGENTS.md |
-| Change state machine | `src/state/decision.ts` | See @src/state/AGENTS.md |
+| Add CLI command | `packages/daemon/src/cli/index.ts` | citty `defineCommand` pattern |
+| Change HTTP API | `packages/daemon/src/daemon/server.ts` | See @packages/daemon/src/daemon/AGENTS.md |
+| Change state machine | `packages/daemon/src/state/decision.ts` | See @packages/daemon/src/state/AGENTS.md |
 | Add worker workflow | `.opencode/skills/legion-worker/workflows/` | See @.opencode/skills/AGENTS.md |
 | Change controller loop | `.opencode/skills/legion-controller/SKILL.md` | See @.opencode/skills/AGENTS.md |
-| Modify issue types | `src/state/types.ts` | Shared by daemon + state |
-| Worker process mgmt | `src/daemon/serve-manager.ts` | Spawns `opencode serve` |
-| Port allocation | `src/daemon/ports.ts` | Sequential from base 13381 |
+| Modify issue types | `packages/daemon/src/state/types.ts` | Shared by daemon + state |
+| Worker process mgmt | `packages/daemon/src/daemon/serve-manager.ts` | Spawns `opencode serve` |
+| Port allocation | `packages/daemon/src/daemon/ports.ts` | Sequential from base 13381 |
 
 ## Conventions
 
@@ -79,21 +79,22 @@ legion attach <team> <issue>  # Attach to worker
 ## Issue Lifecycle
 
 ```
-Triage ──┬──► Icebox ──► Backlog ──► Todo ──► In Progress ──► Needs Review ──► Retro ──► Done
-         │                  ^           ^            ^               │
-         │                  │           │            │               │
-         ├──────────────────┘           │            └───────────────┘
+Triage ──┬──► Icebox ──► Backlog ──► Todo ──► In Progress ──► Testing ──► Needs Review ──► Retro ──► Done
+         │                  ^           ^            ^                             │
+         │                  │           │            │                             │
+         ├──────────────────┘           │            └─────────────────────────────┘
          │   (already spec-ready)       │            (changes requested)
          └──────────────────────────────┘
                     (urgent + clear)
-```
 
-**Worker modes:** architect → plan → implement → review → merge
+**Worker modes:** architect → plan → implement → test → review → merge
 **Retro:** invoked by resuming the implement worker session with `/legion-retro`
 
-**Labels:** `worker-done`, `worker-active`, `user-input-needed`, `user-feedback-given`
+**Labels:** `worker-done`, `worker-active`, `user-input-needed`, `user-feedback-given`, `test-passed`, `test-failed`
 
 **Review signaling:** PR draft status (not labels) — draft = changes requested, ready = approved.
+
+**Testing gate:** Behavioral testing is mandatory after every implementation phase — both fresh implementation AND review-requested changes go through the tester before reaching the reviewer.
 
 ## Documentation
 

--- a/docs/plans/2026-02-28-behavioral-testing-gate-design.md
+++ b/docs/plans/2026-02-28-behavioral-testing-gate-design.md
@@ -1,0 +1,168 @@
+# Behavioral Testing Gate
+
+## Goal
+
+Add a mandatory behavioral testing phase to the Legion worker pipeline. A fresh agent boots the application, exercises user-facing behavior against running infrastructure, and verifies acceptance criteria before code review begins. This catches the class of bugs that unit tests miss — code that passes `bun test` but doesn't actually work when a user interacts with it.
+
+## Motivation
+
+From Legion Retro (#63): "Unit tests are the weakest form of verification. Workers write code that passes `bun test` but we have no idea if the Bitwarden context menus actually work, or if LinkedIn search actually returns fuzzy results."
+
+The current quality gate (run `bun test`, `tsc`, `biome` before dispatching reviewer) is necessary but insufficient. It verifies the code compiles and unit tests pass, but never verifies that the feature works end-to-end. A fresh agent with no implementation context provides independent behavioral verification — the same way a real user would discover bugs the developer missed.
+
+## Decisions
+
+- **New worker mode** — `test` joins the existing 5 modes (architect, plan, implement, review, merge)
+- **New issue status** — `Testing` sits between `In Progress` and `Needs Review`
+- **Mandatory gate** — every issue passes through Testing; this is not opt-in
+- **Fresh agent** — the tester is a new session, not the implementer; independence prevents confirmation bias
+- **Controller owns transitions** — the controller moves issues between statuses; workers signal completion via `worker-done` label
+- **Label-based pass/fail** — tester adds `test-passed` or `test-failed` label; controller reads these to decide next action
+- **Failure loops back** — test failure returns the issue to In Progress and resumes the same implementer session with the failure report
+- **Upstream workflows feed the tester** — architect flags infra gaps, planner writes the testing plan, implementer updates docs
+
+## Pipeline
+
+### Updated lifecycle
+
+```
+architect → plan → implement → test → review → retro → merge
+```
+
+### Updated issue statuses
+
+```
+Backlog → Todo → In Progress → Testing → Needs Review → Retro → Done
+```
+
+### Phase responsibilities
+
+| Phase | Responsibility | Testing-related change |
+|-------|---------------|----------------------|
+| Architect | Break down issues, define acceptance criteria | Add testing infrastructure assessment: flag gaps (no local server setup, missing seed data, no browser test harness) |
+| Planner | Create implementation plan | Add testing plan section: boot commands, health checks, verification steps per criterion, tools needed |
+| Implementer | TDD implementation, PR creation | Must update docs for user-facing changes; must add `worker-done` on exit (currently exits without it) |
+| Tester | **New.** Behavioral verification | Boot app, execute testing plan, capture evidence, post results + doc feedback to PR |
+| Reviewer | Code review | No change — but now receives behaviorally-verified PRs with tester comments for context |
+| Merger | Merge PR | No change |
+
+## Tester Workflow
+
+### Inputs
+
+- The issue (with acceptance criteria from architect)
+- The testing plan (from planner, in issue comments or plan doc)
+- The PR (code changes, implementer's documentation)
+
+### Steps
+
+1. **Setup** — Fetch issue, testing plan, and PR metadata. Check out the branch.
+
+2. **Read the docs first** — Before doing anything else, try to understand the feature from the repo's documentation alone. The tester's first experience with the docs mirrors a real user's experience. This is intentional.
+
+3. **Boot the environment** — Follow the testing plan's setup instructions (start servers, seed data, build assets, etc.). If the environment fails to boot, that's a test failure.
+
+4. **Execute acceptance criteria** — Work through each criterion from the testing plan using appropriate tools:
+   - Playwright / agent-browser for web UIs
+   - curl / HTTP requests for APIs
+   - CLI commands for command-line tools
+   - Subprocess execution for scripts and build tools
+
+5. **Capture evidence** — For each criterion: screenshots, log output, command output, or other concrete artifacts. Not just "it worked" — actual proof.
+
+6. **Post results to PR** — A structured comment containing:
+   - Pass/fail for each acceptance criterion with evidence
+   - Documentation quality feedback (was it easy to get started? anything missing or confusing?)
+   - Observations about UX, error messages, or edge cases noticed during testing
+
+7. **Signal completion** — Add `worker-done` label plus `test-passed` or `test-failed` label.
+
+### Failure path
+
+Tester fails → adds `worker-done` + `test-failed` → controller transitions issue back to In Progress → controller resumes the same implementer session with the test failure report → implementer fixes → adds `worker-done` → controller transitions to Testing → dispatches fresh tester.
+
+## State Machine Changes
+
+### New types
+
+```
+IssueStatusLiteral: add "Testing" (between "In Progress" and "Needs Review")
+
+WorkerModeLiteral: add "test" (6 modes: architect, plan, implement, test, review, merge)
+
+ActionType: add 3 new actions:
+  - "transition_to_testing"
+  - "dispatch_tester"
+  - "resume_implementer_for_test_failure"
+```
+
+### Decision logic
+
+```
+In Progress + worker-done               → transition_to_testing  (was: transition_to_needs_review)
+
+Testing + no worker-done + no live worker           → dispatch_tester
+Testing + worker-done + test-passed label           → transition_to_needs_review
+Testing + worker-done + !test-passed label      → resume_implementer_for_test_failure
+Testing + live worker                               → skip
+```
+
+**Note:** The state machine checks `hasTestPassed` (presence of `test-passed`), not `hasTestFailed`. The `test-failed` label is for human visibility and controller cleanup only. `hasPr` is not checked for `transition_to_testing` — the controller's quality gate catches missing PRs before dispatching the tester.
+
+### Label lifecycle
+
+The controller handles label cleanup during transitions:
+- On `transition_to_testing`: remove `worker-done` from In Progress
+- On `transition_to_needs_review` from Testing: remove `worker-done`, `test-passed`
+- On `resume_implementer_for_test_failure`: remove `worker-done`, `test-failed`, transition to In Progress
+
+**Post-design additions (implemented during development):**
+- Spec compliance check added as step 2 of tester workflow (before reading docs)
+- Review-changes → testing loop: reviewer requests changes → controller transitions to In Progress → implementer fixes → testing gate runs again
+- Controller must transition to In Progress before resuming implementer for changes (avoids infinite loop)
+
+### Implementer `worker-done` change
+
+Currently the implementer opens a draft PR and exits without adding `worker-done`. The state machine detects completion implicitly (Needs Review status + no worker + no worker-done). With the test gate, the implementer should add `worker-done` explicitly so the state machine has a clear signal to transition to Testing. This is cleaner than the current implicit detection.
+
+## Upstream Workflow Modifications
+
+### Architect workflow
+
+Add a **Testing Infrastructure Assessment** after acceptance criteria:
+
+- Can the acceptance criteria be verified against running infrastructure?
+- What infrastructure is needed? (local server, browser, database, seed data, etc.)
+- What's missing? (no docker-compose, no seed script, README doesn't explain how to run locally)
+
+This surfaces during the user's review of the architect output, before planning begins. If major gaps exist, the user can address them or scope them into the issue.
+
+### Planner workflow
+
+Add a **Testing Plan** section to the plan output:
+
+- **Setup steps** — concrete commands to boot the environment
+- **Health check** — how to verify the environment is ready (URL, port, expected response)
+- **Verification steps** — for each acceptance criterion: specific actions and expected outcomes
+- **Tools needed** — what the tester should use (Playwright, curl, CLI, etc.)
+
+### Implementer workflow
+
+Two additions to exit criteria:
+
+1. **Documentation requirement** — for any user-facing behavior change, update relevant docs (README, usage guides, API docs) before creating the PR. Docs explain how to use the feature, not just what changed.
+2. **Explicit `worker-done`** — add `worker-done` label on exit instead of relying on implicit detection.
+
+## What This Doesn't Cover
+
+- **Testing infrastructure provisioning** — the tester uses whatever exists. If a repo doesn't have a way to run locally, the architect flags this and the user addresses it. Legion doesn't create infrastructure.
+- **Performance testing** — the tester verifies behavior, not performance. Performance benchmarking is a separate concern.
+- **Flaky test handling** — the tester gets one shot. If the test fails, it's assumed to be a real bug, not flakiness. As repos mature with Legion, testing infrastructure stabilizes and false negatives become rare.
+- **CI status integration** — tracked separately in #62. The tester is behavioral verification; CI is automated checks. They complement each other.
+
+## Related Issues
+
+- #63 — Legion Retro (motivation, "your tester idea — strong agree")
+- #25 — E2E Testing Capability Set (closed; established E2E as loadable capability, superseded by this design making it mandatory)
+- #62 — State machine CI status (complementary; CI checks are orthogonal to behavioral testing)
+- #30 — Pre-transition quality gates (existing gate; behavioral testing is the next layer)

--- a/docs/plans/2026-02-28-behavioral-testing-gate-impl.md
+++ b/docs/plans/2026-02-28-behavioral-testing-gate-impl.md
@@ -1,0 +1,848 @@
+# Behavioral Testing Gate Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a mandatory behavioral testing phase (`test` mode) to the Legion pipeline between implement and review.
+
+**Architecture:** New `Testing` issue status + `test` worker mode + `dispatch_tester` action. Tester is a fresh agent that boots the app and verifies acceptance criteria. Upstream workflows (architect, planner, implementer) gain testing-related sections. Controller routes new actions.
+
+**Tech Stack:** TypeScript/Bun (daemon), Markdown (skills), Bun test (testing)
+
+**Design doc:** `docs/plans/2026-02-28-behavioral-testing-gate-design.md`
+
+---
+
+### Task 1: Add new types — Independent
+
+**Files:**
+- Modify: `packages/daemon/src/state/types.ts`
+
+**Step 1: Add "Testing" status**
+
+In `IssueStatusLiteral` (line 22), add `"Testing"` between `"In Progress"` and `"Needs Review"`:
+
+```typescript
+export type IssueStatusLiteral =
+  | "Triage"
+  | "Icebox"
+  | "Backlog"
+  | "Todo"
+  | "In Progress"
+  | "Testing"
+  | "Needs Review"
+  | "Retro"
+  | "Done";
+```
+
+In `IssueStatus` constant (line 63), add after `IN_PROGRESS`:
+
+```typescript
+TESTING: "Testing" as IssueStatusLiteral,
+```
+
+In `_lowercaseCanonicalMap` (line 123), add after `["in progress", "In Progress"]`:
+
+```typescript
+["testing", "Testing"],
+```
+
+**Step 2: Add "test" worker mode**
+
+In `WorkerModeLiteral` (line 35):
+
+```typescript
+export type WorkerModeLiteral = "architect" | "plan" | "implement" | "test" | "review" | "merge";
+```
+
+In `WorkerMode` constant (line 141), add after `IMPLEMENT`:
+
+```typescript
+TEST: "test" as WorkerModeLiteral,
+```
+
+**Step 3: Add new action types**
+
+In `ActionType` (line 40), add after `"dispatch_implementer_for_retro"`:
+
+```typescript
+  | "dispatch_tester"
+  | "transition_to_testing"
+  | "resume_implementer_for_test_failure"
+```
+
+**Step 4: Add test label computed properties to ParsedIssue**
+
+In `createParsedIssue` (line 242), add getters after `hasHumanApproved`:
+
+```typescript
+    get hasTestPassed() {
+      return this.labels.includes("test-passed");
+    },
+
+    get hasTestFailed() {
+      return this.labels.includes("test-failed");
+    },
+```
+
+Update the `ParsedIssue` interface (line 221) to include these:
+
+```typescript
+  readonly hasTestPassed: boolean;
+  readonly hasTestFailed: boolean;
+```
+
+**Step 5: Add test fields to FetchedIssueData**
+
+In `FetchedIssueData` interface (line 297), add after `hasHumanApproved`:
+
+```typescript
+  hasTestPassed: boolean;
+  hasTestFailed: boolean;
+```
+
+**Step 6: Run type check**
+
+Run: `bunx tsc --noEmit`
+Expected: Errors in fetch.ts and decision.ts about missing fields (we'll fix those in Tasks 2-3)
+
+**Step 7: Commit**
+
+```bash
+jj describe -m "feat: add Testing status, test mode, and tester action types"
+jj new
+```
+
+---
+
+### Task 2: Write failing tests for new decision logic — Depends on: Task 1
+
+**Files:**
+- Modify: `packages/daemon/src/state/__tests__/decision.test.ts`
+
+**Step 1: Add Testing tests to suggestAction describe block**
+
+Add after the existing `done_always_skips` test (around line 131):
+
+```typescript
+  // Testing status
+  it("in_progress_worker_done_transitions_to_testing", () => {
+    const action = suggestAction(IssueStatus.IN_PROGRESS, true, false, null, false, false);
+    expect(action).toBe("transition_to_testing");
+  });
+
+  it("testing_no_worker_done_no_live_worker_dispatches_tester", () => {
+    const action = suggestAction(IssueStatus.TESTING, false, false, null, false, false);
+    expect(action).toBe("dispatch_tester");
+  });
+
+  it("testing_worker_done_test_passed_transitions_to_needs_review", () => {
+    const action = suggestAction(IssueStatus.TESTING, true, false, null, true, true);
+    expect(action).toBe("transition_to_needs_review");
+  });
+
+  it("testing_worker_done_test_failed_resumes_implementer", () => {
+    const action = suggestAction(IssueStatus.TESTING, true, false, null, true, false);
+    expect(action).toBe("resume_implementer_for_test_failure");
+  });
+
+  it("testing_with_live_worker_skips", () => {
+    const action = suggestAction(IssueStatus.TESTING, false, true, null, false, false);
+    expect(action).toBe("skip");
+  });
+```
+
+**Step 2: Update existing in_progress_worker_done test**
+
+The test at line 28 expects `transition_to_needs_review` — update to `transition_to_testing`:
+
+```typescript
+  it("in_progress_worker_done transitions to testing", () => {
+    const action = suggestAction(IssueStatus.IN_PROGRESS, true, false, null, false, false);
+    expect(action).toBe("transition_to_testing");
+  });
+```
+
+Also update the `feedback_without_input_needed_follows_normal_flow` test (line 224) which expects `transition_to_needs_review` for In Progress + worker-done — it should now expect `transition_to_testing`:
+
+```typescript
+    expect(state.suggestedAction).toBe("transition_to_testing");
+```
+
+And the `buildCollectedState` test `builds_state_for_multiple_issues` (line 556) which expects `transition_to_needs_review` for In Progress + worker-done:
+
+```typescript
+    expect(state.issues["ENG-22"].suggestedAction).toBe("transition_to_testing");
+```
+
+**Step 3: Add buildIssueState tests for Testing status**
+
+Add to the `buildIssueState` describe block:
+
+```typescript
+  it("testing_worker_done_test_passed_transitions_to_needs_review", () => {
+    const data: FetchedIssueData = {
+      issueId: "ENG-21",
+      status: "Testing",
+      labels: ["worker-done", "test-passed"],
+      hasPr: true,
+      prIsDraft: null,
+      hasLiveWorker: false,
+      workerMode: null,
+      workerStatus: null,
+      hasUserFeedback: false,
+      hasUserInputNeeded: false,
+      hasNeedsApproval: false,
+      hasHumanApproved: false,
+      hasTestPassed: true,
+      hasTestFailed: false,
+      source: null,
+    };
+
+    const state = buildIssueState(data, "00000000-0000-0000-0000-000000000000");
+    expect(state.suggestedAction).toBe("transition_to_needs_review");
+  });
+
+  it("testing_worker_done_test_failed_resumes_implementer", () => {
+    const data: FetchedIssueData = {
+      issueId: "ENG-21",
+      status: "Testing",
+      labels: ["worker-done", "test-failed"],
+      hasPr: true,
+      prIsDraft: null,
+      hasLiveWorker: false,
+      workerMode: null,
+      workerStatus: null,
+      hasUserFeedback: false,
+      hasUserInputNeeded: false,
+      hasNeedsApproval: false,
+      hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: true,
+      source: null,
+    };
+
+    const state = buildIssueState(data, "00000000-0000-0000-0000-000000000000");
+    expect(state.suggestedAction).toBe("resume_implementer_for_test_failure");
+  });
+```
+
+**Step 4: Update all existing FetchedIssueData literals**
+
+Every `FetchedIssueData` object in the test file needs the two new fields. Add to each:
+
+```typescript
+      hasTestPassed: false,
+      hasTestFailed: false,
+```
+
+There are approximately 20 FetchedIssueData literals in the file. Each one needs these fields.
+
+**Step 5: Run tests to verify they fail**
+
+Run: `bun test packages/daemon/src/state/__tests__/decision.test.ts`
+Expected: FAIL — `suggestAction` signature doesn't match yet, Testing case not implemented
+
+**Step 6: Commit**
+
+```bash
+jj describe -m "test: add failing tests for Testing status and tester dispatch"
+jj new
+```
+
+---
+
+### Task 3: Implement decision logic — Depends on: Task 2
+
+**Files:**
+- Modify: `packages/daemon/src/state/decision.ts`
+
+**Step 1: Update suggestAction signature and In Progress case**
+
+Add `hasTestPassed` parameter and change In Progress transition:
+
+```typescript
+export function suggestAction(
+  status: IssueStatusLiteral | string,
+  hasWorkerDone: boolean,
+  hasLiveWorker: boolean,
+  prIsDraft: boolean | null,
+  hasPr: boolean,
+  hasTestPassed: boolean
+): ActionType {
+```
+
+In the `IN_PROGRESS` case (line 53), change `transition_to_needs_review` to `transition_to_testing`:
+
+```typescript
+    case IssueStatus.IN_PROGRESS:
+      if (hasWorkerDone) {
+        return "transition_to_testing";
+      }
+```
+
+**Step 2: Add Testing case**
+
+Add after the `IN_PROGRESS` case, before `NEEDS_REVIEW`:
+
+```typescript
+    case IssueStatus.TESTING:
+      if (hasWorkerDone) {
+        if (hasTestPassed) {
+          return "transition_to_needs_review";
+        }
+        return "resume_implementer_for_test_failure";
+      }
+      if (hasLiveWorker) {
+        return "skip";
+      }
+      return "dispatch_tester";
+```
+
+**Step 3: Update ACTION_TO_MODE**
+
+Add new action mappings (line 97):
+
+```typescript
+  dispatch_tester: WorkerMode.TEST,
+  transition_to_testing: WorkerMode.TEST,
+  resume_implementer_for_test_failure: WorkerMode.IMPLEMENT,
+```
+
+**Step 4: Update buildIssueState to pass hasTestPassed**
+
+In `buildIssueState` (line 118), update the `suggestAction` call to pass the new parameter:
+
+```typescript
+    action = suggestAction(
+      data.status,
+      data.labels.includes("worker-done"),
+      data.hasLiveWorker,
+      data.prIsDraft,
+      data.hasPr,
+      data.hasTestPassed ?? false
+    );
+```
+
+**Step 5: Run tests**
+
+Run: `bun test packages/daemon/src/state/__tests__/decision.test.ts`
+Expected: ALL PASS
+
+**Step 6: Run full suite + type check**
+
+Run: `bun test && bunx tsc --noEmit`
+Expected: PASS (may have fetch.ts errors if FetchedIssueData fields not wired yet — fix in Task 4)
+
+**Step 7: Commit**
+
+```bash
+jj describe -m "feat: implement Testing status decision logic and tester dispatch"
+jj new
+```
+
+---
+
+### Task 4: Wire up new fields in enrichment — Depends on: Task 1
+
+**Files:**
+- Modify: `packages/daemon/src/state/fetch.ts`
+
+**Step 1: Add test label fields to enrichParsedIssues return**
+
+In `enrichParsedIssues` (line 290), add to the return object (after `hasHumanApproved`, around line 337):
+
+```typescript
+      hasTestPassed: issue.hasTestPassed,
+      hasTestFailed: issue.hasTestFailed,
+```
+
+**Step 2: Run type check and tests**
+
+Run: `bunx tsc --noEmit && bun test`
+Expected: ALL PASS
+
+**Step 3: Commit**
+
+```bash
+jj describe -m "feat: wire test-passed/test-failed labels in enrichment"
+jj new
+```
+
+---
+
+### Task 5: Create tester workflow — Independent
+
+**Files:**
+- Create: `.opencode/skills/legion-worker/workflows/test.md`
+
+**Step 1: Write the tester workflow**
+
+Create `.opencode/skills/legion-worker/workflows/test.md` with the following content. Follow the existing workflow file patterns (architect.md, implement.md) for structure and conventions.
+
+The workflow should contain:
+
+```markdown
+# Test Workflow
+
+Behavioral verification of implemented features against running infrastructure.
+
+## Context
+
+You are a fresh agent with no prior context about the implementation.
+Your job is to verify that the feature works by exercising it against real
+running infrastructure — not by reading code or running unit tests.
+
+## Inputs
+
+You receive:
+- The issue (with acceptance criteria from architect)
+- The testing plan (from planner, posted as an issue comment)
+- The PR (code changes and documentation)
+
+## Workflow
+
+### 1. Fetch Context
+
+[GitHub/Linear fetch commands — same pattern as other workflows]
+
+Extract:
+- Acceptance criteria from the issue
+- Testing plan from issue comments (look for "Testing Plan" section)
+- PR metadata: `gh pr view $PR_NUMBER --json title,body,files -R $OWNER/$REPO`
+
+### 2. Read the Documentation
+
+Before doing anything else, try to understand the feature from the repo's
+documentation alone. Read the README, usage guides, and any docs the
+implementer updated in the PR.
+
+This is intentional — your first experience mirrors a real user's experience.
+Note any gaps, confusion, or missing information.
+
+### 3. Boot the Environment
+
+Follow the testing plan's setup instructions:
+
+1. Run the setup commands from the testing plan
+2. Run the health check to verify the environment is ready
+3. If the environment fails to boot, that is a test failure — skip to
+   step 6 with the boot error as evidence
+
+### 4. Execute Acceptance Criteria
+
+Work through each criterion from the testing plan. Use appropriate tools:
+
+- **Playwright / agent-browser** for web UIs (navigate, click, fill forms,
+  verify results)
+- **curl / HTTP requests** for APIs (hit endpoints, verify responses)
+- **CLI commands** for command-line tools (run commands, verify output)
+- **Subprocess execution** for scripts, build tools
+
+For each criterion, capture concrete evidence:
+- Screenshots (for UI tests)
+- Command output (for CLI/API tests)
+- Log excerpts (for backend behavior)
+
+Do NOT accept "it looks like it works" — capture actual artifacts.
+
+### 5. Assess Documentation Quality
+
+Based on your experience in steps 2-4:
+- Was it easy to understand what the feature does from the docs?
+- Were setup instructions accurate and complete?
+- Were there steps you had to figure out that should have been documented?
+- Would a new user be able to use this feature from the docs alone?
+
+### 6. Post Results to PR
+
+Post a structured comment on the PR:
+
+[Template with pass/fail per criterion, evidence, doc feedback, observations]
+
+### 7. Signal Completion
+
+Add labels based on outcome:
+
+**If all criteria pass:**
+- Add `worker-done` label
+- Add `test-passed` label
+
+**If any criterion fails:**
+- Add `worker-done` label
+- Add `test-failed` label
+
+Then remove `worker-active` and exit.
+```
+
+Flesh out each section with the full GitHub/Linear command patterns matching the other workflow files. Include the PR comment template, label update commands, and error handling patterns.
+
+**Step 2: Commit**
+
+```bash
+jj describe -m "feat: create tester workflow (test.md)"
+jj new
+```
+
+---
+
+### Task 6: Update worker SKILL.md — Depends on: Task 5
+
+**Files:**
+- Modify: `.opencode/skills/legion-worker/SKILL.md`
+
+**Step 1: Add test to mode routing table**
+
+In the Mode Routing table (line 126), add after `implement`:
+
+```markdown
+| `test` | @workflows/test.md | Yes |
+```
+
+**Step 2: Update lifecycle order**
+
+Update line 134:
+
+```markdown
+**Lifecycle order:** architect → plan → implement → test → review → (implement if changes requested) → retro → merge
+```
+
+**Step 3: Commit**
+
+```bash
+jj describe -m "feat: add test mode to worker routing table"
+jj new
+```
+
+---
+
+### Task 7: Update architect workflow — Independent
+
+**Files:**
+- Modify: `.opencode/skills/legion-worker/workflows/architect.md`
+
+**Step 1: Add Testing Infrastructure Assessment**
+
+After the "What Makes Good Acceptance Criteria" section (line 88), add a new section:
+
+```markdown
+## Testing Infrastructure Assessment
+
+After defining acceptance criteria, assess whether they can be verified
+against running infrastructure. Add a "Testing Infrastructure" section
+to your output:
+
+**For each acceptance criterion, evaluate:**
+- Can this be verified against a running application?
+- What infrastructure is needed? (local server, browser, database, seed data)
+- What's missing? (no docker-compose, no seed script, README doesn't explain
+  how to run locally)
+
+**Example output:**
+
+```
+### Testing Infrastructure
+
+**Available:**
+- Local dev server via `bun run dev`
+- Seed data script at `scripts/seed.sh`
+
+**Gaps:**
+- No browser test harness (Playwright not configured)
+- README missing instructions for local database setup
+- No health check endpoint to verify server is ready
+```
+
+Flag gaps clearly so the user can address them before planning begins.
+If the project has no way to run locally at all, note this prominently.
+```
+
+**Step 2: Update acceptance criteria guidance**
+
+In the "What Makes Good Acceptance Criteria" section, add a note about behavioral verifiability:
+
+```markdown
+Each criterion should also be **behaviorally verifiable** — a tester should
+be able to verify it by interacting with the running application, not just
+by reading code or running unit tests.
+```
+
+**Step 3: Commit**
+
+```bash
+jj describe -m "feat: add testing infrastructure assessment to architect workflow"
+jj new
+```
+
+---
+
+### Task 8: Update planner workflow — Independent
+
+**Files:**
+- Modify: `.opencode/skills/legion-worker/workflows/plan.md`
+
+**Step 1: Add Testing Plan section**
+
+After the "Parallelism Annotation" section (line 146), add:
+
+```markdown
+#### Testing Plan
+
+After creating executable tasks, add a **Testing Plan** section to the plan.
+The tester agent will use this to verify the implementation works end-to-end.
+
+**Required sections:**
+
+```
+## Testing Plan
+
+### Setup
+- [Concrete commands to boot the environment]
+- [e.g., `bun install && bun run dev`, `docker-compose up -d`]
+
+### Health Check
+- [How to verify the environment is ready]
+- [e.g., `curl -s http://localhost:3000/health` returns 200]
+
+### Verification Steps
+For each acceptance criterion:
+1. **[Criterion name]**
+   - Action: [What to do — navigate to URL, run command, etc.]
+   - Expected: [What should happen — page shows X, API returns Y]
+   - Tool: [Playwright / curl / CLI]
+
+### Tools Needed
+- [List of tools the tester should use]
+- [e.g., Playwright for browser, curl for API, CLI for commands]
+```
+
+**Guidelines:**
+- Setup commands must be copy-pasteable — no placeholders the tester would
+  need to figure out
+- Health checks should have a timeout (e.g., "retry for 30s")
+- Verification steps should be specific enough that a fresh agent with no
+  implementation context can follow them
+- If infrastructure doesn't exist yet (architect flagged gaps), note what
+  the implementer needs to create
+```
+
+**Step 2: Commit**
+
+```bash
+jj describe -m "feat: add testing plan section to planner workflow"
+jj new
+```
+
+---
+
+### Task 9: Update implementer workflow — Independent
+
+**Files:**
+- Modify: `.opencode/skills/legion-worker/workflows/implement.md`
+
+**Step 1: Add documentation requirement to Pre-Ship Verification**
+
+After the Pre-Ship Verification section (line 77), before Cross-Family Review, add:
+
+```markdown
+### 4.5. Documentation
+
+For any user-facing behavior change, update relevant documentation before
+creating the PR:
+
+- **README** — if the feature changes setup, usage, or configuration
+- **Usage guides** — if the feature adds new user-facing functionality
+- **API docs** — if the feature changes or adds API endpoints
+- **Inline help** — if the feature adds CLI commands or options
+
+Documentation should explain **how to use** the feature, not just what changed
+in the code. A user reading only the docs should be able to understand and
+use the new functionality.
+
+Skip this step if the change is purely internal (refactoring, bug fix with
+no behavior change, test-only changes).
+```
+
+**Step 2: Change exit behavior to add worker-done**
+
+In "7. Exit" (line 148), change from:
+
+```markdown
+Exit without adding labels. The controller handles state transitions explicitly.
+```
+
+To:
+
+```markdown
+Add `worker-done` label, then remove `worker-active` label. The controller
+uses `worker-done` to trigger the transition to the Testing phase.
+
+**GitHub:**
+```
+gh issue edit $ISSUE_NUMBER --add-label "worker-done" --remove-label "worker-active" -R $OWNER/$REPO
+```
+
+**Linear:**
+```
+issue = linear_linear(action="get", id=$LEGION_ISSUE_ID)
+current_labels = [l.name for l in issue.labels if l.name != "worker-active"]
+linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "worker-done"])
+```
+```
+
+**Step 3: Update the Mode Routing table reference**
+
+In the worker SKILL.md, the implement mode says "Adds `worker-done`: No". This was updated in Task 6, but double-check that the routing table now says "Yes" for implement mode.
+
+**Step 4: Commit**
+
+```bash
+jj describe -m "feat: add docs requirement and worker-done signal to implementer"
+jj new
+```
+
+---
+
+### Task 10: Update controller skill — Depends on: Task 1
+
+**Files:**
+- Modify: `.opencode/skills/legion-controller/SKILL.md`
+
+**Step 1: Update Implement → Review Handoff section**
+
+Replace the "Implement → Review Handoff" section (line 136) with:
+
+```markdown
+### Implement → Testing → Review Handoff
+
+The implementer now adds `worker-done` when finished:
+1. Implementer opens a **draft PR**, adds `worker-done`, and exits
+2. State machine sees: In Progress + `worker-done` → `transition_to_testing`
+3. Controller transitions issue to Testing status
+4. Controller runs the quality gate (below)
+5. If quality gate passes: dispatch tester
+6. If quality gate fails: move back to In Progress, dispatch fresh implementer
+
+After the tester runs:
+- **Test passed** (`test-passed` label): Controller transitions to Needs Review,
+  dispatches reviewer (no additional quality gate needed — already verified)
+- **Test failed** (`test-failed` label): Controller removes test labels and
+  `worker-done`, transitions back to In Progress, resumes implementer session
+  with the test failure report from the PR comment
+```
+
+**Step 2: Update Quality Gate section**
+
+Update "When to run" (line 148):
+
+```markdown
+**When to run:** Whenever about to execute a `dispatch_tester` action.
+```
+
+**Step 3: Add test-specific labels**
+
+Add to the Labels table (line 340):
+
+```markdown
+| `test-passed` | Tester verified behavior, controller advances |
+| `test-failed` | Tester found issues, controller returns to implementer |
+```
+
+**Step 4: Update Status Flow diagram**
+
+Replace the status flow (line 378):
+
+```markdown
+```
+Triage ─┬─► Icebox ─► Backlog ─► Todo ─► In Progress ─► Testing ─► Needs Review ─► Retro ─► Done
+        ├─► Backlog ──────────────┘           │                         │
+        └─► Todo ─────────────────────────────┴─────────────────────────┘
+```
+```
+
+**Step 5: Update routing table**
+
+The existing prefix-based routing table (line 108) automatically handles new action types. Verify that `dispatch_tester` matches `dispatch_` prefix and `transition_to_testing` matches `transition_to_` prefix. No changes needed if the naming convention is followed.
+
+Add a note after the routing table:
+
+```markdown
+**Test failure handling:** When `resume_implementer_for_test_failure` is suggested:
+1. Remove `worker-done`, `test-failed` labels
+2. Read the tester's PR comment for the failure report
+3. Resume the implementer session with the failure details
+```
+
+**Step 6: Commit**
+
+```bash
+jj describe -m "feat: update controller for Testing status routing"
+jj new
+```
+
+---
+
+### Task 11: Update AGENTS.md and documentation — Depends on: Task 5, Task 6
+
+**Files:**
+- Modify: `.opencode/skills/AGENTS.md`
+- Modify: `AGENTS.md` (root)
+
+**Step 1: Update skills AGENTS.md**
+
+In the Structure section, add `test.md` to the workflows list:
+
+```markdown
+    │   ├── test.md        # Behavioral testing against running infrastructure
+```
+
+Update the Worker Lifecycle section to include the test phase.
+
+**Step 2: Update root AGENTS.md**
+
+Update the Issue Lifecycle diagram:
+
+```markdown
+Triage ──┬──► Icebox ──► Backlog ──► Todo ──► In Progress ──► Testing ──► Needs Review ──► Retro ──► Done
+```
+
+Update "Worker modes" to include: `architect → plan → implement → test → review → merge`
+
+Update the Labels table to include `test-passed` and `test-failed`.
+
+**Step 3: Commit**
+
+```bash
+jj describe -m "docs: update AGENTS.md for behavioral testing gate"
+jj new
+```
+
+---
+
+### Task 12: Final verification — Depends on: Task 1, Task 2, Task 3, Task 4
+
+**Step 1: Run full test suite**
+
+Run: `bun test`
+Expected: ALL PASS
+
+**Step 2: Type check**
+
+Run: `bunx tsc --noEmit`
+Expected: NO ERRORS
+
+**Step 3: Lint**
+
+Run: `bunx biome check packages/daemon/src/`
+Expected: NO ERRORS
+
+**Step 4: Verify test count increased**
+
+Run: `bun test 2>&1 | tail -5`
+Expected: Test count should be higher than baseline (was 172)
+
+**Step 5: Commit (if any fixes needed)**
+
+```bash
+jj describe -m "fix: address lint/type issues from testing gate implementation"
+jj new
+```

--- a/docs/solutions/integration-issues/external-repo-pr-auto-transition-gap.md
+++ b/docs/solutions/integration-issues/external-repo-pr-auto-transition-gap.md
@@ -20,6 +20,8 @@ symptoms:
 date_solved: 2026-02-15
 ---
 
+[HISTORICAL] The implement workflow now uses explicit `worker-done` signaling instead of relying on auto-transition. This issue is largely resolved by the behavioral testing gate, though the detection pattern remains relevant for external repos.
+
 # External Repo PRs Don't Auto-Transition Linear Issues
 
 ## Problem

--- a/docs/solutions/integration-patterns/controller-worker-protocol.md
+++ b/docs/solutions/integration-patterns/controller-worker-protocol.md
@@ -45,21 +45,23 @@ The daemon computes deterministic session IDs: `computeSessionId(teamId, issueId
 - Session resumption after process restarts (sessions persist in SQLite)
 - `initializeSession` handles 409 Duplicate gracefully (session already exists = success)
 
-## Implement → Review Handoff
+## Implement → Testing → Review Handoff
 
-The implementer does NOT use `worker-done`. The flow is:
-1. Implementer opens a **draft PR** (branch and title contain issue ID)
-2. Linear's GitHub integration auto-transitions the issue to Needs Review
-3. State machine sees: Needs Review, no worker-done, no live worker → `dispatch_reviewer`
-4. Controller runs quality gate, then dispatches reviewer
+[HISTORICAL] This section predates the behavioral testing gate. The current flow is:
 
-This is the only handoff that relies on a side-channel (Linear's GitHub integration) rather than explicit label signaling.
+1. Implementer opens a **draft PR**, adds `worker-done`, and exits
+2. State machine: In Progress + `worker-done` → `transition_to_testing`
+3. Controller runs quality gate, dispatches tester
+4. Tester passes → `transition_to_needs_review`
+5. Controller dispatches reviewer
 
-## Review → Implement Feedback Loop
+The implementer now uses explicit `worker-done` signaling instead of relying on Linear's auto-transition side-channel.
+
+## Review → Implement → Testing Feedback Loop
 
 The reviewer signals via PR draft status:
 - **PR ready** (not draft) = approved → controller transitions to Retro
-- **PR draft** = changes requested → controller resumes implementer for address-comments
+- **PR draft** = changes requested → controller transitions to In Progress, resumes implementer. Implementer's fixes go through the testing gate again before returning to review.
 
 The reviewer MUST post specific review comments on the PR when requesting changes. Converting to draft without comments leaves the implementer with nothing to address.
 

--- a/packages/daemon/src/__tests__/integration.test.ts
+++ b/packages/daemon/src/__tests__/integration.test.ts
@@ -148,6 +148,8 @@ describe("Integration: state pipeline", () => {
         hasUserInputNeeded: false,
         hasNeedsApproval: false,
         hasHumanApproved: false,
+        hasTestPassed: false,
+        hasTestFailed: false,
         source: null,
       },
       {
@@ -163,6 +165,8 @@ describe("Integration: state pipeline", () => {
         hasUserInputNeeded: false,
         hasNeedsApproval: false,
         hasHumanApproved: false,
+        hasTestPassed: false,
+        hasTestFailed: false,
         source: null,
       },
     ];

--- a/packages/daemon/src/state/AGENTS.md
+++ b/packages/daemon/src/state/AGENTS.md
@@ -14,7 +14,7 @@ POST /state/collect {backend, issues} → backend.parseIssues() → enrichParsed
 
 | File | Responsibility |
 |------|---------------|
-| `types.ts` | All domain types. `IssueStatus` (enum-like with `normalize()`), `WorkerMode`, `ActionType` (16 actions), `ParsedIssue`, `FetchedIssueData`, `IssueState`, `CollectedState`. Also `computeSessionId()` and `computeControllerSessionId()` — shared by daemon. |
+| `types.ts` | All domain types. `IssueStatus` (enum-like with `normalize()`), `WorkerMode`, `ActionType` (21 actions), `ParsedIssue`, `FetchedIssueData`, `IssueState`, `CollectedState`. Also `computeSessionId()` and `computeControllerSessionId()` — shared by daemon. |
 | `fetch.ts` | All I/O. `enrichParsedIssues()` enriches parsed issues with worker status + PR draft status. `fetchAllIssueData()` is the legacy wrapper that parses Linear JSON then enriches. `getLiveWorkers()` (daemon HTTP) + `getPrDraftStatusBatch()` (GitHub GraphQL with 3x retry). Accepts injectable `CommandRunner` for testing. |
 | `decision.ts` | Pure logic, zero I/O. `suggestAction(status, flags...)` → `ActionType`. `buildIssueState()` and `buildCollectedState()` assemble final output. `ACTION_TO_MODE` maps actions to worker modes. |
 | `cli.ts` | Legacy entry point for pipe invocation: `echo $JSON | bun run packages/daemon/src/state/cli.ts --team-id X --daemon-url Y`. Reads stdin, calls fetch + decision, writes JSON to stdout. Superseded by `POST /state/collect`. |
@@ -24,16 +24,21 @@ POST /state/collect {backend, issues} → backend.parseIssues() → enrichParsed
 
 The core of the controller's decision-making. Key transitions:
 
-| Status | worker-done? | live worker? | PR state | → Action |
-|--------|-------------|-------------|----------|----------|
-| Backlog | yes | — | — | `transition_to_todo` |
-| Todo | no | no | — | `dispatch_planner` |
-| In Progress | yes | — | — | `transition_to_needs_review` |
-| Needs Review | yes | — | ready | `transition_to_retro` |
-| Needs Review | yes | — | draft | `resume_implementer_for_changes` |
-| Needs Review | yes | — | no PR | `investigate_no_pr` |
-| Retro | yes | — | — | `dispatch_merger` |
-| Any | — | yes | — | `skip` (worker already running) |
+| Status | worker-done? | live worker? | PR state | test labels | → Action |
+|--------|-------------|-------------|----------|-------------|----------|
+| Backlog | yes | — | — | — | `transition_to_todo` |
+| Todo | no | no | — | — | `dispatch_planner` |
+| In Progress | yes | — | — | — | `transition_to_testing` |
+| Testing | no | no | — | — | `dispatch_tester` |
+| Testing | yes | — | — | test-passed | `transition_to_needs_review` |
+| Testing | yes | — | — | !test-passed | `resume_implementer_for_test_failure` |
+| Needs Review | yes | — | ready | — | `transition_to_retro` |
+| Needs Review | yes | — | draft | — | `resume_implementer_for_changes` |
+| Needs Review | yes | — | no PR | — | `investigate_no_pr` |
+| Retro | yes | — | — | — | `dispatch_merger` |
+| Any | — | yes | — | — | `skip` (worker already running) |
+
+**Note:** The state machine only checks `hasTestPassed` (presence of `test-passed` label). `hasTestFailed`/`test-failed` is computed and wired but not used in decision logic — it exists for human visibility and controller label cleanup. `worker-done` without `test-passed` is treated as failure regardless of whether `test-failed` is present.
 
 ## Anti-Patterns
 

--- a/packages/daemon/src/state/__tests__/decision-regressions.test.ts
+++ b/packages/daemon/src/state/__tests__/decision-regressions.test.ts
@@ -17,6 +17,8 @@ describe("decision regressions (known pipeline stalls)", () => {
       hasUserInputNeeded: false,
       hasNeedsApproval: false,
       hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
       source: null,
     };
 
@@ -38,6 +40,8 @@ describe("decision regressions (known pipeline stalls)", () => {
       hasUserInputNeeded: false,
       hasNeedsApproval: false,
       hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
       source: null,
     };
 

--- a/packages/daemon/src/state/__tests__/decision.test.ts
+++ b/packages/daemon/src/state/__tests__/decision.test.ts
@@ -11,127 +11,148 @@ import { CollectedState, computeSessionId, type FetchedIssueData, IssueStatus } 
 
 describe("suggestAction", () => {
   it("todo_no_worker_done_no_live_worker dispatches planner", () => {
-    const action = suggestAction(IssueStatus.TODO, false, false, null, false);
+    const action = suggestAction(IssueStatus.TODO, false, false, null, false, false);
     expect(action).toBe("dispatch_planner");
   });
 
   it("todo_worker_done transitions to in progress", () => {
-    const action = suggestAction(IssueStatus.TODO, true, false, null, false);
+    const action = suggestAction(IssueStatus.TODO, true, false, null, false, false);
     expect(action).toBe("transition_to_in_progress");
   });
 
   it("in_progress_no_worker_no_done dispatches implementer", () => {
-    const action = suggestAction(IssueStatus.IN_PROGRESS, false, false, null, false);
+    const action = suggestAction(IssueStatus.IN_PROGRESS, false, false, null, false, false);
     expect(action).toBe("dispatch_implementer");
   });
 
-  it("in_progress_worker_done transitions to needs review", () => {
-    const action = suggestAction(IssueStatus.IN_PROGRESS, true, false, null, false);
-    expect(action).toBe("transition_to_needs_review");
+  it("in_progress_worker_done transitions to testing", () => {
+    const action = suggestAction(IssueStatus.IN_PROGRESS, true, false, null, false, false);
+    expect(action).toBe("transition_to_testing");
   });
 
   it("in_progress_with_live_worker skips", () => {
-    const action = suggestAction(IssueStatus.IN_PROGRESS, false, true, null, false);
+    const action = suggestAction(IssueStatus.IN_PROGRESS, false, true, null, false, false);
     expect(action).toBe("skip");
   });
 
   it("needs_review_approved transitions to retro", () => {
-    const action = suggestAction(IssueStatus.NEEDS_REVIEW, true, false, false, true);
+    const action = suggestAction(IssueStatus.NEEDS_REVIEW, true, false, false, true, false);
     expect(action).toBe("transition_to_retro");
   });
 
   it("needs_review_changes_requested resumes implementer", () => {
-    const action = suggestAction(IssueStatus.NEEDS_REVIEW, true, false, true, true);
+    const action = suggestAction(IssueStatus.NEEDS_REVIEW, true, false, true, true, false);
     expect(action).toBe("resume_implementer_for_changes");
   });
 
   it("needs_review_worker_done_has_pr_but_unknown_status retries pr check", () => {
-    const action = suggestAction(IssueStatus.NEEDS_REVIEW, true, false, null, true);
+    const action = suggestAction(IssueStatus.NEEDS_REVIEW, true, false, null, true, false);
     expect(action).toBe("retry_pr_check");
   });
 
   it("needs_review_worker_done_no_pr investigates", () => {
-    const action = suggestAction(IssueStatus.NEEDS_REVIEW, true, false, null, false);
+    const action = suggestAction(IssueStatus.NEEDS_REVIEW, true, false, null, false, false);
     expect(action).toBe("investigate_no_pr");
   });
 
   it("needs_review_no_worker_done dispatches reviewer", () => {
-    const action = suggestAction(IssueStatus.NEEDS_REVIEW, false, false, null, false);
+    const action = suggestAction(IssueStatus.NEEDS_REVIEW, false, false, null, false, false);
     expect(action).toBe("dispatch_reviewer");
   });
 
   it("needs_review_with_live_worker_no_done skips", () => {
-    const action = suggestAction(IssueStatus.NEEDS_REVIEW, false, true, null, false);
+    const action = suggestAction(IssueStatus.NEEDS_REVIEW, false, true, null, false, false);
     expect(action).toBe("skip");
   });
 
   it("needs_review_worker_done_ignores_live_worker", () => {
-    const action = suggestAction(IssueStatus.NEEDS_REVIEW, true, true, false, true);
+    const action = suggestAction(IssueStatus.NEEDS_REVIEW, true, true, false, true, false);
     expect(action).toBe("transition_to_retro");
   });
 
   it("backlog_no_worker_done dispatches architect", () => {
-    const action = suggestAction(IssueStatus.BACKLOG, false, false, null, false);
+    const action = suggestAction(IssueStatus.BACKLOG, false, false, null, false, false);
     expect(action).toBe("dispatch_architect");
   });
 
   it("backlog_worker_done transitions to todo", () => {
     // suggestAction still returns transition_to_todo;
     // buildIssueState converts it to add_needs_approval
-    const action = suggestAction(IssueStatus.BACKLOG, true, false, null, false);
+    const action = suggestAction(IssueStatus.BACKLOG, true, false, null, false, false);
     expect(action).toBe("transition_to_todo");
   });
 
   it("backlog_with_live_worker skips", () => {
-    const action = suggestAction(IssueStatus.BACKLOG, false, true, null, false);
+    const action = suggestAction(IssueStatus.BACKLOG, false, true, null, false, false);
     expect(action).toBe("skip");
   });
 
   it("triage_skips", () => {
-    const action = suggestAction(IssueStatus.TRIAGE, false, false, null, false);
+    const action = suggestAction(IssueStatus.TRIAGE, false, false, null, false, false);
     expect(action).toBe("skip");
   });
 
   it("icebox_skips", () => {
-    const action = suggestAction(IssueStatus.ICEBOX, false, false, null, false);
+    const action = suggestAction(IssueStatus.ICEBOX, false, false, null, false, false);
     expect(action).toBe("skip");
   });
 
   it("retro_worker_done dispatches merger", () => {
-    const action = suggestAction(IssueStatus.RETRO, true, false, null, false);
+    const action = suggestAction(IssueStatus.RETRO, true, false, null, false, false);
     expect(action).toBe("dispatch_merger");
   });
 
   it("retro_without_live_worker_dispatches_implementer_for_retro", () => {
-    const action = suggestAction(IssueStatus.RETRO, false, false, null, false);
+    const action = suggestAction(IssueStatus.RETRO, false, false, null, false, false);
     expect(action).toBe("dispatch_implementer_for_retro");
   });
 
   it("retro_with_live_worker resumes implementer", () => {
-    const action = suggestAction(IssueStatus.RETRO, false, true, null, false);
+    const action = suggestAction(IssueStatus.RETRO, false, true, null, false, false);
     expect(action).toBe("resume_implementer_for_retro");
   });
 
   it("retry_pr_check_is_distinct_from_skip", () => {
-    const retry = suggestAction(IssueStatus.NEEDS_REVIEW, true, false, null, true);
-    const skip = suggestAction(IssueStatus.DONE, false, false, null, false);
+    const retry = suggestAction(IssueStatus.NEEDS_REVIEW, true, false, null, true, false);
+    const skip = suggestAction(IssueStatus.DONE, false, false, null, false, false);
     expect(retry).toBe("retry_pr_check");
     expect(skip).toBe("skip");
     expect(retry).not.toBe(skip);
   });
 
   it("in_progress_has_pr_no_worker_done_no_live_worker_skips", () => {
-    const action = suggestAction(IssueStatus.IN_PROGRESS, false, false, null, true);
+    const action = suggestAction(IssueStatus.IN_PROGRESS, false, false, null, true, false);
     expect(action).toBe("skip");
   });
 
   it("done_always_skips", () => {
-    const action = suggestAction(IssueStatus.DONE, false, false, null, false);
+    const action = suggestAction(IssueStatus.DONE, false, false, null, false, false);
+    expect(action).toBe("skip");
+  });
+
+  // Testing status
+  it("testing_no_worker_done_no_live_worker_dispatches_tester", () => {
+    const action = suggestAction(IssueStatus.TESTING, false, false, null, false, false);
+    expect(action).toBe("dispatch_tester");
+  });
+
+  it("testing_worker_done_test_passed_transitions_to_needs_review", () => {
+    const action = suggestAction(IssueStatus.TESTING, true, false, null, true, true);
+    expect(action).toBe("transition_to_needs_review");
+  });
+
+  it("testing_worker_done_test_failed_resumes_implementer", () => {
+    const action = suggestAction(IssueStatus.TESTING, true, false, null, true, false);
+    expect(action).toBe("resume_implementer_for_test_failure");
+  });
+
+  it("testing_with_live_worker_skips", () => {
+    const action = suggestAction(IssueStatus.TESTING, false, true, null, false, false);
     expect(action).toBe("skip");
   });
 
   it("unknown_status_skips", () => {
-    const action = suggestAction("SomeUnknownStatus", false, false, null, false);
+    const action = suggestAction("SomeUnknownStatus", false, false, null, false, false);
     expect(action).toBe("skip");
   });
 });
@@ -151,6 +172,8 @@ describe("buildIssueState", () => {
       hasUserInputNeeded: false,
       hasNeedsApproval: false,
       hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
       source: null,
     };
 
@@ -172,6 +195,8 @@ describe("buildIssueState", () => {
       hasUserInputNeeded: true,
       hasNeedsApproval: false,
       hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
       source: null,
     };
 
@@ -193,6 +218,8 @@ describe("buildIssueState", () => {
       hasUserInputNeeded: true,
       hasNeedsApproval: false,
       hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
       source: null,
     };
 
@@ -214,6 +241,8 @@ describe("buildIssueState", () => {
       hasUserInputNeeded: true,
       hasNeedsApproval: false,
       hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
       source: null,
     };
 
@@ -236,13 +265,15 @@ describe("buildIssueState", () => {
       hasUserInputNeeded: false,
       hasNeedsApproval: false,
       hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
       source: null,
     };
 
     const state = buildIssueState(data, teamId);
 
-    expect(state.suggestedAction).toBe("transition_to_needs_review");
-    const expectedSessionId = computeSessionId(teamId, "ENG-21", "review");
+    expect(state.suggestedAction).toBe("transition_to_testing");
+    const expectedSessionId = computeSessionId(teamId, "ENG-21", "test");
     expect(state.sessionId).toBe(expectedSessionId);
   });
 
@@ -261,6 +292,8 @@ describe("buildIssueState", () => {
       hasUserInputNeeded: true,
       hasNeedsApproval: false,
       hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
       source: null,
     };
 
@@ -287,6 +320,8 @@ describe("buildIssueState", () => {
       hasUserInputNeeded: true,
       hasNeedsApproval: false,
       hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
       source: null,
     };
     const stateTodo = buildIssueState(dataTodo, teamId);
@@ -305,6 +340,8 @@ describe("buildIssueState", () => {
       hasUserInputNeeded: true,
       hasNeedsApproval: false,
       hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
       source: null,
     };
     const stateReview = buildIssueState(dataReview, teamId);
@@ -325,6 +362,8 @@ describe("buildIssueState", () => {
       hasUserInputNeeded: true,
       hasNeedsApproval: false,
       hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
       source: null,
     };
 
@@ -348,6 +387,8 @@ describe("approval gate", () => {
       hasUserInputNeeded: false,
       hasNeedsApproval: false,
       hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
       source: null,
     };
 
@@ -369,6 +410,8 @@ describe("approval gate", () => {
       hasUserInputNeeded: false,
       hasNeedsApproval: true,
       hasHumanApproved: true,
+      hasTestPassed: false,
+      hasTestFailed: false,
       source: null,
     };
 
@@ -390,6 +433,8 @@ describe("approval gate", () => {
       hasUserInputNeeded: false,
       hasNeedsApproval: true,
       hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
       source: null,
     };
 
@@ -413,6 +458,8 @@ describe("orphan detection", () => {
       hasUserInputNeeded: false,
       hasNeedsApproval: false,
       hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
       source: null,
     };
 
@@ -434,6 +481,8 @@ describe("orphan detection", () => {
       hasUserInputNeeded: false,
       hasNeedsApproval: false,
       hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
       source: null,
     };
 
@@ -455,6 +504,8 @@ describe("orphan detection", () => {
       hasUserInputNeeded: false,
       hasNeedsApproval: false,
       hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
       source: null,
     };
 
@@ -479,6 +530,8 @@ describe("orphan detection", () => {
         hasUserInputNeeded: false,
         hasNeedsApproval: false,
         hasHumanApproved: false,
+        hasTestPassed: false,
+        hasTestFailed: false,
         source: null,
       };
 
@@ -501,6 +554,8 @@ describe("orphan detection", () => {
       hasUserInputNeeded: true,
       hasNeedsApproval: false,
       hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
       source: null,
     };
 
@@ -529,6 +584,8 @@ describe("buildCollectedState", () => {
         hasUserInputNeeded: false,
         hasNeedsApproval: false,
         hasHumanApproved: false,
+        hasTestPassed: false,
+        hasTestFailed: false,
         source: null,
       },
       {
@@ -544,6 +601,8 @@ describe("buildCollectedState", () => {
         hasUserInputNeeded: false,
         hasNeedsApproval: false,
         hasHumanApproved: false,
+        hasTestPassed: false,
+        hasTestFailed: false,
         source: null,
       },
     ];
@@ -553,7 +612,7 @@ describe("buildCollectedState", () => {
     expect("ENG-21" in state.issues).toBe(true);
     expect("ENG-22" in state.issues).toBe(true);
     expect(state.issues["ENG-21"].suggestedAction).toBe("dispatch_planner");
-    expect(state.issues["ENG-22"].suggestedAction).toBe("transition_to_needs_review");
+    expect(state.issues["ENG-22"].suggestedAction).toBe("transition_to_testing");
   });
 
   it("to_dict_serializes_correctly", () => {
@@ -571,6 +630,8 @@ describe("buildCollectedState", () => {
         hasUserInputNeeded: false,
         hasNeedsApproval: false,
         hasHumanApproved: false,
+        hasTestPassed: false,
+        hasTestFailed: false,
         source: null,
       },
     ];
@@ -599,6 +660,8 @@ describe("buildCollectedState", () => {
         hasUserInputNeeded: false,
         hasNeedsApproval: false,
         hasHumanApproved: false,
+        hasTestPassed: false,
+        hasTestFailed: false,
         source: null,
       },
       {
@@ -614,6 +677,8 @@ describe("buildCollectedState", () => {
         hasUserInputNeeded: true,
         hasNeedsApproval: false,
         hasHumanApproved: false,
+        hasTestPassed: false,
+        hasTestFailed: false,
         source: null,
       },
       {
@@ -629,6 +694,8 @@ describe("buildCollectedState", () => {
         hasUserInputNeeded: true,
         hasNeedsApproval: false,
         hasHumanApproved: false,
+        hasTestPassed: false,
+        hasTestFailed: false,
         source: null,
       },
     ];

--- a/packages/daemon/src/state/decision.ts
+++ b/packages/daemon/src/state/decision.ts
@@ -22,7 +22,8 @@ export function suggestAction(
   hasWorkerDone: boolean,
   hasLiveWorker: boolean,
   prIsDraft: boolean | null,
-  hasPr: boolean
+  hasPr: boolean,
+  hasTestPassed: boolean
 ): ActionType {
   switch (status) {
     case IssueStatus.DONE:
@@ -52,7 +53,7 @@ export function suggestAction(
 
     case IssueStatus.IN_PROGRESS:
       if (hasWorkerDone) {
-        return "transition_to_needs_review";
+        return "transition_to_testing";
       }
       if (hasPr && !hasLiveWorker) {
         return "skip";
@@ -61,6 +62,18 @@ export function suggestAction(
         return "skip";
       }
       return "dispatch_implementer";
+
+    case IssueStatus.TESTING:
+      if (hasWorkerDone) {
+        if (hasTestPassed) {
+          return "transition_to_needs_review";
+        }
+        return "resume_implementer_for_test_failure";
+      }
+      if (hasLiveWorker) {
+        return "skip";
+      }
+      return "dispatch_tester";
 
     case IssueStatus.NEEDS_REVIEW:
       if (hasWorkerDone) {
@@ -113,6 +126,9 @@ export const ACTION_TO_MODE: Record<ActionType, WorkerModeLiteral> = {
   remove_worker_active_and_redispatch: WorkerMode.IMPLEMENT,
   add_needs_approval: WorkerMode.PLAN,
   retry_pr_check: WorkerMode.REVIEW,
+  dispatch_tester: WorkerMode.TEST,
+  transition_to_testing: WorkerMode.TEST,
+  resume_implementer_for_test_failure: WorkerMode.IMPLEMENT,
 };
 
 export function buildIssueState(data: FetchedIssueData, teamId: string): IssueState {
@@ -134,7 +150,8 @@ export function buildIssueState(data: FetchedIssueData, teamId: string): IssueSt
       data.labels.includes("worker-done"),
       data.hasLiveWorker,
       data.prIsDraft,
-      data.hasPr
+      data.hasPr,
+      data.hasTestPassed ?? false
     );
     if (action === "transition_to_todo") {
       action = "add_needs_approval";

--- a/packages/daemon/src/state/fetch.ts
+++ b/packages/daemon/src/state/fetch.ts
@@ -335,6 +335,8 @@ export async function enrichParsedIssues(
       hasUserInputNeeded: issue.hasUserInputNeeded,
       hasNeedsApproval: issue.hasNeedsApproval,
       hasHumanApproved: issue.hasHumanApproved,
+      hasTestPassed: issue.hasTestPassed,
+      hasTestFailed: issue.hasTestFailed,
       source: issue.source,
     };
   });

--- a/packages/daemon/src/state/types.ts
+++ b/packages/daemon/src/state/types.ts
@@ -25,6 +25,7 @@ export type IssueStatusLiteral =
   | "Backlog"
   | "Todo"
   | "In Progress"
+  | "Testing"
   | "Needs Review"
   | "Retro"
   | "Done";
@@ -32,7 +33,7 @@ export type IssueStatusLiteral =
 /**
  * Worker mode values for session ID computation.
  */
-export type WorkerModeLiteral = "architect" | "plan" | "implement" | "review" | "merge";
+export type WorkerModeLiteral = "architect" | "plan" | "implement" | "test" | "review" | "merge";
 
 /**
  * Action types for state machine transitions.
@@ -44,6 +45,9 @@ export type ActionType =
   | "dispatch_planner"
   | "dispatch_implementer"
   | "dispatch_implementer_for_retro"
+  | "dispatch_tester"
+  | "transition_to_testing"
+  | "resume_implementer_for_test_failure"
   | "dispatch_reviewer"
   | "dispatch_merger"
   | "resume_implementer_for_changes"
@@ -66,6 +70,7 @@ export const IssueStatus = {
   BACKLOG: "Backlog" as IssueStatusLiteral,
   TODO: "Todo" as IssueStatusLiteral,
   IN_PROGRESS: "In Progress" as IssueStatusLiteral,
+  TESTING: "Testing" as IssueStatusLiteral,
   NEEDS_REVIEW: "Needs Review" as IssueStatusLiteral,
   RETRO: "Retro" as IssueStatusLiteral,
   DONE: "Done" as IssueStatusLiteral,
@@ -126,6 +131,7 @@ const _lowercaseCanonicalMap = new Map<string, IssueStatusLiteral>([
   ["backlog", "Backlog"],
   ["todo", "Todo"],
   ["in progress", "In Progress"],
+  ["testing", "Testing"],
   ["needs review", "Needs Review"],
   ["retro", "Retro"],
   ["done", "Done"],
@@ -142,6 +148,7 @@ export const WorkerMode = {
   ARCHITECT: "architect" as WorkerModeLiteral,
   PLAN: "plan" as WorkerModeLiteral,
   IMPLEMENT: "implement" as WorkerModeLiteral,
+  TEST: "test" as WorkerModeLiteral,
   REVIEW: "review" as WorkerModeLiteral,
   MERGE: "merge" as WorkerModeLiteral,
 } as const;
@@ -232,6 +239,8 @@ export interface ParsedIssue {
   readonly hasWorkerActive: boolean;
   readonly hasNeedsApproval: boolean;
   readonly hasHumanApproved: boolean;
+  readonly hasTestPassed: boolean;
+  readonly hasTestFailed: boolean;
   readonly hasPr: boolean;
   readonly needsPrStatus: boolean;
 }
@@ -277,6 +286,14 @@ export function createParsedIssue(
       return this.labels.includes("human-approved");
     },
 
+    get hasTestPassed() {
+      return this.labels.includes("test-passed");
+    },
+
+    get hasTestFailed() {
+      return this.labels.includes("test-failed");
+    },
+
     get hasPr() {
       return this.prRef !== null;
     },
@@ -307,6 +324,8 @@ export interface FetchedIssueData {
   hasUserInputNeeded: boolean;
   hasNeedsApproval: boolean;
   hasHumanApproved: boolean;
+  hasTestPassed: boolean;
+  hasTestFailed: boolean;
   source: IssueSource | null; // Canonical identity for GitHub issues, null for Linear
 }
 


### PR DESCRIPTION
## Summary

Adds a mandatory behavioral testing phase (`Testing`) to the Legion worker pipeline between `implement` and `review`. A fresh agent boots the application and verifies user-facing behavior against running infrastructure before code review begins.

Closes #63 (behavioral testing recommendation from retro)
Supersedes #25 (E2E capability set — testing is now a mandatory gate, not opt-in)

## What changed

### State machine (TypeScript)
- **New status:** `Testing` between `In Progress` and `Needs Review`
- **New mode:** `test` (6th worker mode)
- **New actions:** `dispatch_tester`, `transition_to_testing`, `resume_implementer_for_test_failure`
- `In Progress + worker-done` now transitions to `Testing` (was `Needs Review`)
- 4 new tests, 3 updated expectations (48 total in decision tests, 640 total)

### Upstream workflow changes
- **Architect:** Testing infrastructure assessment — flags gaps before planning
- **Planner:** Testing plan section — setup commands, health checks, verification steps
- **Implementer:** Documentation requirement for user-facing changes + explicit `worker-done` signal on exit (both fresh and address-comments modes)

### Tester workflow (new)
7-step workflow: fetch context → spec compliance check (reuses `/superpowers/subagent-driven-development` spec-reviewer) → read docs → boot environment → execute acceptance criteria → post results to PR → signal pass/fail via labels

### Controller updates
- `transition_to_testing` routing with quality gate
- Review-changes loop: fixes go through testing again before re-review
- Label cleanup: `test-passed` and `worker-done` removed on pass path; `test-failed` and `worker-done` on fail path

### Documentation
- Design doc: `docs/plans/2026-02-28-behavioral-testing-gate-design.md`
- Implementation plan: `docs/plans/2026-02-28-behavioral-testing-gate-impl.md`
- Updated: root `AGENTS.md`, skills `AGENTS.md`, state `AGENTS.md`, controller-worker-protocol solution doc

## Pipeline flow

```
architect → plan → implement → test → review → (implement → test if changes requested) → retro → merge
```

## Testing

- 640 tests pass, 0 failures
- All existing tests updated for new transitions
- 4 new tests for Testing status (dispatch, pass, fail, skip)