### PR TITLE
fix: reinforce worker-done labeling + PR reopen after force-push + retro commit isolation

### DIFF
--- a/.opencode/skills/legion-retro/SKILL.md
+++ b/.opencode/skills/legion-retro/SKILL.md
@@ -90,19 +90,33 @@ Write the integrated learnings to `docs/solutions/`. Optimize for **discoverabil
 Push to the **existing PR branch** — do NOT create a new branch or bookmark.
 The implementer already created the branch when opening the PR.
 
+**Critical: Create a new change first** — do NOT describe the current change, which
+contains the implementer's code. The retro docs go in a separate commit.
+
 ```bash
+jj new  # Create fresh change for retro docs (preserves implementer's commit)
+# ... write docs/solutions/ files ...
 jj describe -m "$LEGION_ISSUE_ID: retro learnings"
-jj git push  # Pushes to the existing tracked branch
+```
+
+Then ensure the bookmark includes this new change and push:
+
+```bash
+# Find the bookmark name (usually matches the issue ID or branch name)
+jj bookmark list
+# Move bookmark forward to include the retro change
+jj bookmark set "$BOOKMARK_NAME" -r @
+jj git push
 ```
 
 **If jj says there's no tracked branch:** The implementer should have created this branch.
 Verify whether the bookmark exists:
 ```bash
-jj bookmark list  # Should see a bookmark matching $LEGION_ISSUE_ID
+jj bookmark list  # Should see a bookmark matching the issue ID or branch name
 ```
-- **If the bookmark exists:** move it to the current change and push:
+- **If the bookmark exists but isn't at @:** move it forward and push:
   ```bash
-  jj bookmark set "$LEGION_ISSUE_ID" -r @
+  jj bookmark set "$BOOKMARK_NAME" -r @
   jj git push
   ```
 - **If the bookmark does NOT exist:** something went wrong — the implementer should have

--- a/.opencode/skills/legion-worker/workflows/implement.md
+++ b/.opencode/skills/legion-worker/workflows/implement.md
@@ -203,11 +203,31 @@ convert back to draft (`gh pr ready --undo`) if needed.
 
 ### 8. Exit
 
-Add `worker-done` label to signal the controller to transition to the Testing phase.
+**CRITICAL: The `worker-done` label is how the controller knows you finished.** If you skip this,
+the issue silently stalls and no one advances it. This is the MOST IMPORTANT step.
+
+First, verify the PR is still open (force-pushes can accidentally close PRs):
 
 **GitHub:**
+```bash
+PR_STATE=$(gh pr view $ISSUE_NUMBER --json state --jq '.state' -R $OWNER/$REPO 2>/dev/null)
+if [ "$PR_STATE" = "CLOSED" ]; then
+  gh pr reopen $ISSUE_NUMBER -R $OWNER/$REPO
+  echo "PR was accidentally closed by force-push, reopened"
+fi
 ```
+
+Then add the label and verify it was applied:
+
+**GitHub:**
+```bash
 gh issue edit $ISSUE_NUMBER --add-label "worker-done" --remove-label "worker-active" -R $OWNER/$REPO
+# Verify the label was actually applied
+LABELS=$(gh issue view $ISSUE_NUMBER --json labels --jq '[.labels[].name] | join(",")' -R $OWNER/$REPO)
+if ! echo "$LABELS" | grep -q "worker-done"; then
+  echo "WARNING: worker-done label not applied, retrying"
+  gh issue edit $ISSUE_NUMBER --add-label "worker-done" -R $OWNER/$REPO
+fi
 ```
 
 **Linear:**
@@ -279,11 +299,31 @@ Reply in PR comment threads acknowledging fixes. Reference specific changes made
 
 ### 6. Exit
 
-Add `worker-done` label to signal the controller. The controller has already transitioned the issue to In Progress before resuming you, so `worker-done` will trigger the testing gate — your fixes get behaviorally verified before the reviewer sees them again.
+**CRITICAL: The `worker-done` label is how the controller knows you finished.** If you skip this,
+the issue silently stalls and no one advances it. This is the MOST IMPORTANT step.
+
+First, verify the PR is still open (force-pushes can accidentally close PRs):
 
 **GitHub:**
+```bash
+PR_STATE=$(gh pr view $ISSUE_NUMBER --json state --jq '.state' -R $OWNER/$REPO 2>/dev/null)
+if [ "$PR_STATE" = "CLOSED" ]; then
+  gh pr reopen $ISSUE_NUMBER -R $OWNER/$REPO
+  echo "PR was accidentally closed by force-push, reopened"
+fi
 ```
+
+Then add the label and verify it was applied:
+
+**GitHub:**
+```bash
 gh issue edit $ISSUE_NUMBER --add-label "worker-done" --remove-label "worker-active" -R $OWNER/$REPO
+# Verify the label was actually applied
+LABELS=$(gh issue view $ISSUE_NUMBER --json labels --jq '[.labels[].name] | join(",")' -R $OWNER/$REPO)
+if ! echo "$LABELS" | grep -q "worker-done"; then
+  echo "WARNING: worker-done label not applied, retrying"
+  gh issue edit $ISSUE_NUMBER --add-label "worker-done" -R $OWNER/$REPO
+fi
 ```
 
 **Linear:**

--- a/.opencode/skills/legion-worker/workflows/review.md
+++ b/.opencode/skills/legion-worker/workflows/review.md
@@ -106,11 +106,23 @@ gh pr ready "$LEGION_ISSUE_ID"
 
 ### 6. Signal Completion
 
-Add `worker-done` to the issue, then exit:
+**CRITICAL: The `worker-done` label is how the controller knows you finished.** If you skip this,
+the issue silently stalls. This is the MOST IMPORTANT step.
 
-- **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "worker-done" -R $OWNER/$REPO`
-- **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current + "worker-done"])`
+**GitHub:**
+```bash
+gh issue edit $ISSUE_NUMBER --add-label "worker-done" --remove-label "worker-active" -R $OWNER/$REPO
+# Verify the label was actually applied
+LABELS=$(gh issue view $ISSUE_NUMBER --json labels --jq '[.labels[].name] | join(",")' -R $OWNER/$REPO)
+if ! echo "$LABELS" | grep -q "worker-done"; then
+  echo "WARNING: worker-done label not applied, retrying"
+  gh issue edit $ISSUE_NUMBER --add-label "worker-done" -R $OWNER/$REPO
+fi
+```
 
-Then remove `worker-active`:
-- **GitHub:** `gh issue edit $ISSUE_NUMBER --remove-label "worker-active" -R $OWNER/$REPO`
-- **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current labels without "worker-active"])`
+**Linear:**
+```
+issue = linear_linear(action="get", id=$LEGION_ISSUE_ID)
+current_labels = [l.name for l in issue.labels if l.name != "worker-active"]
+linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "worker-done"])
+```

--- a/.opencode/skills/legion-worker/workflows/test.md
+++ b/.opencode/skills/legion-worker/workflows/test.md
@@ -166,11 +166,19 @@ linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="## Behavioral Test Re
 
 ### 7. Signal Completion
 
+**CRITICAL: The labels are how the controller knows you finished.** If you skip this,
+the issue silently stalls. This is the MOST IMPORTANT step.
+
 **If all criteria pass:**
 
 **GitHub:**
-```
+```bash
 gh issue edit $ISSUE_NUMBER --add-label "worker-done" --add-label "test-passed" --remove-label "worker-active" -R $OWNER/$REPO
+# Verify labels applied
+LABELS=$(gh issue view $ISSUE_NUMBER --json labels --jq '[.labels[].name] | join(",")' -R $OWNER/$REPO)
+if ! echo "$LABELS" | grep -q "worker-done"; then
+  gh issue edit $ISSUE_NUMBER --add-label "worker-done" --add-label "test-passed" -R $OWNER/$REPO
+fi
 ```
 
 **Linear:**
@@ -183,8 +191,13 @@ linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "
 **If any criterion fails:**
 
 **GitHub:**
-```
+```bash
 gh issue edit $ISSUE_NUMBER --add-label "worker-done" --add-label "test-failed" --remove-label "worker-active" -R $OWNER/$REPO
+# Verify labels applied
+LABELS=$(gh issue view $ISSUE_NUMBER --json labels --jq '[.labels[].name] | join(",")' -R $OWNER/$REPO)
+if ! echo "$LABELS" | grep -q "worker-done"; then
+  gh issue edit $ISSUE_NUMBER --add-label "worker-done" --add-label "test-failed" -R $OWNER/$REPO
+fi
 ```
 
 **Linear:**
@@ -193,8 +206,6 @@ issue = linear_linear(action="get", id=$LEGION_ISSUE_ID)
 current_labels = [l.name for l in issue.labels if l.name != "worker-active"]
 linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "worker-done", "test-failed"])
 ```
-
-Exit immediately after signaling.
 
 ## Blocking on User Input
 


### PR DESCRIPTION
## Summary

Three skill fixes based on issues observed during multi-day controller session managing 15+ issues through the full pipeline.

### Changes

**1. Worker-done label reliability (implement, test, review workflows)**
Workers were completing work (pushing code, resolving conflicts) but silently failing to add the `worker-done` label. The controller relies on this label to detect completions — without it, issues stall indefinitely with no indication of why.

- Added `CRITICAL` emphasis on the labeling step being the most important
- Added verification: check label was actually applied after the `gh issue edit` call
- Added retry if verification fails

**2. PR reopen after force-push (implement workflow)**
`jj git push` after rebase can force-push in a way that causes GitHub to auto-close the PR. Confirmed on PR #1720 (agent-c) where force-push and close events had identical timestamps.

- Added PR state check after push
- Auto-reopen if PR was accidentally closed

**3. Retro commit isolation (retro skill)**
The retro skill was doing `jj describe -m "retro learnings"` on the current change, which overwrote the implementer's actual code commit message. Also caused orphaned commits when the bookmark wasn't moved forward.

- Retro now creates a new change (`jj new`) before writing docs
- Explicit bookmark management to include the retro change in the PR branch

### Files changed
- `.opencode/skills/legion-retro/SKILL.md`
- `.opencode/skills/legion-worker/workflows/implement.md`
- `.opencode/skills/legion-worker/workflows/review.md`
- `.opencode/skills/legion-worker/workflows/test.md`