### PR TITLE
fix: worker status filtering, GraphQL project fetcher, Today→Todo alias

### DIFF
--- a/packages/daemon/src/state/__tests__/github-fetch.test.ts
+++ b/packages/daemon/src/state/__tests__/github-fetch.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Tests for GitHub GraphQL project fetching with organization/user fallback.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { CommandRunner } from "../fetch";
+import { fetchGitHubProjectItems } from "../github-fetch";
+
+describe("fetchGitHubProjectItems", () => {
+  it("successfully fetches from organization", async () => {
+    const mockRunner: CommandRunner = async (cmd: string[]) => {
+      expect(cmd).toContain("graphql");
+      const queryArg = cmd.find((arg) => arg.startsWith("query="));
+      expect(queryArg).toContain("organization(login:");
+
+      return {
+        stdout: JSON.stringify({
+          data: {
+            organization: {
+              projectV2: {
+                items: {
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  nodes: [
+                    {
+                      id: "item1",
+                      fieldValueByName: { name: "Todo" },
+                      labels: { labels: { nodes: [{ name: "bug" }] } },
+                      content: {
+                        __typename: "Issue",
+                        number: 42,
+                        title: "Test Issue",
+                        url: "https://github.com/owner/repo/issues/42",
+                        repository: { nameWithOwner: "owner/repo" },
+                        linkedPullRequests: { nodes: [] },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+        exitCode: 0,
+      };
+    };
+
+    const result = await fetchGitHubProjectItems("testorg", 1, mockRunner);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      id: "item1",
+      status: "Todo",
+      content: {
+        type: "Issue",
+        number: 42,
+        title: "Test Issue",
+      },
+    });
+  });
+
+  it("falls back to user query when organization query returns access error", async () => {
+    let callCount = 0;
+    const mockRunner: CommandRunner = async (cmd: string[]) => {
+      callCount++;
+      const queryArg = cmd.find((arg) => arg.startsWith("query="));
+
+      if (callCount === 1) {
+        // First call should be organization query
+        expect(queryArg).toContain("organization(login:");
+
+        return {
+          stdout: JSON.stringify({
+            errors: [{ message: "Could not resolve to an Organization with the name 'testuser'" }],
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      } else {
+        // Second call should be user query
+        expect(queryArg).toContain("user(login:");
+
+        return {
+          stdout: JSON.stringify({
+            data: {
+              user: {
+                projectV2: {
+                  items: {
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                    nodes: [
+                      {
+                        id: "item2",
+                        fieldValueByName: { name: "In Progress" },
+                        labels: { labels: { nodes: [] } },
+                        content: {
+                          __typename: "Issue",
+                          number: 43,
+                          title: "User Issue",
+                          url: "https://github.com/testuser/repo/issues/43",
+                          repository: { nameWithOwner: "testuser/repo" },
+                          linkedPullRequests: { nodes: [] },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      }
+    };
+
+    const result = await fetchGitHubProjectItems("testuser", 1, mockRunner);
+
+    expect(callCount).toBe(2);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      id: "item2",
+      status: "In Progress",
+      content: {
+        type: "Issue",
+        number: 43,
+        title: "User Issue",
+      },
+    });
+  });
+
+  it("falls back to user query when organization query fails with exception", async () => {
+    let callCount = 0;
+    const mockRunner: CommandRunner = async (cmd: string[]) => {
+      callCount++;
+      const queryArg = cmd.find((arg) => arg.startsWith("query="));
+
+      if (callCount === 1) {
+        // First call should be organization query and fail
+        expect(queryArg).toContain("organization(login:");
+        throw new Error("GitHub GraphQL query failed (exit 1): Forbidden");
+      } else {
+        // Second call should be user query
+        expect(queryArg).toContain("user(login:");
+
+        return {
+          stdout: JSON.stringify({
+            data: {
+              user: {
+                projectV2: {
+                  items: {
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                    nodes: [],
+                  },
+                },
+              },
+            },
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      }
+    };
+
+    const result = await fetchGitHubProjectItems("testuser", 1, mockRunner);
+
+    expect(callCount).toBe(2);
+    expect(result.items).toHaveLength(0);
+  });
+
+  it("continues using user query for pagination after fallback", async () => {
+    let callCount = 0;
+    const mockRunner: CommandRunner = async (cmd: string[]) => {
+      callCount++;
+      const queryArg = cmd.find((arg) => arg.startsWith("query="));
+
+      if (callCount === 1) {
+        // First call - organization query fails
+        expect(queryArg).toContain("organization(login:");
+
+        return {
+          stdout: JSON.stringify({
+            errors: [{ message: "Could not resolve to an Organization" }],
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      } else if (callCount === 2) {
+        // Second call - user query with first page
+        expect(queryArg).toContain("user(login:");
+        expect(cmd).not.toContain("after=");
+
+        return {
+          stdout: JSON.stringify({
+            data: {
+              user: {
+                projectV2: {
+                  items: {
+                    pageInfo: { hasNextPage: true, endCursor: "cursor1" },
+                    nodes: [
+                      {
+                        id: "item1",
+                        fieldValueByName: { name: "Todo" },
+                        labels: { labels: { nodes: [] } },
+                        content: {
+                          __typename: "Issue",
+                          number: 1,
+                          title: "Issue 1",
+                          url: "https://github.com/testuser/repo/issues/1",
+                          repository: { nameWithOwner: "testuser/repo" },
+                          linkedPullRequests: { nodes: [] },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      } else {
+        // Third call - user query with second page
+        expect(queryArg).toContain("user(login:");
+        expect(cmd).toContain("after=cursor1");
+
+        return {
+          stdout: JSON.stringify({
+            data: {
+              user: {
+                projectV2: {
+                  items: {
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                    nodes: [
+                      {
+                        id: "item2",
+                        fieldValueByName: { name: "Done" },
+                        labels: { labels: { nodes: [] } },
+                        content: {
+                          __typename: "Issue",
+                          number: 2,
+                          title: "Issue 2",
+                          url: "https://github.com/testuser/repo/issues/2",
+                          repository: { nameWithOwner: "testuser/repo" },
+                          linkedPullRequests: { nodes: [] },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      }
+    };
+
+    const result = await fetchGitHubProjectItems("testuser", 1, mockRunner);
+
+    expect(callCount).toBe(3);
+    expect(result.items).toHaveLength(2);
+    expect((result.items[0].content as { number: number }).number).toBe(1);
+    expect((result.items[1].content as { number: number }).number).toBe(2);
+  });
+
+  it("throws error when both organization and user queries fail", async () => {
+    let callCount = 0;
+    const mockRunner: CommandRunner = async (cmd: string[]) => {
+      callCount++;
+      const queryArg = cmd.find((arg) => arg.startsWith("query="));
+
+      if (callCount === 1) {
+        expect(queryArg).toContain("organization(login:");
+        throw new Error("GitHub GraphQL query failed (exit 1): Forbidden");
+      } else {
+        expect(queryArg).toContain("user(login:");
+
+        return {
+          stdout: JSON.stringify({
+            errors: [{ message: "User not found" }],
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      }
+    };
+
+    await expect(fetchGitHubProjectItems("nonexistent", 1, mockRunner)).rejects.toThrow(
+      "GraphQL errors: User not found"
+    );
+
+    expect(callCount).toBe(2);
+  });
+
+  it("throws error when organization query has non-access related errors", async () => {
+    const mockRunner: CommandRunner = async (cmd: string[]) => {
+      const queryArg = cmd.find((arg) => arg.startsWith("query="));
+      expect(queryArg).toContain("organization(login:");
+
+      return {
+        stdout: JSON.stringify({
+          errors: [{ message: "Rate limit exceeded" }],
+        }),
+        stderr: "",
+        exitCode: 0,
+      };
+    };
+
+    await expect(fetchGitHubProjectItems("testorg", 1, mockRunner)).rejects.toThrow(
+      "GraphQL errors: Rate limit exceeded"
+    );
+  });
+});

--- a/packages/daemon/src/state/github-fetch.ts
+++ b/packages/daemon/src/state/github-fetch.ts
@@ -48,15 +48,76 @@ interface GitHubProjectItemsPage {
         };
       };
     };
+    user?: {
+      projectV2?: {
+        items: {
+          pageInfo: {
+            hasNextPage: boolean;
+            endCursor: string | null;
+          };
+          nodes: GitHubProjectItemNode[];
+        };
+      };
+    };
   };
   errors?: Array<{ message: string }>;
 }
 
 const ITEMS_PER_PAGE = 100;
 
-const QUERY = `
+const ORG_QUERY = `
 query($owner: String!, $number: Int!, $first: Int!, $after: String) {
   organization(login: $owner) {
+    projectV2(number: $number) {
+      items(first: $first, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue {
+              name
+            }
+          }
+          labels: fieldValueByName(name: "Labels") {
+            ... on ProjectV2ItemFieldLabelValue {
+              labels(first: 20) {
+                nodes { name }
+              }
+            }
+          }
+          content {
+            __typename
+            ... on Issue {
+              number
+              title
+              url
+              repository { nameWithOwner }
+              linkedPullRequests: closedByPullRequestsReferences(first: 10, includeClosedPrs: true) {
+                nodes { url }
+              }
+            }
+            ... on PullRequest {
+              number
+              title
+              url
+              repository { nameWithOwner }
+            }
+            ... on DraftIssue {
+              title
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const USER_QUERY = `
+query($owner: String!, $number: Int!, $first: Int!, $after: String) {
+  user(login: $owner) {
     projectV2(number: $number) {
       items(first: $first, after: $after) {
         pageInfo {
@@ -160,7 +221,60 @@ function nodeToProjectItem(node: GitHubProjectItemNode): Record<string, unknown>
 }
 
 /**
+ * Execute a GraphQL query with fallback from organization to user.
+ *
+ * @param query - The GraphQL query string
+ * @param owner - GitHub organization or user
+ * @param projectNumber - Project number (from the URL)
+ * @param cursor - Pagination cursor
+ * @param runner - Command runner (for testing)
+ * @returns GraphQL response
+ */
+async function executeGraphQLQuery(
+  query: string,
+  owner: string,
+  projectNumber: number,
+  cursor: string | null,
+  runner: CommandRunner
+): Promise<GitHubProjectItemsPage> {
+  const cmd: string[] = [
+    "gh",
+    "api",
+    "graphql",
+    "-f",
+    `query=${query}`,
+    "-f",
+    `owner=${owner}`,
+    "-F",
+    `number=${projectNumber}`,
+    "-F",
+    `first=${ITEMS_PER_PAGE}`,
+  ];
+  if (cursor) {
+    cmd.push("-f", `after=${cursor}`);
+  }
+
+  const result: CommandResult = await runner(cmd);
+
+  if (result.exitCode !== 0) {
+    throw new Error(`GitHub GraphQL query failed (exit ${result.exitCode}): ${result.stderr}`);
+  }
+
+  let response: GitHubProjectItemsPage;
+  try {
+    response = JSON.parse(result.stdout) as GitHubProjectItemsPage;
+  } catch {
+    throw new Error(`Failed to parse GraphQL response: ${result.stdout.slice(0, 200)}`);
+  }
+
+  return response;
+}
+
+/**
  * Fetch all items from a GitHub Project V2 using cursor-based GraphQL pagination.
+ *
+ * Tries organization query first, falls back to user query if the authenticated
+ * user is not a member of the organization.
  *
  * @param owner - GitHub organization or user
  * @param projectNumber - Project number (from the URL)
@@ -175,54 +289,79 @@ export async function fetchGitHubProjectItems(
   const allItems: Record<string, unknown>[] = [];
   let cursor: string | null = null;
   let hasNextPage = true;
+  let useUserQuery = false;
 
   while (hasNextPage) {
-    const variables: Record<string, unknown> = {
-      owner,
-      number: projectNumber,
-      first: ITEMS_PER_PAGE,
-    };
-    if (cursor) {
-      variables.after = cursor;
-    }
-
-    const cmd: string[] = [
-      "gh",
-      "api",
-      "graphql",
-      "-f",
-      `query=${QUERY}`,
-      "-f",
-      `owner=${owner}`,
-      "-F",
-      `number=${projectNumber}`,
-      "-F",
-      `first=${ITEMS_PER_PAGE}`,
-    ];
-    if (cursor) {
-      cmd.push("-f", `after=${cursor}`);
-    }
-
-    const result: CommandResult = await runner(cmd);
-
-    if (result.exitCode !== 0) {
-      throw new Error(`GitHub GraphQL query failed (exit ${result.exitCode}): ${result.stderr}`);
-    }
-
+    // Try organization query first, fall back to user query
     let response: GitHubProjectItemsPage;
-    try {
-      response = JSON.parse(result.stdout) as GitHubProjectItemsPage;
-    } catch {
-      throw new Error(`Failed to parse GraphQL response: ${result.stdout.slice(0, 200)}`);
+    let items:
+      | {
+          pageInfo: { hasNextPage: boolean; endCursor: string | null };
+          nodes: GitHubProjectItemNode[];
+        }
+      | undefined;
+
+    if (!useUserQuery) {
+      try {
+        response = await executeGraphQLQuery(ORG_QUERY, owner, projectNumber, cursor, runner);
+
+        if (response.errors?.length) {
+          // Check if the error is about organization access
+          const hasOrgAccessError = response.errors.some(
+            (error) =>
+              error.message.includes("Could not resolve to an Organization") ||
+              error.message.includes("not a member")
+          );
+
+          if (hasOrgAccessError) {
+            // Fall back to user query
+            useUserQuery = true;
+            response = await executeGraphQLQuery(USER_QUERY, owner, projectNumber, cursor, runner);
+            items = response.data?.user?.projectV2?.items;
+          } else {
+            throw new Error(`GraphQL errors: ${response.errors.map((e) => e.message).join(", ")}`);
+          }
+        } else {
+          items = response.data?.organization?.projectV2?.items;
+        }
+      } catch (error) {
+        // If organization query fails completely with access-related error, try user query
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const isAccessError =
+          errorMessage.includes("Forbidden") ||
+          errorMessage.includes("not a member") ||
+          errorMessage.includes("Could not resolve to an Organization");
+
+        if (isAccessError) {
+          useUserQuery = true;
+          response = await executeGraphQLQuery(USER_QUERY, owner, projectNumber, cursor, runner);
+
+          if (response.errors?.length) {
+            throw new Error(`GraphQL errors: ${response.errors.map((e) => e.message).join(", ")}`);
+          }
+
+          items = response.data?.user?.projectV2?.items;
+        } else {
+          // Re-throw non-access errors
+          throw error;
+        }
+      }
+    } else {
+      // Use user query
+      response = await executeGraphQLQuery(USER_QUERY, owner, projectNumber, cursor, runner);
+
+      if (response.errors?.length) {
+        throw new Error(`GraphQL errors: ${response.errors.map((e) => e.message).join(", ")}`);
+      }
+
+      items = response.data?.user?.projectV2?.items;
     }
 
-    if (response.errors?.length) {
-      throw new Error(`GraphQL errors: ${response.errors.map((e) => e.message).join(", ")}`);
-    }
-
-    const items = response.data?.organization?.projectV2?.items;
     if (!items) {
-      throw new Error("Unexpected GraphQL response structure — missing projectV2.items");
+      const queryType = useUserQuery ? "user" : "organization";
+      throw new Error(
+        `Unexpected GraphQL response structure — missing ${queryType}.projectV2.items`
+      );
     }
 
     for (const node of items.nodes) {


### PR DESCRIPTION
## Summary

Fixes three bugs discovered during the opencode-legion plugin trial run:

- **Worker status endpoint returns empty object** — `GET /workers/:id/status` was returning the full session status map from `session.status()` instead of filtering to just the requested session. Now returns only the requested session's status.
- **State machine misses recently-added project items (#82)** — `gh project item-list` silently drops items when projects have 200+ entries. Added `POST /state/fetch-and-collect` endpoint that fetches all items via GraphQL cursor-based pagination (found 339 items vs 30 from the CLI).
- **"Today" status not recognized** — GitHub project uses "Today" instead of "Todo". Added `Today → Todo` alias in `IssueStatus.ALIASES`.

## Changes

| File | Change |
|------|--------|
| `packages/daemon/src/daemon/runtime/opencode.ts` | Filter `session.status()` response to just the requested session ID |
| `packages/daemon/src/state/github-fetch.ts` | New GraphQL-based project item fetcher with cursor pagination |
| `packages/daemon/src/daemon/server.ts` | New `POST /state/fetch-and-collect` endpoint |
| `packages/daemon/src/state/types.ts` | `Today → Todo` status alias |
| `packages/daemon/src/state/__tests__/types.test.ts` | Updated test for Today alias |
| `docs/plans/2026-03-10-*` | Design + impl docs for opencode-legion plugin trial |

## Testing

- All 400 daemon tests passing
- `fetch-and-collect` verified against live GitHub project (trajectory-labs-pbc/2): 339 issues fetched, #3188 correctly resolved as `status: Todo`

Closes #82