### PR TITLE
fix: update outdated Compound Engineering skill references to ce/ prefix

### DIFF
--- a/.opencode/skills/legion-worker/workflows/plan.md
+++ b/.opencode/skills/legion-worker/workflows/plan.md
@@ -12,7 +12,7 @@ digraph plan_workflow {
     fetch [label="1. Fetch Issue"];
     metis [label="1.5. Metis Pre-Analysis"];
     critical [label="Critical ambiguities?" shape=diamond];
-    research_plan [label="2. /workflows:plan (autonomous)"];
+    research_plan [label="2. /ce:plan (autonomous)"];
     unclear [label="Requirements unclear?" shape=diamond];
     executable [label="3. /superpowers/writing-plans"];
     review [label="4. /plan-review"];
@@ -82,9 +82,9 @@ Metis pre-analysis:
 Create the implementation plan accounting for these findings.
 ```
 
-### 2. Invoke /workflows:plan (Autonomous)
+### 2. Invoke /ce:plan (Autonomous)
 
-Invoke `/workflows:plan` with this context:
+Invoke `/ce:plan` with this context:
 
 ```
 You are running autonomously without user interaction.
@@ -242,7 +242,7 @@ Then remove `worker-active`:
 |------|--------|------------|
 | Fetch | Get issue details | `gh issue view $ISSUE_NUMBER ...` or `linear_linear(action="get", ...)` |
 | Pre-Analysis | Identify risks | Metis agent (background) |
-| Research + Structure | Create plan | `/workflows:plan` (autonomous) |
+| Research + Structure | Create plan | `/ce:plan` (autonomous) |
 | Executable | Bite-sized tasks | `/superpowers/writing-plans` |
 | Validate | Review plan | `/plan-review` (iterate) |
 | Post | Full plan to issue | `gh issue comment ...` or `linear_linear(action="comment", ...)` |
@@ -271,4 +271,4 @@ Do NOT ask the user questions interactively. If uncertain:
 | Posting summary instead of full plan | Post complete executable plan from /superpowers/writing-plans |
 | Asking user questions | Use legion-oracle first, then assumptions, escalate only as last resort |
 | Skipping plan review iteration | Always iterate until /plan-review passes or max 3 attempts |
-| Ignoring Metis pre-analysis | Always pass Metis findings to /workflows:plan as context |
+| Ignoring Metis pre-analysis | Always pass Metis findings to /ce:plan as context |

--- a/.opencode/skills/legion-worker/workflows/review.md
+++ b/.opencode/skills/legion-worker/workflows/review.md
@@ -39,7 +39,7 @@ gh pr view "$LEGION_ISSUE_ID" --json title,body,headRefName
 
 ### 2. Run Review
 
-Invoke `/compound-engineering/workflows/review` with the branch name.
+Invoke `/ce:review` with the branch name.
 
 Pass the context gathered in step 1. The review skill will:
 - Dispatch multiple reviewer agents in parallel


### PR DESCRIPTION
## Summary

- Updated `/workflows:plan` → `/ce:plan` in `plan.md` (5 occurrences)
- Updated `/compound-engineering/workflows/review` → `/ce:review` in `review.md` (1 occurrence)

Compound Engineering renamed all skills to use the `ce/` prefix. The old `/workflows:` and `/compound-engineering/workflows/` references were stale.