### PR TITLE
fix: use UUID session IDs for Claude Code runtime

### DIFF
--- a/packages/daemon/src/daemon/__tests__/config.test.ts
+++ b/packages/daemon/src/daemon/__tests__/config.test.ts
@@ -48,7 +48,24 @@ describe("daemon config", () => {
   it("throws when controllerSessionId has invalid format", () => {
     expect(() => {
       loadConfig({ LEGION_CONTROLLER_SESSION_ID: "bad_value" });
-    }).toThrow("LEGION_CONTROLLER_SESSION_ID must start with 'ses_' (got: bad_value)");
+    }).toThrow("LEGION_CONTROLLER_SESSION_ID must be ses_ (got: bad_value)");
+  });
+
+  it("accepts UUID controllerSessionId when runtime is claude-code", () => {
+    const config = loadConfig({
+      LEGION_RUNTIME: "claude-code",
+      LEGION_CONTROLLER_SESSION_ID: "123e4567-e89b-12d3-a456-426614174000",
+    });
+    expect(config.controllerSessionId).toBe("123e4567-e89b-12d3-a456-426614174000");
+  });
+
+  it("rejects non-UUID controllerSessionId when runtime is claude-code", () => {
+    expect(() => {
+      loadConfig({
+        LEGION_RUNTIME: "claude-code",
+        LEGION_CONTROLLER_SESSION_ID: "ses_abc123",
+      });
+    }).toThrow("LEGION_CONTROLLER_SESSION_ID must be a valid UUID");
   });
 
   describe("issueBackend", () => {

--- a/packages/daemon/src/daemon/config.ts
+++ b/packages/daemon/src/daemon/config.ts
@@ -1,5 +1,6 @@
 import os from "node:os";
 import path from "node:path";
+import type { SessionIdFormat } from "../state/types";
 
 export interface DaemonConfig {
   daemonPort: number;
@@ -35,6 +36,15 @@ function resolveStateFilePath(legionDir?: string): string {
   return path.join(baseDir, ".legion", "daemon", "workers.json");
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+function isValidUuid(s: string): boolean {
+  return UUID_RE.test(s);
+}
+
+export function runtimeToSessionFormat(runtime: "opencode" | "claude-code"): SessionIdFormat {
+  return runtime === "claude-code" ? "uuid" : "opencode";
+}
+
 export function validateControllerPrompt(prompt: string | undefined): void {
   if (!prompt) {
     return;
@@ -66,10 +76,20 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): DaemonConfig {
   const controllerSessionId = env.LEGION_CONTROLLER_SESSION_ID || undefined;
   const controllerPrompt = env.LEGION_CONTROLLER_PROMPT || undefined;
 
-  if (controllerSessionId && !controllerSessionId.startsWith("ses_")) {
-    throw new Error(
-      `LEGION_CONTROLLER_SESSION_ID must start with 'ses_' (got: ${controllerSessionId})`
-    );
+  const rawRuntime = env.LEGION_RUNTIME;
+  if (rawRuntime !== undefined && rawRuntime !== "opencode" && rawRuntime !== "claude-code") {
+    throw new Error(`LEGION_RUNTIME must be 'opencode' or 'claude-code' (got: ${rawRuntime})`);
+  }
+  const runtime = rawRuntime === "claude-code" ? "claude-code" : "opencode";
+
+  if (controllerSessionId) {
+    const validPrefix = runtime === "claude-code" ? isValidUuid(controllerSessionId) : controllerSessionId.startsWith("ses_");
+    if (!validPrefix) {
+      const expected = runtime === "claude-code" ? "a valid UUID" : "ses_";
+      throw new Error(
+        `LEGION_CONTROLLER_SESSION_ID must be ${expected} (got: ${controllerSessionId})`
+      );
+    }
   }
 
   validateControllerPrompt(controllerPrompt);
@@ -80,11 +100,6 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): DaemonConfig {
   }
   const issueBackend = rawBackend === "github" ? "github" : "linear";
 
-  const rawRuntime = env.LEGION_RUNTIME;
-  if (rawRuntime !== undefined && rawRuntime !== "opencode" && rawRuntime !== "claude-code") {
-    throw new Error(`LEGION_RUNTIME must be 'opencode' or 'claude-code' (got: ${rawRuntime})`);
-  }
-  const runtime = rawRuntime === "claude-code" ? "claude-code" : "opencode";
   return {
     daemonPort: parseNumber(env.LEGION_DAEMON_PORT, DEFAULT_DAEMON_PORT),
     teamId: env.LEGION_TEAM_ID,

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -1,6 +1,6 @@
 import { mkdirSync } from "node:fs";
 import { computeControllerSessionId } from "../state/types";
-import { type DaemonConfig, loadConfig, validateControllerPrompt } from "./config";
+import { type DaemonConfig, loadConfig, runtimeToSessionFormat, validateControllerPrompt } from "./config";
 import { createAdapter } from "./runtime";
 import type { RuntimeAdapter } from "./runtime/types";
 import { startServer } from "./server";
@@ -187,7 +187,7 @@ export async function startDaemon(
     if (!teamId) {
       throw new Error("LEGION_TEAM_ID is required when no external controller session ID is set");
     }
-    const requestedSessionId = computeControllerSessionId(teamId);
+    const requestedSessionId = computeControllerSessionId(teamId, runtimeToSessionFormat(config.runtime));
     let actualSessionId: string | undefined;
     try {
       actualSessionId = await resolvedDeps.adapter.createSession(

--- a/packages/daemon/src/daemon/runtime/__tests__/claude-code.test.ts
+++ b/packages/daemon/src/daemon/runtime/__tests__/claude-code.test.ts
@@ -130,7 +130,7 @@ describe("ClaudeCodeAdapter", () => {
   });
 
   describe("sendPrompt", () => {
-    it("launches fresh claude when no process running (none)", async () => {
+    it("tries --resume then falls back to --session-id when no process running (none)", async () => {
       const { spawn, calls } = makeSpawn({
         pane_current_command: { exitCode: 1, stdout: "" },
       });
@@ -142,6 +142,8 @@ describe("ClaudeCodeAdapter", () => {
       );
       expect(sendKeysCall).toBeDefined();
       const cmdArg = sendKeysCall?.find((a) => a.includes("claude"));
+      // Should try --resume first, fall back to --session-id
+      expect(cmdArg).toContain("--resume");
       expect(cmdArg).toContain("--session-id");
       expect(cmdArg).toContain("ses_1");
       expect(cmdArg).toContain("--dangerously-skip-permissions");
@@ -243,6 +245,7 @@ describe("ClaudeCodeAdapter", () => {
       expect(sendKeysCall).toBeDefined();
       const cmdArg = sendKeysCall?.find((a) => a.includes("claude"));
       expect(cmdArg).toContain("hello'\\''");
+      // The || separates resume from new-session fallback, not a shell injection
       expect(cmdArg).not.toMatch(/hello';/);
     });
 

--- a/packages/daemon/src/daemon/runtime/claude-code.ts
+++ b/packages/daemon/src/daemon/runtime/claude-code.ts
@@ -108,7 +108,11 @@ export class ClaudeCodeAdapter implements RuntimeAdapter {
       const cmd = `claude --resume '${shellEscape(sessionId)}' -p '${shellEscape(text)}' --dangerously-skip-permissions`;
       result = this.spawn(["tmux", "send-keys", "-t", windowTarget, cmd, "Enter"]);
     } else {
-      const cmd = `claude -p '${shellEscape(text)}' --session-id '${shellEscape(sessionId)}' --dangerously-skip-permissions`;
+      // Try --resume first (handles daemon restart when session exists in Claude's store),
+      // fall back to --session-id for truly new sessions.
+      const resumeCmd = `claude --resume '${shellEscape(sessionId)}' -p '${shellEscape(text)}' --dangerously-skip-permissions`;
+      const newCmd = `claude -p '${shellEscape(text)}' --session-id '${shellEscape(sessionId)}' --dangerously-skip-permissions`;
+      const cmd = `${resumeCmd} || ${newCmd}`;
       result = this.spawn(["tmux", "send-keys", "-t", windowTarget, cmd, "Enter"]);
     }
     if (result.exitCode !== 0) {

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -5,9 +5,11 @@ import { enrichParsedIssues } from "../state/fetch";
 import {
   CollectedState,
   computeSessionId,
+  type SessionIdFormat,
   WorkerMode,
   type WorkerModeLiteral,
 } from "../state/types";
+import { runtimeToSessionFormat } from "./config";
 import type { RuntimeAdapter } from "./runtime/types";
 import type { WorkerEntry } from "./serve-manager";
 import {
@@ -202,7 +204,8 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
               }
             }
 
-            const sessionId = computeSessionId(opts.teamId, issueId, mode as WorkerModeLiteral);
+            const sessionFormat = runtimeToSessionFormat((opts.runtime as "opencode" | "claude-code") ?? "opencode");
+            const sessionId = computeSessionId(opts.teamId, issueId, mode as WorkerModeLiteral, sessionFormat);
 
             let actualSessionId = sessionId;
             try {
@@ -382,7 +385,8 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
             const parsed = tracker.parseIssues(issues);
             const daemonUrl = `http://127.0.0.1:${server.port}`;
             const issuesData = await enrichParsedIssues(parsed, daemonUrl);
-            const state = buildCollectedState(issuesData, opts.teamId);
+            const collectFormat = runtimeToSessionFormat((opts.runtime as "opencode" | "claude-code") ?? "opencode");
+            const state = buildCollectedState(issuesData, opts.teamId, collectFormat);
             return jsonResponse(CollectedState.toDict(state));
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);

--- a/packages/daemon/src/state/__tests__/types.test.ts
+++ b/packages/daemon/src/state/__tests__/types.test.ts
@@ -127,6 +127,50 @@ describe("computeControllerSessionId with non-UUID team ID", () => {
   });
 });
 
+describe("computeSessionId with uuid format (Claude Code)", () => {
+  const teamId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+  it("returns raw UUID when format is uuid", () => {
+    const result = computeSessionId(teamId, "ENG-21", "implement", "uuid");
+    expect(result).toMatch(UUID_RE);
+  });
+
+  it("is deterministic", () => {
+    const r1 = computeSessionId(teamId, "ENG-21", "implement", "uuid");
+    const r2 = computeSessionId(teamId, "ENG-21", "implement", "uuid");
+    expect(r1).toBe(r2);
+  });
+
+  it("differs from opencode format for same inputs", () => {
+    const uuid = computeSessionId(teamId, "ENG-21", "implement", "uuid");
+    const ses = computeSessionId(teamId, "ENG-21", "implement", "opencode");
+    expect(uuid).not.toBe(ses);
+  });
+
+  it("different issues produce different UUIDs", () => {
+    const r1 = computeSessionId(teamId, "ENG-21", "implement", "uuid");
+    const r2 = computeSessionId(teamId, "ENG-22", "implement", "uuid");
+    expect(r1).not.toBe(r2);
+  });
+});
+
+describe("computeControllerSessionId with uuid format (Claude Code)", () => {
+  const teamId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+  it("returns raw UUID when format is uuid", () => {
+    const result = computeControllerSessionId(teamId, "uuid");
+    expect(result).toMatch(UUID_RE);
+  });
+
+  it("is deterministic", () => {
+    const r1 = computeControllerSessionId(teamId, "uuid");
+    const r2 = computeControllerSessionId(teamId, "uuid");
+    expect(r1).toBe(r2);
+  });
+});
+
 describe("IssueStatus.normalize", () => {
   it("returns direct match unchanged", () => {
     expect(IssueStatus.normalize("Todo")).toBe("Todo");

--- a/packages/daemon/src/state/decision.ts
+++ b/packages/daemon/src/state/decision.ts
@@ -13,6 +13,7 @@ import {
   type IssueState,
   IssueStatus,
   type IssueStatusLiteral,
+  type SessionIdFormat,
   WorkerMode,
   type WorkerModeLiteral,
 } from "./types";
@@ -131,7 +132,11 @@ export const ACTION_TO_MODE: Record<ActionType, WorkerModeLiteral> = {
   resume_implementer_for_test_failure: WorkerMode.IMPLEMENT,
 };
 
-export function buildIssueState(data: FetchedIssueData, teamId: string): IssueState {
+export function buildIssueState(
+  data: FetchedIssueData,
+  teamId: string,
+  sessionFormat: SessionIdFormat = "opencode",
+): IssueState {
   let action: ActionType;
 
   if (data.hasUserInputNeeded && data.hasUserFeedback) {
@@ -159,7 +164,7 @@ export function buildIssueState(data: FetchedIssueData, teamId: string): IssueSt
   }
 
   const mode = ACTION_TO_MODE[action] ?? WorkerMode.IMPLEMENT;
-  const sessionId = computeSessionId(teamId, data.issueId, mode);
+  const sessionId = computeSessionId(teamId, data.issueId, mode, sessionFormat);
 
   return {
     status: data.status,
@@ -178,12 +183,13 @@ export function buildIssueState(data: FetchedIssueData, teamId: string): IssueSt
 
 export function buildCollectedState(
   issuesData: FetchedIssueData[],
-  teamId: string
+  teamId: string,
+  sessionFormat: SessionIdFormat = "opencode",
 ): CollectedState {
   const result: CollectedState = { issues: {} };
 
   for (const data of issuesData) {
-    result.issues[data.issueId] = buildIssueState(data, teamId);
+    result.issues[data.issueId] = buildIssueState(data, teamId, sessionFormat);
   }
 
   return result;

--- a/packages/daemon/src/state/types.ts
+++ b/packages/daemon/src/state/types.ts
@@ -457,33 +457,40 @@ function uuidToSessionId(uuid: string): string {
   return `ses_${hexPart}${base62Chars.join("")}`;
 }
 
+export type SessionIdFormat = "opencode" | "uuid";
+
 /**
  * Compute deterministic session ID for a worker.
- *
- * Session IDs match OpenCode's format: ses_ + 12 hex + 14 Base62.
- * Pattern: ^ses_[0-9a-f]{12}[0-9A-Za-z]{14}$
  *
  * @param teamId - Team identifier (UUID or arbitrary string)
  * @param issueId - Issue identifier (e.g., "ENG-21")
  * @param mode - Worker mode (e.g., "implement", "review")
- * @returns Session ID string matching OpenCode format
+ * @param format - "opencode" for ses_ prefix format, "uuid" for raw UUID (Claude Code)
+ * @returns Session ID string
  */
-export function computeSessionId(teamId: string, issueId: string, mode: WorkerModeLiteral): string {
+export function computeSessionId(
+  teamId: string,
+  issueId: string,
+  mode: WorkerModeLiteral,
+  format: SessionIdFormat = "opencode",
+): string {
   const namespace = teamIdToNamespace(teamId);
   const uuid = uuidv5(`${issueId.toLowerCase()}:${mode}`, namespace);
-  return uuidToSessionId(uuid);
+  return format === "uuid" ? uuid : uuidToSessionId(uuid);
 }
 
 /**
  * Compute deterministic session ID for controller.
  *
- * Session IDs match OpenCode's format: ses_ + 12 hex + 14 Base62.
- *
  * @param teamId - Team identifier (UUID or arbitrary string)
- * @returns Session ID string matching OpenCode format
+ * @param format - "opencode" for ses_ prefix format, "uuid" for raw UUID (Claude Code)
+ * @returns Session ID string
  */
-export function computeControllerSessionId(teamId: string): string {
+export function computeControllerSessionId(
+  teamId: string,
+  format: SessionIdFormat = "opencode",
+): string {
   const namespace = teamIdToNamespace(teamId);
   const uuid = uuidv5("controller", namespace);
-  return uuidToSessionId(uuid);
+  return format === "uuid" ? uuid : uuidToSessionId(uuid);
 }


### PR DESCRIPTION
## Summary
- Claude Code CLI requires raw UUIDs for `--session-id`, but `computeSessionId()` was always returning OpenCode's `ses_` format, causing "Invalid session ID" errors
- Added `SessionIdFormat` type (`"opencode" | "uuid"`) threaded through types → decision → server → index
- Made config validation runtime-aware (UUID for claude-code, ses_ for opencode)
- Fixed `sendPrompt` "none" case to try `--resume` first, falling back to `--session-id` for new sessions (handles daemon restart when session already exists in Claude's store)

## Test plan
- [x] All 648 tests pass
- [x] Type check clean (`tsc --noEmit`)
- [x] Biome lint clean
- [x] Manually tested: started legion with Claude Code runtime against PLT Linear team, controller session launched successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)