### PR TITLE
fix: reinforce worker completion signaling with required startup todos

### DIFF
--- a/.opencode/skills/legion-worker/SKILL.md
+++ b/.opencode/skills/legion-worker/SKILL.md
@@ -32,7 +32,7 @@ Use the **backend** from your prompt to choose GitHub CLI or Linear MCP commands
    branches or bookmarks in review, retro, or merge workflows.
    **Exception:** The retro workflow has a recovery fallback for when the tracked branch is
    lost — it may re-create the bookmark in that narrow case. See the retro SKILL.md for details.
-4. **Signal completion** - add `worker-done` label when done (see routing table)
+4. **Signal completion (MOST IMPORTANT)** — before you stop for ANY reason, you MUST: push your work, add `worker-done` label, remove `worker-active` label. If you skip this, the issue silently stalls. Create a todo for this at session start (see Required Startup Todos below).
 5. **Clean up on exit** - remove `worker-active` label when exiting (done or blocked)
 
 ## Skill Discipline
@@ -60,6 +60,18 @@ jj new  # Fresh commit for this session
 
 If you're resuming after user feedback, also read the issue comments for the answer.
 
+### Required Startup Todos
+
+**Before starting any workflow work**, create these todos (adapt the signal todo to your mode):
+
+1. Your workflow-specific work items (from the workflow file)
+2. A **signal completion** todo as the LAST item:
+   - `Signal completion: push changes, add worker-done label, remove worker-active label`
+   - Keep this todo `pending` until you have actually run the label commands and verified they succeeded
+   - **Do not mark this complete early** — it is your contract with the controller
+
+The signal completion todo ensures you never finish a session without updating labels.
+If you are about to stop or exit for any reason, check whether this todo is still pending — if so, do it now.
 ### Blocking on User Input
 
 When you need human input that the legion-oracle can't answer:


### PR DESCRIPTION
## Summary

Workers occasionally finish their work without adding the `worker-done` label, causing issues to silently stall. The controller then has to manually investigate and fix each case.

### Root Cause (data-driven)

Analyzed 66 main worker sessions across Legion and Agent-C repos:
- **60/66 (91%) signaled successfully** — the actual failure rate is ~9%, not the ~80% originally estimated
- **Context exhaustion is NOT the cause** — failed sessions had 60-75% context remaining, all finished with `stop` (not `max_tokens`)
- **Root cause**: workflow compliance gap — the LLM completes substantive work and decides it's "done" without executing the signaling step at the end of the workflow

### Fix

Simple workflow reinforcement (no plugin hooks, no controller fallback, no new infrastructure):

1. **Strengthened Essential Rule #4** — signaling is now marked as "MOST IMPORTANT" with explicit instructions to push, add `worker-done`, and remove `worker-active` before stopping for any reason
2. **Required Startup Todos section** — workers must create a "Signal completion" todo at session start, keeping it pending until label commands are verified. This makes signaling a tracked obligation from the beginning, not an afterthought at the end

### What was removed from the original PR

The original PR implemented a 3-layer defense (plugin idle hook, workflow hardening, controller fallback). Based on session data analysis, the simpler approach is sufficient:

- ~~Plugin idle signaling enforcer~~ — fragile string matching, infinite loop risk with existing continuation enforcer
- ~~Controller fallback tiers~~ — referenced non-existent API endpoints (`/workers/:id/resume`)
- ~~Workflow breadcrumbs~~ — redundant with GitHub's auto-linking (PR→issue, CI status on PR)
- ~~Learning docs~~ — premises (context exhaustion, 80% failure rate) don't match the data

Closes #85