### PR TITLE
feat(#65): state machine hardening — fix pre-existing issues

### DIFF
--- a/.opencode/skills/legion-controller/SKILL.md
+++ b/.opencode/skills/legion-controller/SKILL.md
@@ -97,7 +97,7 @@ about what to do:
 
 | suggestedAction | Signals | Controller should... |
 |-----------------|---------|---------------------|
-| `skip` | `hasPr: true`, status: In Progress | PR opened but no `worker-done` yet; wait for implementer to finish and add `worker-done` (which triggers testing gate) |
+| `skip` | `hasPr: true`, status: In Progress, `hasLiveWorker: true` | Live implementer still working on PR; wait for it to finish |
 | `skip` | `workerStatus: "dead"` | Dead worker blocking progress; clean up and re-evaluate |
 | `retry_pr_check` | `prIsDraft: null` | GitHub API flaked; try again next iteration |
 
@@ -185,6 +185,20 @@ legion dispatch "$ISSUE_IDENTIFIER" implement \
 signaling completion. If CI is failing when the controller sees a PR, the implementer didn't
 finish — re-dispatch an implementer with the CI failure output. The tester should also check
 CI status and include it in the review.
+
+### Post-Merge Monitoring
+
+If an issue remains in Retro after the merger exits, verify PR merge status:
+```bash
+gh pr view "$LEGION_ISSUE_ID" --json state,merged
+```
+
+If the PR is merged but the issue isn't closed, close it explicitly:
+```bash
+gh issue close $ISSUE_NUMBER -R $OWNER/$REPO
+```
+
+This handles edge cases where the merge workflow's explicit close failed or where GitHub auto-close didn't trigger. The `transition_to_done` action type exists in the state machine for this purpose.
 
 ### 4. Route Triage
 

--- a/.opencode/skills/legion-worker/workflows/architect.md
+++ b/.opencode/skills/legion-worker/workflows/architect.md
@@ -41,7 +41,7 @@ If still unclear, escalate.
 
 ### 3. Act
 
-**If unclear:** Add `user-input-needed` label, post comment with specific questions, exit.
+**If unclear:** Add `user-input-needed` label, remove `worker-active` label, post comment with specific questions, exit.
 
 **If too big:** Break down into sub-issues. Each sub-issue must be spec-ready:
 - Clear problem statement (what needs to change and why)
@@ -190,7 +190,7 @@ linear_linear(action="update",
 | Spec-ready | Cross-family review → incorporate feedback → Add `worker-done` to issue |
 | Fully broken down | Cross-family review → incorporate feedback → Add `worker-done` to each child, leave parent unchanged |
 | Partial breakdown | Cross-family review → incorporate feedback → Add `worker-done` to clear children, add `user-input-needed` to parent |
-| Unclear | Add `user-input-needed` to issue (no review needed) |
+| Unclear | Add `user-input-needed` to issue, remove `worker-active` (no review needed) |
 
 **After breakdown:** Parent keeps its existing labels. Do NOT add `worker-done` to parent - only children get it. Post comment to parent explaining what was created and what still needs clarification.
 

--- a/.opencode/skills/legion-worker/workflows/implement.md
+++ b/.opencode/skills/legion-worker/workflows/implement.md
@@ -12,6 +12,20 @@ Trust the controller's explicit mode parameter.
 
 > **Note:** The daemon API mode is always `implement`. The sub-mode (fresh vs address-comments) is conveyed in the controller's prompt text, not the API call.
 
+## Tools Referenced
+
+This workflow references environment-provided tools. These are available in the OpenCode runtime, not defined in this repo:
+
+| Tool | Source | Purpose |
+|------|--------|---------|
+| `task_create` | OpenCode task system | Create a task with dependencies (`blockedBy`) |
+| `task_claim_next` | OpenCode task system | Atomically claim the next ready task |
+| `task_update` | OpenCode task system | Mark task completed/failed |
+| `task_list` | OpenCode task system | List tasks and their status |
+| `background_task` | OpenCode agent system | Spawn a background subagent |
+| `/analyze` | `sjawhar/analyze` skill | Run code quality agents on recent changes |
+
+The task system enables parallel execution with dependency ordering. If these tools are unavailable in your environment, execute tasks sequentially following the plan's dependency annotations.
 ---
 
 ## All Modes: Rebase First

--- a/.opencode/skills/legion-worker/workflows/merge.md
+++ b/.opencode/skills/legion-worker/workflows/merge.md
@@ -33,8 +33,8 @@ If rebase produces conflicts:
 
 **If conflicts are unresolvable:**
 - Add `user-input-needed` label to the issue
-  - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "user-input-needed" -R $OWNER/$REPO`
-  - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current + "user-input-needed"])`
+  - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "user-input-needed" --remove-label "worker-active" -R $OWNER/$REPO`
+  - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current without "worker-active" plus "user-input-needed"])`
 - Post comment describing the conflict
   - **GitHub:** `gh issue comment $ISSUE_NUMBER --body "..." -R $OWNER/$REPO`
   - **Linear:** `linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="...")`
@@ -72,10 +72,26 @@ gh pr merge "$LEGION_ISSUE_ID" --squash --delete-branch
   - **GitHub:** `gh issue comment $ISSUE_NUMBER --body "..." -R $OWNER/$REPO`
   - **Linear:** `linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="...")`
 - Add `user-input-needed` label
-  - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "user-input-needed" -R $OWNER/$REPO`
-  - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current + "user-input-needed"])`
+  - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "user-input-needed" --remove-label "worker-active" -R $OWNER/$REPO`
+  - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current without "worker-active" plus "user-input-needed"])`
 - Exit — the user needs to merge manually or grant access
 
-### 7. Exit
+### 7. Close Issue
 
-Exit without adding a label. The issue auto-closes when the PR merges. The controller will clean up the workspace.
+After successful merge, explicitly close the issue to transition to Done:
+
+**GitHub:**
+```bash
+gh issue close $ISSUE_NUMBER -R $OWNER/$REPO --comment "Closed via PR merge."
+```
+
+**Linear:**
+```
+linear_linear(action="update", id=$LEGION_ISSUE_ID, state="Done")
+```
+
+Then remove `worker-active` if present:
+- **GitHub:** `gh issue edit $ISSUE_NUMBER --remove-label "worker-active" -R $OWNER/$REPO`
+- **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current labels without "worker-active"])`
+
+> **Note:** GitHub auto-close may also fire when the PR merges, which is fine — closing an already-closed issue is a no-op. This explicit close is a safety net for cases where auto-close doesn't trigger (e.g., issue not linked to PR, Linear backend).

--- a/.opencode/skills/legion-worker/workflows/plan.md
+++ b/.opencode/skills/legion-worker/workflows/plan.md
@@ -109,8 +109,8 @@ The skill handles:
 
 **If the skill determines requirements are fundamentally unclear** (even after legion-oracle + assumptions):
 1. Add `user-input-needed` label:
-   - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "user-input-needed" -R $OWNER/$REPO`
-   - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current + "user-input-needed"])`
+   - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "user-input-needed" --remove-label "worker-active" -R $OWNER/$REPO`
+   - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current without "worker-active" plus "user-input-needed"])`
 2. Post a comment explaining what needs clarification:
    - **GitHub:** `gh issue comment $ISSUE_NUMBER --body "..." -R $OWNER/$REPO`
    - **Linear:** `linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="...")`
@@ -202,8 +202,8 @@ This spawns parallel cross-family reviewers:
 
 **Max 3 iterations.** If still failing:
 1. Add `user-input-needed` label:
-   - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "user-input-needed" -R $OWNER/$REPO`
-   - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current + "user-input-needed"])`
+   - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "user-input-needed" --remove-label "worker-active" -R $OWNER/$REPO`
+   - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current without "worker-active" plus "user-input-needed"])`
 2. Post a comment explaining unresolved review issues:
    - **GitHub:** `gh issue comment $ISSUE_NUMBER --body "..." -R $OWNER/$REPO`
    - **Linear:** `linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="...")`

--- a/packages/daemon/src/cli/index.ts
+++ b/packages/daemon/src/cli/index.ts
@@ -710,7 +710,7 @@ export const dispatchCommand = defineCommand({
     },
     mode: {
       type: "positional",
-      description: "Worker mode (architect, plan, implement, review, merge)",
+      description: "Worker mode (architect, plan, implement, test, review, merge)",
       required: true,
     },
     prompt: { type: "string", description: "Custom initial prompt (default: /legion-worker)" },

--- a/packages/daemon/src/state/AGENTS.md
+++ b/packages/daemon/src/state/AGENTS.md
@@ -36,9 +36,17 @@ The core of the controller's decision-making. Key transitions:
 | Needs Review | yes | — | draft | — | `resume_implementer_for_changes` |
 | Needs Review | yes | — | no PR | — | `investigate_no_pr` |
 | Retro | yes | — | — | — | `dispatch_merger` |
+| Retro | no | yes | — | — | `skip` (live worker running) |
+| Retro | no | no | — | — | `dispatch_implementer_for_retro` |
 | Any | — | yes | — | — | `skip` (worker already running) |
 
 **Note:** The state machine only checks `hasTestPassed` (presence of `test-passed` label). `hasTestFailed`/`test-failed` is computed and wired but not used in decision logic — it exists for human visibility and controller label cleanup. `worker-done` without `test-passed` is treated as failure regardless of whether `test-failed` is present.
+
+**Hardening notes (from #65):**
+- `needs-approval` checks are scoped to Backlog/Todo statuses only — prevents blocking In Progress issues that happen to have the label.
+- In Progress no longer returns `skip` when `hasPr && !hasLiveWorker` — this caused a deadlock when workers died after creating a PR.
+- `skip` action uses the actual `workerMode` from the daemon (when available) for sessionId computation, instead of defaulting to `implement`.
+- `transition_to_done` action exists for explicit Done transitions (mapped to `merge` mode).
 
 ## Anti-Patterns
 

--- a/packages/daemon/src/state/__tests__/decision-regressions.test.ts
+++ b/packages/daemon/src/state/__tests__/decision-regressions.test.ts
@@ -3,7 +3,7 @@ import { buildIssueState } from "../decision";
 import type { FetchedIssueData } from "../types";
 
 describe("decision regressions (known pipeline stalls)", () => {
-  it("does not re-dispatch implementer when an In Progress issue already has a PR", () => {
+  it("re-dispatches implementer for In Progress with dead worker and existing PR", () => {
     const data: FetchedIssueData = {
       issueId: "ENG-21",
       status: "In Progress",
@@ -23,10 +23,10 @@ describe("decision regressions (known pipeline stalls)", () => {
     };
 
     const state = buildIssueState(data, "00000000-0000-0000-0000-000000000000");
-    expect(state.suggestedAction).toBe("skip");
+    expect(state.suggestedAction).toBe("dispatch_implementer");
   });
 
-  it("does not skip Retro when a worker exists (should resume retro work)", () => {
+  it("skips Retro when a live worker exists (prevents retro spam)", () => {
     const data: FetchedIssueData = {
       issueId: "ENG-22",
       status: "Retro",
@@ -46,6 +46,6 @@ describe("decision regressions (known pipeline stalls)", () => {
     };
 
     const state = buildIssueState(data, "00000000-0000-0000-0000-000000000000");
-    expect(state.suggestedAction).toBe("resume_implementer_for_retro");
+    expect(state.suggestedAction).toBe("skip");
   });
 });

--- a/packages/daemon/src/state/__tests__/decision.test.ts
+++ b/packages/daemon/src/state/__tests__/decision.test.ts
@@ -107,9 +107,9 @@ describe("suggestAction", () => {
     expect(action).toBe("dispatch_implementer_for_retro");
   });
 
-  it("retro_with_live_worker resumes implementer", () => {
+  it("retro_with_live_worker_skips", () => {
     const action = suggestAction(IssueStatus.RETRO, false, true, null, false, false);
-    expect(action).toBe("resume_implementer_for_retro");
+    expect(action).toBe("skip");
   });
 
   it("retry_pr_check_is_distinct_from_skip", () => {
@@ -120,9 +120,9 @@ describe("suggestAction", () => {
     expect(retry).not.toBe(skip);
   });
 
-  it("in_progress_has_pr_no_worker_done_no_live_worker_skips", () => {
+  it("in_progress_has_pr_no_worker_done_no_live_worker_dispatches", () => {
     const action = suggestAction(IssueStatus.IN_PROGRESS, false, false, null, true, false);
-    expect(action).toBe("skip");
+    expect(action).toBe("dispatch_implementer");
   });
 
   it("done_always_skips", () => {

--- a/packages/daemon/src/state/decision.ts
+++ b/packages/daemon/src/state/decision.ts
@@ -55,9 +55,6 @@ export function suggestAction(
       if (hasWorkerDone) {
         return "transition_to_testing";
       }
-      if (hasPr && !hasLiveWorker) {
-        return "skip";
-      }
       if (hasLiveWorker) {
         return "skip";
       }
@@ -98,7 +95,7 @@ export function suggestAction(
         return "dispatch_merger";
       }
       if (hasLiveWorker) {
-        return "resume_implementer_for_retro";
+        return "skip";
       }
       return "dispatch_implementer_for_retro";
 
@@ -122,6 +119,7 @@ export const ACTION_TO_MODE: Record<ActionType, WorkerModeLiteral> = {
   transition_to_needs_review: WorkerMode.REVIEW,
   transition_to_todo: WorkerMode.PLAN,
   transition_to_retro: WorkerMode.IMPLEMENT,
+  transition_to_done: WorkerMode.MERGE,
   relay_user_feedback: WorkerMode.IMPLEMENT,
   remove_worker_active_and_redispatch: WorkerMode.IMPLEMENT,
   add_needs_approval: WorkerMode.PLAN,
@@ -130,6 +128,15 @@ export const ACTION_TO_MODE: Record<ActionType, WorkerModeLiteral> = {
   transition_to_testing: WorkerMode.TEST,
   resume_implementer_for_test_failure: WorkerMode.IMPLEMENT,
 };
+
+const VALID_WORKER_MODES = new Set<string>([
+  WorkerMode.ARCHITECT,
+  WorkerMode.PLAN,
+  WorkerMode.IMPLEMENT,
+  WorkerMode.TEST,
+  WorkerMode.REVIEW,
+  WorkerMode.MERGE,
+]);
 
 export function buildIssueState(data: FetchedIssueData, teamId: string): IssueState {
   let action: ActionType;
@@ -140,9 +147,16 @@ export function buildIssueState(data: FetchedIssueData, teamId: string): IssueSt
     action = "skip";
   } else if (data.labels.includes("worker-active") && !data.hasLiveWorker) {
     action = "remove_worker_active_and_redispatch";
-  } else if (data.hasNeedsApproval && data.hasHumanApproved) {
+  } else if (
+    data.hasNeedsApproval &&
+    data.hasHumanApproved &&
+    (data.status === IssueStatus.BACKLOG || data.status === IssueStatus.TODO)
+  ) {
     action = "transition_to_todo";
-  } else if (data.hasNeedsApproval) {
+  } else if (
+    data.hasNeedsApproval &&
+    (data.status === IssueStatus.BACKLOG || data.status === IssueStatus.TODO)
+  ) {
     action = "skip";
   } else {
     action = suggestAction(
@@ -158,7 +172,18 @@ export function buildIssueState(data: FetchedIssueData, teamId: string): IssueSt
     }
   }
 
-  const mode = ACTION_TO_MODE[action] ?? WorkerMode.IMPLEMENT;
+  // Use actual worker mode for skip actions when available
+  let mode: WorkerModeLiteral;
+  if (
+    action === "skip" &&
+    data.hasLiveWorker &&
+    data.workerMode &&
+    VALID_WORKER_MODES.has(data.workerMode)
+  ) {
+    mode = data.workerMode as WorkerModeLiteral;
+  } else {
+    mode = ACTION_TO_MODE[action] ?? WorkerMode.IMPLEMENT;
+  }
   const sessionId = computeSessionId(teamId, data.issueId, mode);
 
   return {

--- a/packages/daemon/src/state/types.ts
+++ b/packages/daemon/src/state/types.ts
@@ -56,6 +56,7 @@ export type ActionType =
   | "transition_to_needs_review"
   | "transition_to_retro"
   | "transition_to_todo"
+  | "transition_to_done"
   | "relay_user_feedback"
   | "remove_worker_active_and_redispatch"
   | "add_needs_approval"


### PR DESCRIPTION
## Summary

Extracted from the accumulated sjawhar-legion-62 branch — this contains only the #65 state machine hardening changes.

### Changes
- **In Progress deadlock fix**: Removed `hasPr && !hasLiveWorker → skip` that caused deadlock when workers died after creating a PR
- **Retro spam fix**: Live worker in Retro now returns `skip` instead of `resume_implementer_for_retro`
- **Needs-approval scope**: `needs-approval` checks scoped to Backlog/Todo only — prevents blocking In Progress issues
- **Skip sessionId fix**: `skip` actions use actual `workerMode` from daemon for session ID computation (gated on `hasLiveWorker`)
- **transition_to_done**: New action type for explicit Done transitions
- **Worker-active cleanup**: All exit paths (architect, plan, merge workflows) now remove `worker-active` when adding `user-input-needed`
- **Merge workflow**: Explicit issue close step after PR merge (safety net for auto-close failures)
- **CLI**: Added "test" to worker mode description

### Testing
641 tests pass (0 failures). No new test files — updated existing regression and decision tests to match corrected behaviors.