### PR TITLE
feat: first-class workspace management (#93)

### DIFF
--- a/.opencode/skills/AGENTS.md
+++ b/.opencode/skills/AGENTS.md
@@ -8,7 +8,7 @@ OpenCode skills that orchestrate the autonomous development loop. These are mark
 |-----------|-----------|---------|
 | HTTP API | Controller → Daemon | `curl -X POST http://127.0.0.1:$LEGION_DAEMON_PORT/state/collect` |
 | Piped CLI (legacy) | Controller → State | `echo $JSON \| bun run packages/daemon/src/state/cli.ts --team-id X` — being replaced by `POST /state/collect` |
-| Env vars | Daemon → Controller | `LEGION_TEAM_ID`, `LEGION_DAEMON_PORT`, etc. |
+| Env vars | Daemon → Controller | `LEGION_ID`, `LEGION_DAEMON_PORT`, etc. |
 | Prompt context | Controller → Worker | Issue ID, mode, backend passed in dispatch/resume prompt text |
 | Issue backend | Worker → Linear/GitHub | `linear_linear(action="get"\|"update"\|"comment"\|"create"\|"search")` or `gh issue view/edit/comment` |
 
@@ -47,7 +47,7 @@ workers receive all context (issue ID, mode, backend) via the dispatch prompt, n
 
 | Variable | Set By | Used By | Purpose |
 |----------|--------|---------|---------|
-| `LEGION_TEAM_ID` | CLI/daemon | Controller | Team/project identifier (Linear UUID or GitHub `owner/project-number`) |
+| `LEGION_ID` | CLI/daemon | Controller | Team/project identifier (Linear UUID or GitHub `owner/project-number`) |
 | `LEGION_DIR` | CLI/daemon | Controller | Default jj workspace path |
 | `LEGION_SHORT_ID` | CLI/daemon | Controller | Instance ID for heartbeat |
 | `LEGION_DAEMON_PORT` | Daemon | Controller | HTTP API port (default 13370) |

--- a/.opencode/skills/github/SKILL.md
+++ b/.opencode/skills/github/SKILL.md
@@ -25,7 +25,7 @@ gh project item-list $PROJECT_NUM --owner $OWNER --format json
 ```
 
 **Parameters:**
-- `$PROJECT_NUM`: Project number (from `LEGION_TEAM_ID` format: `owner/project-number`)
+- `$PROJECT_NUM`: Project number (from `LEGION_ID` format: `owner/project-number`)
 - `$OWNER`: Repository owner
 - `--format json`: Returns structured data for parsing
 
@@ -182,7 +182,7 @@ gh issue create --title "Feature: Add dark mode" --body "User request from #789"
 - **Labels are additive**: Use `--add-label` and `--remove-label` separately (unlike Linear which replaces all)
 - **Status updates require Projects V2 GraphQL** — not just issue labels
 - **PR association is automatic** — GitHub links issues and PRs natively
-- **`$OWNER` and `$REPO` come from `LEGION_TEAM_ID`** (format: `owner/project-number`)
+- **`$OWNER` and `$REPO` come from `LEGION_ID`** (format: `owner/project-number`)
 - **Field/option IDs must be cached** by the controller after first resolution
 
 ## Error Handling

--- a/.opencode/skills/legion-controller/SKILL.md
+++ b/.opencode/skills/legion-controller/SKILL.md
@@ -14,9 +14,8 @@ Persistent coordinator that loops forever, dispatching and resuming workers base
 ## Environment
 
 Required:
-- `LEGION_TEAM_ID` - team/project identifier (Linear UUID or GitHub `owner/project-number`)
+- `LEGION_ID` - team/project identifier (Linear UUID or GitHub `owner/project-number`)
 - `LEGION_ISSUE_BACKEND` - issue backend: `"linear"` or `"github"`
-- `LEGION_DIR` - path to default jj workspace
 - `LEGION_SHORT_ID` - short ID for daemon identification
 - `LEGION_DAEMON_PORT` - daemon HTTP API port (default: 13370)
 
@@ -51,18 +50,18 @@ digraph controller {
 ### 1. Fetch Issues
 
 ```bash
-# Derive OWNER and PROJECT_NUM from LEGION_TEAM_ID for GitHub backend
-# LEGION_TEAM_ID format for GitHub: "owner/project-number"
+# Derive OWNER and PROJECT_NUM from LEGION_ID for GitHub backend
+# LEGION_ID format for GitHub: "owner/project-number"
 if [ "$LEGION_ISSUE_BACKEND" = "github" ]; then
-  OWNER="${LEGION_TEAM_ID%%/*}"
-  PROJECT_NUM="${LEGION_TEAM_ID##*/}"
+  OWNER="${LEGION_ID%%/*}"
+  PROJECT_NUM="${LEGION_ID##*/}"
 fi
 
 # Fetch issues based on backend
 if [ "$LEGION_ISSUE_BACKEND" = "github" ]; then
   ISSUES_JSON=$(gh project item-list $PROJECT_NUM --owner $OWNER --format json)
 else
-  ISSUES_JSON=$(linear_linear(action="search", query={"team": "$LEGION_TEAM_ID"}))
+  ISSUES_JSON=$(linear_linear(action="search", query={"team": "$LEGION_ID"}))
 fi
 
 ACTIVE_WORKERS=$(curl -s http://127.0.0.1:$LEGION_DAEMON_PORT/workers | jq 'length')
@@ -178,6 +177,7 @@ If any checks are failing, do NOT dispatch the tester. Instead:
 2. Re-dispatch an implementer with the CI failure output:
 ```bash
 legion dispatch "$ISSUE_IDENTIFIER" implement \
+  --repo "$OWNER/$REPO" \
   --prompt "Invoke the /legion-worker skill for implement mode. CI is failing: [paste failure summary]. Fix and push. ($BACKEND_SUFFIX)"
 ```
 
@@ -228,16 +228,15 @@ Controller routes Triage issues directly (no worker needed):
 
 For Done issues without live workers:
 ```bash
-WORKSPACES_DIR=$(dirname "$LEGION_DIR")
-ISSUE_LOWER=$(echo "$ISSUE_IDENTIFIER" | tr '[:upper:]' '[:lower:]')
-jj workspace forget "$ISSUE_LOWER" -R "$LEGION_DIR"
-rm -rf "$WORKSPACES_DIR/$ISSUE_LOWER"
+curl -s -X DELETE "http://127.0.0.1:$LEGION_DAEMON_PORT/workers/$WORKER_ID/workspace" \
+  -H 'Content-Type: application/json' \
+  -d '{"repo": "'"'$OWNER/$REPO'"'"}'
 ```
 
 ### 7. Write Heartbeat
 
 ```bash
-mkdir -p ~/.legion/$LEGION_SHORT_ID && touch ~/.legion/$LEGION_SHORT_ID/heartbeat
+The daemon handles heartbeat writing automatically. No manual heartbeat step needed.
 ```
 
 ### 8. Update To-Do List
@@ -285,6 +284,7 @@ getting the full skill content.
 ```bash
 # GitHub example:
 legion dispatch "$ISSUE_IDENTIFIER" "$MODE" \
+  --repo "$OWNER/$REPO" \
   --prompt "Invoke the /legion-worker skill for $MODE mode for $ISSUE_IDENTIFIER (github backend, repo: $OWNER/$REPO)"
 
 # Linear example:
@@ -297,6 +297,7 @@ The `dispatch` command handles: workspace creation (jj workspace add), daemon AP
 For custom prompts, still include the backend suffix:
 ```bash
 legion dispatch "$ISSUE_IDENTIFIER" "$MODE" \
+  --repo "$OWNER/$REPO" \
   --prompt "Custom instructions here (github backend, repo: $OWNER/$REPO)"
 ```
 
@@ -349,16 +350,45 @@ curl -s http://127.0.0.1:$LEGION_DAEMON_PORT/workers/$WORKER_ID/status | jq '.'
 The state machine reports `hasLiveWorker`, `workerMode`, and `workerStatus` for each issue.
 Use these signals — don't independently verify worker liveness.
 
-### Forcing a Fresh Session
+### Session Versioning (Escape Hatch Only)
 
 Session IDs are **deterministic** — `computeSessionId(teamId, issueId, mode)` uses UUID v5.
 Same inputs always produce the same session ID. If the serve still has that session in
 memory, re-dispatching with the same issue ID and mode re-attaches to the existing session
 (the serve returns 409 DuplicateIDError, which the daemon treats as "reuse").
 
-This is normally desirable — it's how workers resume across prompts. If you genuinely
-need a fresh session, the daemon will need a session version incrementer (planned).
+**This is by design — session reuse preserves the worker's full context.** A worker that has
+been reading code, making changes, and iterating on review feedback carries all that context
+in its session. Re-dispatching without a version increment reconnects to that session, so
+the worker continues where it left off.
 
+The `--version` flag on `legion dispatch` exists **only as an escape hatch** for unrecoverable
+sessions — e.g., the session is corrupted, the serve crashed and lost the session, or the
+workspace was deleted and recreated. **Do NOT increment versions during normal pipeline
+operation.** Each version increment creates a completely fresh session that has zero context
+about the issue, the codebase changes, or prior work.
+
+**NEVER do this:**
+```bash
+# WRONG: Incrementing version on every dispatch throws away all worker context
+legion dispatch issue-123 implement --version 1 --prompt "Fix review feedback"
+# Later...
+legion dispatch issue-123 implement --version 2 --prompt "Fix CI"
+# Later...
+legion dispatch issue-123 implement --version 3 --prompt "Fix more things"
+```
+
+**Do this instead:**
+```bash
+# CORRECT: Same version (or no version) = worker resumes with full context
+legion dispatch issue-123 implement --prompt "Fix review feedback"
+# Later...
+legion dispatch issue-123 implement --prompt "Fix CI"  # Same session, worker remembers everything
+```
+
+A context-less worker is dangerous — it doesn't understand the branch topology, prior
+changes, or conventions established during earlier work. This can lead to destructive
+actions like force-pushing to the wrong branch.
 ### Don't Delete a Workspace While Workers May Resume
 
 **A worker whose workspace has been deleted cannot respond to prompts.** Every tool call
@@ -425,6 +455,7 @@ If you catch yourself thinking any of these, STOP. You're about to make a mistak
 | "This issue is too big/complex" | No issue is too big. That's what the architect phase is for. Route to Backlog. |
 | "The worker is busy, I'll wait" | Check the transcript. If the worker received prompts but produced no response, the workspace may have been deleted. A worker cannot function without its workspace. |
 | "CI can be fixed later" | CI is the implementer's responsibility. If CI is failing, the implementer isn't done — re-dispatch. |
+| "This worker keeps failing, let me increment the version" | **NEVER increment `--version` during normal operation.** Version increments destroy all worker context. Re-dispatch without version — the worker resumes with full context of prior work. Version is an escape hatch for unrecoverable sessions only. |
 
 ## Common Mistakes
 
@@ -440,6 +471,7 @@ If you catch yourself thinking any of these, STOP. You're about to make a mistak
 | Classify issues as "too big" | Route to Backlog for architect breakdown. No issue is too big for Legion. |
 | Advance pipeline with CI failing | Re-dispatch implementer with CI failure output. Don't dispatch reviewer until CI passes. |
 | Delete a workspace to "reset" a worker | **Never delete a workspace while the worker might be resumed.** A deleted workspace silently kills the worker — prompts arrive but every tool call fails. Only delete during Cleanup Done. |
+| Increment `--version` on every dispatch | **Never increment version during normal pipeline operation.** Each increment creates a fresh session with zero context. A context-less worker is dangerous — it can push to wrong branches, overwrite work, or break the repo. Only use `--version` when a session is truly unrecoverable (serve crash, corrupted session). |
 
 ## Status Flow
 

--- a/.opencode/skills/legion-worker/workflows/architect.md
+++ b/.opencode/skills/legion-worker/workflows/architect.md
@@ -58,7 +58,15 @@ Create each spec-ready sub-issue with `worker-done` label.
 
 This unblocks work on clear pieces while getting answers on unclear ones.
 
-**If spec-ready:** Ensure acceptance criteria are present and testable, add `worker-done` label. Exit.
+**If spec-ready:** Refine the acceptance criteria, add testing infrastructure assessment, and
+**update the issue body** with the complete designed spec. The issue body is the canonical
+record of what this issue is — it must reflect the architect's output, not just the original
+rough description.
+
+- **GitHub:** `gh issue edit $ISSUE_NUMBER --body "[refined spec with acceptance criteria and testing infrastructure]" -R $OWNER/$REPO`
+- **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, description="[refined spec]")`
+
+Then add `worker-done` label. Exit.
 
 ### 4. Cross-Family Review
 

--- a/.opencode/skills/legion-worker/workflows/implement.md
+++ b/.opencode/skills/legion-worker/workflows/implement.md
@@ -187,6 +187,10 @@ jj diff --stat --from main    # File count should match expectations — no unre
 
 If unrelated commits are in the ancestry, rebase to isolate your changes before creating the PR.
 
+**CRITICAL: The PR body MUST include `Closes #$ISSUE_NUMBER`.** This is how GitHub links PRs to
+issues and auto-closes them on merge. Without it, merged PRs leave orphaned issues that stall
+the pipeline. This is NOT optional.
+
 ```bash
 jj describe -m "$LEGION_ISSUE_ID: [description]"
 jj git push --named "$LEGION_ISSUE_ID"=@
@@ -199,6 +203,11 @@ gh pr create --draft \
 [summary]" \
   --head "$LEGION_ISSUE_ID" \
   -R $OWNER/$REPO
+```
+
+**Verify the PR body contains the closing keyword** after creation:
+```bash
+gh pr view $LEGION_ISSUE_ID --json body --jq '.body' -R $OWNER/$REPO | grep -q 'Closes #'
 ```
 
 The issue ID in the branch/title preserves traceability for the controller.

--- a/docs/plans/2026-03-10-fix-deterministic-session-ids.md
+++ b/docs/plans/2026-03-10-fix-deterministic-session-ids.md
@@ -1,0 +1,163 @@
+# Fix Deterministic Session IDs via Version Bump Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Resolve issue #84 by standardizing on `--version` for re-dispatch so operators can intentionally generate a new deterministic session ID.
+
+**Architecture:** Keep the existing deterministic seed model (`computeSessionId(teamId, issueId, mode, version)`) and avoid any session deletion semantics. The fix is documentation, operator workflow clarity, and test coverage around versioned dispatch behavior already introduced in PR #83.
+
+**Tech Stack:** TypeScript, Bun runtime, citty CLI, Bun test runner
+
+---
+
+## Scope Decision (Blocking Feedback Applied)
+
+- In scope:
+  - Validate and document version-based re-dispatch (`--version N`).
+  - Add/adjust tests proving version is threaded end-to-end and changes session ID deterministically.
+  - Update issue narrative to describe version bump workflow.
+- Explicitly out of scope:
+  - No session deletion APIs.
+  - No `--fresh` flag.
+  - No workspace mismatch detection.
+  - No crash-history/workspace tracking additions.
+
+---
+
+## Desired Behavior
+
+1. First dispatch defaults to version `0` (or omitted) and uses base deterministic session ID.
+2. Re-dispatch for same issue/mode can pass `--version 1`, `--version 2`, etc.
+3. Different version values produce different deterministic session IDs.
+4. Same version value remains deterministic across retries.
+5. Operator guidance is clear: bump `--version` when a clean session context is needed.
+
+---
+
+### Task 1: Confirm and lock current version threading behavior
+
+**Files:**
+- Validate: `packages/daemon/src/cli/index.ts`
+- Validate: `packages/daemon/src/daemon/server.ts`
+- Validate: `packages/daemon/src/state/types.ts`
+- Validate: `packages/daemon/src/state/__tests__/types.test.ts`
+
+**Step 1: Verify CLI argument semantics**
+
+- Confirm `dispatch` accepts `--version`.
+- Confirm CLI validates non-negative integer and forwards `version` to `POST /workers`.
+
+**Step 2: Verify daemon threading**
+
+- Confirm `POST /workers` parses `version` and passes it into `computeSessionId(...)`.
+
+**Step 3: Verify deterministic contract tests exist**
+
+- Confirm tests in `state/__tests__/types.test.ts` cover:
+  - version `0` equivalence,
+  - version differentiation,
+  - deterministic same-version output.
+
+---
+
+### Task 2: Add missing tests for version behavior at CLI and daemon boundaries
+
+**Files:**
+- Modify: `packages/daemon/src/cli/__tests__/index.test.ts`
+- Modify: `packages/daemon/src/daemon/__tests__/server.test.ts`
+- Modify: `packages/daemon/src/daemon/__tests__/session-id-contract.test.ts` (if needed)
+
+**Step 1: CLI dispatch payload tests**
+
+- Add/adjust tests to assert:
+  - `--version 2` sends `version: 2` in body.
+  - omitted `--version` does not send invalid values.
+  - invalid version input is rejected with clear error.
+
+**Step 2: Server session ID version tests**
+
+- Add tests in `server.test.ts` to assert:
+  - same `issueId+mode` with different `version` values yields different `sessionId`.
+  - same `version` yields same deterministic `sessionId`.
+
+**Step 3: Contract-level coverage (optional if already sufficient)**
+
+- If current contract tests are thin, add one end-to-end contract case from `/workers` request with explicit `version` to expected `computeSessionId(..., version)`.
+
+---
+
+### Task 3: Minimal operator documentation for re-dispatch
+
+**Files:**
+- Modify: `packages/daemon/src/cli/index.ts` (arg description text only, if needed)
+- Modify: `docs/plans/2026-03-10-fix-deterministic-session-ids.md` (this plan may be final reference)
+- Optional docs location (if available in repo): worker/runbook docs referencing dispatch retries
+
+**Step 1: Clarify command help text**
+
+- Ensure `--version` description explains practical use: bump for fresh session context on re-dispatch.
+
+**Step 2: Add concise operator workflow snippet**
+
+- Example:
+  - initial: `legion dispatch ENG-42 plan`
+  - retry clean context: `legion dispatch ENG-42 plan --version 1`
+  - second retry: `legion dispatch ENG-42 plan --version 2`
+
+---
+
+### Task 4: Optional small enhancement - daemon auto-increment fallback (only if trivial)
+
+**Decision gate:** implement only if the code change is small and testable without introducing session deletion logic.
+
+**Files (if implemented):**
+- Modify: `packages/daemon/src/daemon/server.ts`
+- Modify: `packages/daemon/src/daemon/__tests__/server.test.ts`
+
+**Behavior candidate:**
+
+- If `version` is omitted and session create returns duplicate conflict path, try `version+1` up to a tiny cap (e.g., +3) and use first successful deterministic ID.
+- Keep explicit operator-provided version authoritative (no auto-bump when user specified `version`).
+
+**If not trivial:** skip this task and keep explicit operator bump only.
+
+---
+
+### Task 5: Update issue communication
+
+**Files/Systems:**
+- GitHub issue #84 comments/description in `sjawhar/legion`
+
+**Step 1: Post concise resolution strategy comment**
+
+- State that the accepted fix is versioned session IDs (already in PR #83), with tests and operator guidance.
+- Explicitly state no session deletion/fresh flag/workspace tracking changes are planned.
+
+**Step 2: Link verification evidence**
+
+- Reference relevant tests and command examples.
+
+---
+
+## Testing Plan
+
+### Targeted
+
+- `bun test packages/daemon/src/state/__tests__/types.test.ts`
+- `bun test packages/daemon/src/cli/__tests__/index.test.ts`
+- `bun test packages/daemon/src/daemon/__tests__/server.test.ts`
+- `bun test packages/daemon/src/daemon/__tests__/session-id-contract.test.ts`
+
+### Quality Gate
+
+- `bunx tsc --noEmit`
+- `bun test`
+
+---
+
+## Acceptance Criteria
+
+- Version-based re-dispatch behavior is covered by tests at state, CLI, and daemon boundaries.
+- Operator-facing guidance for `--version` is explicit and accurate.
+- No session deletion semantics are introduced.
+- No workspace mismatch tracking or auto-fresh logic is introduced.

--- a/docs/plans/2026-03-10-fix-worker-signaling.md
+++ b/docs/plans/2026-03-10-fix-worker-signaling.md
@@ -1,0 +1,347 @@
+# Worker Signaling Reliability Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ensure workers reliably complete end-of-work signaling (`worker-done` label, push/PR/comment steps) even when long runs approach context limits.
+
+**Architecture:** Implement three defensive layers: (1) plugin-level idle-time signaling enforcement, (2) workflow-level signaling todo hardening so continuation stays active, and (3) controller-level stalled-worker fallback that resumes signaling or performs safe terminal labeling when work is already verifiably complete. The design treats context exhaustion as expected behavior and moves final signaling guarantees to increasingly external control loops.
+
+**Tech Stack:** TypeScript, Bun, OpenCode plugin hooks (`event`, `chat.message`, `tool.execute.before`, `experimental.*`), Legion worker/controller skills (Markdown workflows), GitHub CLI, daemon state machine.
+
+---
+
+## Hook Point Evaluation (Required Design Inputs)
+
+The OpenCode plugin hook surface (from `@opencode-ai/plugin/dist/index.d.ts`) currently supports:
+
+- `event`
+- `config`
+- `tool`
+- `auth`
+- `chat.message`
+- `chat.params`
+- `chat.headers`
+- `permission.ask`
+- `command.execute.before`
+- `tool.execute.before`
+- `tool.execute.after`
+- `shell.env`
+- `experimental.chat.messages.transform`
+- `experimental.chat.system.transform`
+- `experimental.session.compacting`
+- `experimental.text.complete`
+
+Relevant event types (from `@opencode-ai/sdk`): `session.status`, `session.idle`, `session.error`, `session.compacted`, `session.deleted`, etc.
+
+**Conclusion for issue #85:**
+- `session.idle` already exists and is the correct hook for post-work signaling injection.
+- There is no `agent.turn.complete` hook in current plugin API.
+- We should not block on adding new core hook APIs; implement with existing `event` + `session.idle` now.
+
+---
+
+### Task 1: Add Plugin-Level Worker Signaling Enforcer
+
+**Files:**
+- Create: `packages/opencode-plugin/src/hooks/worker-signaling-enforcer.ts`
+- Modify: `packages/opencode-plugin/src/index.ts`
+- Test: `packages/opencode-plugin/src/__tests__/integration.test.ts`
+
+**Step 1: Write failing tests for idle-time signaling injection**
+
+Add integration tests that simulate:
+- Worker session idles with unfinished signaling context -> signaling prompt is injected.
+- Session idles but signaling is already complete -> no injection.
+- Background session -> no injection.
+- Stop-continuation active -> no injection.
+- Prompt injection error -> swallowed with warning (no crash).
+
+Use existing continuation test style in `integration.test.ts` as a template (stub `session.todo`, `session.messages`, `session.promptAsync`).
+
+**Step 2: Run targeted test to confirm RED state**
+
+Run: `bun test src/__tests__/integration.test.ts`
+Expected: New signaling-enforcer tests fail because hook does not exist yet.
+
+**Step 3: Implement `worker-signaling-enforcer` hook**
+
+Implement a new hook that listens on `event` for `session.idle` and performs guarded injection:
+
+1. Resolve session ID from event props.
+2. Bail if session is background, recovering, or continuation is manually stopped.
+3. Detect worker context (session appears to be a Legion worker flow, not random interactive session).
+4. Detect whether signaling is still pending (initial version should use explicit todo marker; see Task 2).
+5. If pending, inject a concise signaling-only prompt via `ctx.client.session.promptAsync`.
+
+Prompt text should be narrow and non-ambiguous, e.g.:
+
+```text
+Complete only workflow signaling now: finish exit/signaling steps (label updates, push/PR/comment checks) and then stop.
+```
+
+**Step 4: Wire the hook in plugin entrypoint**
+
+In `packages/opencode-plugin/src/index.ts`:
+- Initialize the new hook with existing guard dependencies used by `todo-continuation-enforcer`.
+- Call its `event` handler in the main `event` pipeline.
+- Call its `chat.message` cancellation path if implemented (mirrors timer invalidation strategy).
+
+**Step 5: Run test to confirm GREEN state**
+
+Run: `bun test src/__tests__/integration.test.ts`
+Expected: Signaling-enforcer tests and existing continuation tests pass.
+
+**Step 6: Commit checkpoint**
+
+```bash
+jj describe -m "fix(plugin): inject signaling prompt when worker idles before completion"
+jj new
+```
+
+---
+
+### Task 2: Harden Worker Workflows with Early Signaling Todo
+
+**Files:**
+- Modify: `.opencode/skills/legion-worker/workflows/implement.md`
+- Modify: `.opencode/skills/legion-worker/workflows/plan.md`
+- Modify: `.opencode/skills/legion-worker/workflows/test.md`
+- Modify: `.opencode/skills/legion-worker/workflows/review.md`
+- Modify: `.opencode/skills/legion-worker/workflows/architect.md`
+- (No change expected) `.opencode/skills/legion-worker/workflows/merge.md`
+
+**Step 1: Add explicit signaling todo at workflow start**
+
+In each affected workflow, add an early step that creates a persistent todo such as:
+
+- `Signal completion (worker-done + worker-active cleanup + required PR/CI/comment checks)`
+
+and mark it as `in_progress` early. Keep it incomplete until final signaling step.
+
+**Step 2: Mark signaling todo complete only at final signaling step**
+
+At current final exit/signaling sections, add explicit instruction to mark the signaling todo `completed` only after label application verification succeeds.
+
+**Step 3: Keep merge workflow unchanged**
+
+Document in `merge.md` (or in a shared note referenced by merge) that `worker-done` is intentionally not used for merge mode.
+
+**Step 4: Validate markdown consistency**
+
+Run: `bun test src/__tests__/integration.test.ts`
+Expected: No plugin regression from workflow wording changes (tests remain green).
+
+**Step 5: Commit checkpoint**
+
+```bash
+jj describe -m "fix(workflows): create signaling todo early to keep continuation alive"
+jj new
+```
+
+---
+
+### Task 3: Extend Plugin Signaling Detection to Use Todo Semantics
+
+**Files:**
+- Modify: `packages/opencode-plugin/src/hooks/worker-signaling-enforcer.ts`
+- Test: `packages/opencode-plugin/src/__tests__/integration.test.ts`
+
+**Step 1: Add deterministic signaling-todo matcher**
+
+Implement matcher logic to identify signaling todo items by stable phrase/prefix (exact convention added in Task 2).
+
+**Step 2: Enforce "inject only when signaling todo incomplete"**
+
+Before injecting prompt, fetch todos and require at least one incomplete signaling todo.
+
+**Step 3: Add tests for matcher behavior**
+
+Add tests:
+- Incomplete signaling todo -> inject.
+- Signaling todo completed -> do not inject.
+- Non-signaling todos only -> do not inject.
+
+**Step 4: Run tests**
+
+Run: `bun test src/__tests__/integration.test.ts`
+Expected: All pass.
+
+**Step 5: Commit checkpoint**
+
+```bash
+jj describe -m "fix(plugin): gate idle signaling prompts on dedicated signaling todo"
+jj new
+```
+
+---
+
+### Task 4: Add Controller Fallback for Stalled Signaling
+
+**Files:**
+- Modify: `.opencode/skills/legion-controller/SKILL.md`
+- Modify: `packages/daemon/src/state/decision.ts` (if new explicit action is added)
+- Modify: `packages/daemon/src/state/types.ts` (if new action enum value is added)
+- Modify: `packages/daemon/src/state/__tests__/decision.test.ts`
+- Modify: `packages/daemon/src/state/__tests__/decision-regressions.test.ts`
+
+**Step 1: Define stalled-signaling policy**
+
+Policy condition (GitHub backend):
+- Issue is in active worker pipeline status (`In Progress`, `Testing`, `Needs Review`, or `Retro`).
+- No live worker response progression for configurable threshold (e.g. >10 minutes idle/dead/no session progress).
+- Missing `worker-done`.
+
+**Step 2: Implement fallback behavior in controller skill**
+
+In controller loop logic:
+1. First fallback: resume existing worker with signaling-only prompt.
+2. Second fallback (ultimate, external): if objective evidence shows work is already complete (PR exists, branch pushed, CI status acceptable for stage), apply labels directly (`worker-done`, remove `worker-active`) and post an audit comment describing automated fallback.
+
+Use daemon endpoints (`/workers`, `/workers/:id/status`) and existing state signals; do not inspect serve internals directly.
+
+**Step 3: Optionally codify as explicit state action**
+
+If controller logic would be cleaner with a first-class state action, add one (example: `resume_worker_for_signaling`) through state types + decision mapping + tests.
+
+**Step 4: Add/adjust state decision tests**
+
+Cover:
+- Existing behavior remains unchanged for normal paths.
+- New fallback action (if introduced) only appears under stalled-signaling conditions.
+
+**Step 5: Run daemon state tests**
+
+Run:
+- `bun test src/state/__tests__/decision.test.ts src/state/__tests__/decision-regressions.test.ts`
+
+Expected: Pass.
+
+**Step 6: Commit checkpoint**
+
+```bash
+jj describe -m "fix(controller): recover stalled workers that miss final signaling"
+jj new
+```
+
+---
+
+### Task 5: Handle True Context Exhaustion Explicitly (No More Injection Possible)
+
+**Files:**
+- Modify: `.opencode/skills/legion-controller/SKILL.md`
+- Modify: `.opencode/skills/legion-worker/workflows/implement.md`
+- Modify: `.opencode/skills/legion-worker/workflows/test.md`
+- Modify: `.opencode/skills/legion-worker/workflows/review.md`
+- Modify: `.opencode/skills/legion-worker/workflows/plan.md`
+- Modify: `.opencode/skills/legion-worker/workflows/architect.md`
+
+**Step 1: Document hard-failure path in controller**
+
+Add explicit "when prompt injection/resume fails repeatedly" section:
+- Retry limited number of times.
+- Then perform controller-side terminal signaling only when objective completion evidence exists.
+- Otherwise mark as `user-input-needed` with precise diagnostics.
+
+**Step 2: Add worker-side breadcrumbs to aid fallback**
+
+In workflow docs, require workers to post/maintain minimal verifiable breadcrumbs before heavy operations where possible (e.g., branch name/PR number in comments when created). This improves controller confidence for safe fallback labeling.
+
+**Step 3: Ensure fallback is backend-aware**
+
+Retain GitHub + Linear branches in policy text, but treat GitHub as first implementation target (issue #85 is GitHub-driven).
+
+**Step 4: Commit checkpoint**
+
+```bash
+jj describe -m "docs(controller): codify ultimate fallback when session cannot be resumed"
+jj new
+```
+
+---
+
+### Task 6: End-to-End Validation and Regression Sweep
+
+**Files:**
+- Test: `packages/opencode-plugin/src/__tests__/integration.test.ts`
+- Test: `packages/daemon/src/state/__tests__/decision.test.ts`
+- Test: `packages/daemon/src/state/__tests__/decision-regressions.test.ts`
+
+**Step 1: Run plugin test suite**
+
+Run: `bun test src/__tests__/integration.test.ts`
+Expected: Pass.
+
+**Step 2: Run daemon state tests**
+
+Run: `bun test src/state/__tests__/decision.test.ts src/state/__tests__/decision-regressions.test.ts`
+Expected: Pass.
+
+**Step 3: Run project checks for touched packages**
+
+Run:
+- `bunx tsc --noEmit`
+- `bunx biome check packages/opencode-plugin/src packages/daemon/src/state`
+
+Expected: No type or lint errors.
+
+**Step 4: Manual scenario verification checklist (required before ship)**
+
+Validate these scenarios in a controlled test issue:
+1. Normal completion path still signals once (no duplicate prompts).
+2. Idle before signaling triggers plugin injection and completes signaling.
+3. Simulated hard-stop worker gets recovered by controller fallback.
+4. Merge mode is unaffected (no `worker-done` required).
+
+**Step 5: Final commit checkpoint**
+
+```bash
+jj describe -m "fix: harden worker completion signaling across plugin workflow and controller"
+jj new
+```
+
+---
+
+## Testing Plan
+
+### Setup
+- `bun install`
+- Plugin package tests run from `packages/opencode-plugin`
+- Daemon package tests run from `packages/daemon`
+
+### Health Check
+- `bun --version` returns successfully.
+- `gh auth status` works for GitHub-backed integration checks.
+
+### Verification Steps
+1. **Plugin idle injection behavior**
+   - Action: Run plugin integration tests with new signaling cases.
+   - Expected: Injection happens only for incomplete signaling todos in worker sessions.
+   - Tool: Bun test.
+
+2. **State/controller fallback routing**
+   - Action: Run daemon decision tests.
+   - Expected: Existing transitions unchanged; stalled-signaling fallback path covered.
+   - Tool: Bun test.
+
+3. **Workflow hardening semantics**
+   - Action: Inspect workflow markdown changes.
+   - Expected: Each non-merge worker mode creates signaling todo early and completes it only at exit signaling.
+   - Tool: Manual review + grep.
+
+4. **No regression in core quality gates**
+   - Action: Run typecheck + biome on changed paths.
+   - Expected: Clean.
+   - Tool: Bunx.
+
+### Tools Needed
+- Bun (`bun test`, `bunx tsc`, `bunx biome`)
+- GitHub CLI (`gh`) for real signaling flow checks
+- Read/Grep for workflow and skill policy verification
+
+---
+
+## Risk Notes
+
+- Primary risk is false-positive signaling injection in non-worker sessions; mitigated by strict worker-context detection + signaling-todo gating.
+- Controller-side direct labeling must be constrained to evidence-backed cases only; otherwise it can advance incomplete work.
+- Do not rely on adding new OpenCode core hook types for this fix; implement with current hook API.

--- a/docs/plans/2026-03-10-opencode-legion-plugin-trial-design.md
+++ b/docs/plans/2026-03-10-opencode-legion-plugin-trial-design.md
@@ -1,0 +1,156 @@
+# opencode-legion Plugin Trial via Isolated Config
+
+**Date:** 2026-03-10
+**Status:** Approved
+**Goal:** Run legion workers under the opencode-legion plugin (instead of oh-my-opencode) using an isolated config directory, with a live Sisyphus session as the external controller.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ SISYPHUS SESSION (External Controller)                    │
+│ Config: ~/.config/opencode/ (UNCHANGED, oh-my-opencode)   │
+│ Role: Hybrid controller — runs loop, user interrupts      │
+│ Communicates with daemon via HTTP on port 13370            │
+└────────────────────────┬─────────────────────────────────┘
+                         │ HTTP calls (curl / skill)
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│ DAEMON (legion start, background process)                 │
+│ Env: LEGION_CONTROLLER_SESSION_ID=ses_external_trial      │
+│ Thin substrate: state machine, worker tracking, HTTP API  │
+│ Flags: -b github                                          │
+└────────────────────────┬─────────────────────────────────┘
+                         │ manages
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│ SHARED SERVE (opencode serve, port 13381)                 │
+│ Env: XDG_CONFIG_HOME=~/.legion/trial-config               │
+│ Reads config from: ~/.legion/trial-config/opencode/       │
+│   → opencode-legion plugin (NOT oh-my-opencode)           │
+│   → essential skills only                                 │
+│                                                           │
+│ ┌────────────┐ ┌────────────┐ ┌────────────┐            │
+│ │  Worker 1  │ │  Worker 2  │ │  Worker N  │            │
+│ └────────────┘ └────────────┘ └────────────┘            │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Key Insight
+
+The external controller communicates with workers ONLY through the daemon HTTP API — never directly through the shared serve. Controller config and worker config are completely independent.
+
+## Isolated Config Directory
+
+Location: `~/.legion/trial-config/opencode/`
+
+### Real files (created)
+
+**`opencode.json`** — Verbatim copy of `~/.config/opencode/opencode.json` with one change:
+
+```diff
+- "file://{env:HOME}/oh-my-opencode/original",
++ "file:///home/ubuntu/legion/default/packages/opencode-plugin",
+```
+
+All other sections (keybinds, provider, instructions, mcp, autoupdate) copied verbatim.
+
+**`opencode-legion.json`** — Plugin config ported from current oh-my-opencode.json:
+
+```json
+{
+  "agents": {
+    "orchestrator": { "model": "anthropic/claude-opus-4-6" },
+    "executor": { "model": "anthropic/claude-sonnet-4-6" },
+    "explorer": { "model": "anthropic/claude-haiku-4-5" },
+    "librarian": { "model": "anthropic/claude-sonnet-4-6" },
+    "oracle": { "model": "openai/gpt-5.4" },
+    "metis": { "model": "openai/gpt-5.4" },
+    "momus": { "model": "openai/gpt-5.4" }
+  },
+  "categories": {
+    "ultrabrain": { "defaultModel": "anthropic/claude-opus-4-6" },
+    "deep": { "defaultModel": "openai/gpt-5.3-codex" },
+    "visual-engineering": { "defaultModel": "google/gemini-3.1-pro-preview" },
+    "quick": { "defaultModel": "anthropic/claude-haiku-4-5" },
+    "unspecified-low": { "defaultModel": "anthropic/claude-sonnet-4-6" },
+    "unspecified-high": { "defaultModel": "anthropic/claude-opus-4-6" },
+    "writing": { "defaultModel": "google/gemini-3-flash-preview" },
+    "artistry": { "defaultModel": "google/gemini-3.1-pro-preview" }
+  }
+}
+```
+
+### Symlinks (point to existing files)
+
+| Symlink | Target | Purpose |
+|---------|--------|---------|
+| `AGENTS.md` | `~/.dotfiles/.claude/CLAUDE.md` | Agent instructions |
+| `mcp-oauth.json` | `~/.config/opencode/mcp-oauth.json` | MCP auth tokens |
+| `package.json` | `~/.config/opencode/package.json` | @opencode-ai/plugin dep |
+| `node_modules/` | `~/.config/opencode/node_modules/` | Installed deps |
+| `bun.lock` | `~/.config/opencode/bun.lock` | Lockfile |
+| `skills/superpowers` | `~/.dotfiles/vendor/superpowers/skills` | Superpowers skills |
+| `skills/legion` | `~/.dotfiles/vendor/legion/.opencode/skills` | Legion skills |
+| `skills/using-jj` | `~/.dotfiles/plugins/sjawhar/skills/using-jj` | jj VCS skill |
+| `skills/github` | `~/legion/default/.opencode/skills/github` | GitHub skill |
+| `skills/linear` | `~/legion/default/.opencode/skills/linear` | Linear skill |
+| `plugins/superpowers.js` | `~/.dotfiles/vendor/superpowers/.opencode/plugins/superpowers.js` | Superpowers plugin |
+
+### Intentionally absent
+
+- `oh-my-opencode.json` — not needed, plugin removed
+- Non-essential skills (ce, sjawhar, sentry-for-ai) — workers don't need them
+
+## Prerequisites
+
+1. **Build opencode-legion plugin** — `dist/` directory doesn't exist yet:
+   ```bash
+   cd packages/opencode-plugin && bun run build
+   ```
+
+## Startup Sequence
+
+```bash
+# 1. Build plugin (one-time)
+cd ~/legion/default/packages/opencode-plugin && bun run build
+
+# 2. Run setup script (creates isolated config dir)
+# (script creates ~/.legion/trial-config/opencode/ with files + symlinks)
+
+# 3. Start daemon
+XDG_CONFIG_HOME=$HOME/.legion/trial-config \
+LEGION_CONTROLLER_SESSION_ID=ses_external_trial \
+legion start <team> -b github -w ~/legion/default
+```
+
+Then in the Sisyphus session:
+1. Set `LEGION_DAEMON_PORT=13370` (env or hardcoded in curl calls)
+2. Invoke `/legion-controller` skill for hybrid loop
+3. User can interrupt and issue manual overrides at any time
+
+## Teardown / Rollback
+
+```bash
+legion stop <team>              # Stop daemon + shared serve + all workers
+rm -rf ~/.legion/trial-config   # Delete isolated config
+```
+
+Real `~/.config/opencode/` is **never modified**.
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|-----------|
+| opencode-legion plugin fails to load | Medium | Pre-validate: run `XDG_CONFIG_HOME=~/.legion/trial-config opencode debug config` before starting daemon |
+| Workers miss a skill | Low | Essential skills included; can add more symlinks without restart |
+| Auth/API keys not available | Low | Auth plugins in opencode.json plugin list; mcp-oauth.json symlinked |
+| Plugin has runtime bugs | Medium | This is the whole point of the trial — catch issues with Sisyphus as controller for live debugging |
+| Model assignments don't match | Low | Ported from oh-my-opencode.json; verify with `opencode debug agent` under trial config |
+
+## Success Criteria
+
+1. Daemon starts cleanly with external controller
+2. Workers load opencode-legion plugin (visible in serve logs)
+3. At least one worker completes a full workflow (dispatch → implement → done)
+4. No regressions vs oh-my-opencode behavior for worker tasks

--- a/docs/plans/2026-03-10-opencode-legion-plugin-trial-impl.md
+++ b/docs/plans/2026-03-10-opencode-legion-plugin-trial-impl.md
@@ -1,0 +1,277 @@
+# opencode-legion Plugin Trial — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Set up an isolated opencode config that uses the opencode-legion plugin instead of oh-my-opencode, start the daemon with a Sisyphus external controller, and validate workers load the new plugin.
+
+**Architecture:** Isolated config directory via `XDG_CONFIG_HOME` redirect. External controller communicates with daemon HTTP API. Workers on shared serve inherit the isolated config. See design doc: `docs/plans/2026-03-10-opencode-legion-plugin-trial-design.md`
+
+**Tech Stack:** Bun (build), opencode serve, legion daemon, jj
+
+---
+
+### Task 1: Build the opencode-legion plugin
+
+The plugin at `packages/opencode-plugin/` has no `dist/` directory. It needs to be built since `package.json` declares `"main": "dist/index.js"`.
+
+**Files:**
+- Build output: `packages/opencode-plugin/dist/`
+
+**Step 1: Run the build**
+
+```bash
+cd ~/legion/default/packages/opencode-plugin && bun run build
+```
+
+Expected: `dist/index.js` and `dist/cli/index.js` created.
+
+**Step 2: Verify build output**
+
+```bash
+ls -la ~/legion/default/packages/opencode-plugin/dist/
+```
+
+Expected: `index.js` exists.
+
+---
+
+### Task 2: Create isolated config directory structure
+
+**Files:**
+- Create: `~/.legion/trial-config/opencode/` (directory tree)
+
+**Step 1: Create directories**
+
+```bash
+mkdir -p ~/.legion/trial-config/opencode/skills
+mkdir -p ~/.legion/trial-config/opencode/plugins
+```
+
+**Step 2: Create symlinks — config infrastructure**
+
+```bash
+cd ~/.legion/trial-config/opencode
+ln -s ~/.dotfiles/.claude/CLAUDE.md AGENTS.md
+ln -s ~/.config/opencode/mcp-oauth.json mcp-oauth.json
+ln -s ~/.config/opencode/package.json package.json
+ln -s ~/.config/opencode/node_modules node_modules
+ln -s ~/.config/opencode/bun.lock bun.lock
+```
+
+**Step 3: Create symlinks — essential skills**
+
+```bash
+cd ~/.legion/trial-config/opencode/skills
+ln -s ~/.dotfiles/vendor/superpowers/skills superpowers
+ln -s ~/.dotfiles/vendor/legion/.opencode/skills legion
+ln -s ~/.dotfiles/plugins/sjawhar/skills/using-jj using-jj
+ln -s ~/legion/default/.opencode/skills/github github
+ln -s ~/legion/default/.opencode/skills/linear linear
+```
+
+**Step 4: Create symlink — superpowers plugin**
+
+```bash
+cd ~/.legion/trial-config/opencode/plugins
+ln -s ~/.dotfiles/vendor/superpowers/.opencode/plugins/superpowers.js superpowers.js
+```
+
+**Step 5: Verify symlinks resolve**
+
+```bash
+ls -la ~/.legion/trial-config/opencode/
+ls -la ~/.legion/trial-config/opencode/skills/
+ls -la ~/.legion/trial-config/opencode/plugins/
+```
+
+Expected: All symlinks resolve (no broken links).
+
+---
+
+### Task 3: Create modified opencode.json
+
+**Files:**
+- Create: `~/.legion/trial-config/opencode/opencode.json`
+
+**Step 1: Write the config**
+
+Copy current `~/.config/opencode/opencode.json` verbatim, replacing the oh-my-opencode plugin reference:
+
+```diff
+- "file://{env:HOME}/oh-my-opencode/original",
++ "file:///home/ubuntu/legion/default/packages/opencode-plugin",
+```
+
+All other sections (keybinds, provider, instructions, mcp, autoupdate) remain identical.
+
+**Step 2: Verify JSON is valid**
+
+```bash
+bun -e "console.log(JSON.parse(require('fs').readFileSync('$HOME/.legion/trial-config/opencode/opencode.json','utf8')).plugin)"
+```
+
+Expected: Plugin array contains `file:///home/ubuntu/legion/default/packages/opencode-plugin` and NOT `oh-my-opencode`.
+
+---
+
+### Task 4: Create opencode-legion.json with ported model assignments
+
+**Files:**
+- Create: `~/.legion/trial-config/opencode/opencode-legion.json`
+
+**Step 1: Write the plugin config**
+
+Port model assignments from current `~/.config/opencode/oh-my-opencode.json`:
+
+```json
+{
+  "agents": {
+    "orchestrator": { "model": "anthropic/claude-opus-4-6" },
+    "executor": { "model": "anthropic/claude-sonnet-4-6" },
+    "explorer": { "model": "anthropic/claude-haiku-4-5" },
+    "librarian": { "model": "anthropic/claude-sonnet-4-6" },
+    "oracle": { "model": "openai/gpt-5.4" },
+    "metis": { "model": "openai/gpt-5.4" },
+    "momus": { "model": "openai/gpt-5.4" },
+    "multimodal": { "model": "openai/gpt-5.4" }
+  },
+  "categories": {
+    "ultrabrain": { "defaultModel": "anthropic/claude-opus-4-6" },
+    "deep": { "defaultModel": "openai/gpt-5.3-codex" },
+    "visual-engineering": { "defaultModel": "google/gemini-3.1-pro-preview" },
+    "quick": { "defaultModel": "anthropic/claude-haiku-4-5" },
+    "unspecified-low": { "defaultModel": "anthropic/claude-sonnet-4-6" },
+    "unspecified-high": { "defaultModel": "anthropic/claude-opus-4-6" },
+    "writing": { "defaultModel": "google/gemini-3-flash-preview" },
+    "artistry": { "defaultModel": "google/gemini-3.1-pro-preview" }
+  }
+}
+```
+
+---
+
+### Task 5: Validate the isolated config loads correctly
+
+**Step 1: Check opencode sees the right config path**
+
+```bash
+XDG_CONFIG_HOME=$HOME/.legion/trial-config opencode debug paths
+```
+
+Expected: `config` line shows `~/.legion/trial-config/opencode`.
+
+**Step 2: Check opencode resolves the plugin**
+
+```bash
+XDG_CONFIG_HOME=$HOME/.legion/trial-config opencode debug config 2>&1 | head -40
+```
+
+Expected: Config loads without errors. Plugin list includes `opencode-legion`. No reference to `oh-my-opencode`.
+
+**Step 3: If validation fails, diagnose and fix before proceeding**
+
+Common issues:
+- Plugin build failed → rebuild
+- Broken symlinks → check target paths
+- JSON parse error → fix syntax in opencode.json
+- Missing dependency → check node_modules symlink
+
+---
+
+### Task 6: Start the daemon with external controller
+
+**Step 1: Determine team ID**
+
+The user needs to provide the GitHub project team key. Ask if not known.
+
+**Step 2: Start daemon in background**
+
+```bash
+XDG_CONFIG_HOME=$HOME/.legion/trial-config \
+LEGION_CONTROLLER_SESSION_ID=ses_external_trial \
+nohup legion start <team> -b github -w ~/legion/default > ~/.legion/trial-config/daemon.log 2>&1 &
+```
+
+**Step 3: Verify daemon is running**
+
+```bash
+curl -s http://127.0.0.1:13370/health | jq .
+```
+
+Expected: `{"status":"ok", "workerCount":0, ...}`
+
+**Step 4: Check daemon logs for plugin loading**
+
+```bash
+tail -20 ~/.legion/trial-config/daemon.log
+```
+
+Expected: Shared serve started, no plugin errors.
+
+---
+
+### Task 7: Start the controller loop
+
+**Step 1: Set controller env vars in the Sisyphus session**
+
+The controller skill reads `LEGION_DAEMON_PORT`, `LEGION_TEAM_ID`, `LEGION_ISSUE_BACKEND`, etc. These need to be available. Export them in the session's shell:
+
+```bash
+export LEGION_DAEMON_PORT=13370
+export LEGION_TEAM_ID=<team>
+export LEGION_ISSUE_BACKEND=github
+export LEGION_DIR=~/legion/default
+```
+
+**Step 2: Invoke the controller skill**
+
+In the Sisyphus session, invoke `/legion-controller` to start the hybrid loop.
+
+**Step 3: Verify controller can reach daemon**
+
+The controller's first action is `POST /state/collect`. Watch for successful response.
+
+---
+
+### Task 8: Smoke test — dispatch a worker
+
+**Step 1: Pick a test issue**
+
+Choose a small, well-defined issue from the GitHub project.
+
+**Step 2: Let the controller dispatch (or manually dispatch)**
+
+Either let the controller loop pick it up, or manually:
+
+```bash
+curl -s -X POST http://127.0.0.1:13370/workers \
+  -H "Content-Type: application/json" \
+  -d '{"issueId":"<issue-id>","mode":"implement","workspace":"/home/ubuntu/legion/default"}' | jq .
+```
+
+**Step 3: Verify worker is running**
+
+```bash
+curl -s http://127.0.0.1:13370/workers | jq .
+```
+
+Expected: One worker with status `running` or `starting`.
+
+**Step 4: Check worker uses opencode-legion plugin**
+
+The worker should be running on the shared serve which loaded the isolated config. Verify by checking serve logs or worker behavior (delegation tools, model routing should match opencode-legion config).
+
+---
+
+### Teardown (when done with trial)
+
+```bash
+# Stop daemon
+curl -s -X POST http://127.0.0.1:13370/shutdown
+
+# Or if daemon is in foreground:
+# Ctrl+C or: legion stop <team>
+
+# Delete isolated config
+rm -rf ~/.legion/trial-config
+```

--- a/docs/plans/2026-03-12-workspace-management-design.md
+++ b/docs/plans/2026-03-12-workspace-management-design.md
@@ -1,0 +1,177 @@
+# First-Class Workspace Management
+
+**Date:** 2026-03-12
+**Status:** Approved
+
+## Problem
+
+Legion's workspace model has three compounding issues:
+
+1. **Workspace pollution**: `jj workspace add ... -R user-repo` registers workspaces in the user's jj repo store. `jj workspace list` in a personal checkout shows all Legion workspaces, cluttering the personal environment.
+
+2. **Single-repo assumption**: One `LEGION_DIR` per daemon, one repo per project. But a single GitHub Project can track issues across multiple repositories (agent-c, legion, etc.). Legion can't route issues to different repos.
+
+3. **Non-standard state location**: `~/.legion/` is hardcoded. Not XDG-compliant.
+
+## Solution
+
+Legion manages its own repo clones (fully isolated from personal checkouts), auto-discovers repos from issue metadata, uses XDG-compliant directories, and renames the core unit from "team" to "legion."
+
+## Directory Layout
+
+```
+~/.local/share/legion/                    # XDG_DATA_HOME/legion
+  repos/
+    github.com/<owner>/<repo>/            # Legion's own jj clones (shared across legions)
+  workspaces/
+    <project-id>/
+      <issue-id>/                         # jj workspaces, per-legion
+
+~/.local/state/legion/                    # XDG_STATE_HOME/legion
+  legions.json                            # {project-id: {port, servePort, pid, startedAt}}
+  legions/
+    <project-id>/
+      workers.json
+      logs/
+      heartbeat
+```
+
+### Rationale
+
+- **Repos keyed by `github.com/owner/repo`**: Mirrors `go get`/`ghq` conventions, supports future non-GitHub hosts.
+- **Repos shared across legions**: A repo is a git clone — safe to share since jj workspaces provide isolation. Avoids cloning the same large repo multiple times.
+- **Workspaces keyed by project-id then issue-id**: A workspace belongs to a legion, and that legion's controller manages its lifecycle.
+- **State vs data split**: `XDG_STATE_HOME` for ephemeral operational state (workers.json, logs). `XDG_DATA_HOME` for persistent artifacts (repo clones, in-progress workspaces with uncommitted work).
+
+### XDG Defaults
+
+| Variable | Default | Contents |
+|----------|---------|----------|
+| `XDG_DATA_HOME` | `~/.local/share` | Repo clones, workspaces |
+| `XDG_STATE_HOME` | `~/.local/state` | legions.json, workers.json, logs |
+
+## Repo Management & Auto-Cloning
+
+Workspace management moves into the daemon. The daemon resolves issue ID → repo → clone → workspace.
+
+### Flow
+
+```
+Controller: legion dispatch owner-repo-42 implement
+  ↓
+CLI POSTs to daemon: {issueId: "owner-repo-42", mode: "implement"}
+  ↓
+Daemon resolves repo from issue ID:
+  "owner-repo-42" → github.com/owner/repo
+  ↓
+Daemon ensures clone exists:
+  ~/.local/share/legion/repos/github.com/owner/repo/
+  If missing: jj git clone https://github.com/owner/repo <path>
+  If exists:  jj git fetch -R <path>
+  ↓
+Daemon creates jj workspace if needed:
+  jj workspace add <workspace-path> --name owner-repo-42 -R <clone-path>
+  ↓
+Daemon creates session with workspace path, returns worker entry
+```
+
+### Key Changes
+
+- **`POST /workers` no longer requires `workspace` param** — daemon computes it from issue ID + project ID.
+- **CLI dispatch becomes thinner** — just passes issue ID and mode.
+- **Repo resolution from issue ID** — `owner-repo-42` → `github.com/owner/repo`. This parsing already exists conceptually in the controller skill.
+- **Clone-on-demand** — first issue from a new repo triggers a clone. Subsequent issues reuse the existing clone with a fetch.
+- **`LEGION_DIR` removed** — replaced by the repo pool. No single "base repo" concept.
+
+## Naming: "Legion" not "Team"
+
+A running instance (daemon + controller + workers, focused on one project) is a **legion**. The "team" terminology came from Linear; "legion" is the natural unit.
+
+| Old | New |
+|-----|-----|
+| `teams.json` | `legions.json` |
+| `~/.legion/{teamId}/` | `~/.local/state/legion/legions/{project-id}/` |
+| `LEGION_TEAM_ID` | Retained as env var (it's the project identifier), but conceptually it identifies the legion |
+
+## Multi-Legion Support
+
+Multiple independent daemon instances, each managing its own project. No inter-daemon communication. Only shared resource is the repo pool.
+
+### `legions.json`
+
+```json
+{
+  "sjawhar/42": {"port": 13370, "servePort": 13381, "pid": 12345, "startedAt": "2026-03-12T10:00:00Z"},
+  "other-org/7": {"port": 13371, "servePort": 13382, "pid": 12346, "startedAt": "2026-03-12T11:00:00Z"}
+}
+```
+
+Project ID is the legion ID — no alias layer.
+
+### Port Allocation
+
+- Auto-assigned from base (13370, 13371, ...) by scanning `legions.json` for in-use ports.
+- User can override with `--port` or `LEGION_DAEMON_PORT`.
+- Serve port auto-assigned similarly (base 13381).
+- Stale PID detection: if a legion's PID is dead, reclaim the port.
+
+### CLI Routing
+
+- **Controller → daemon**: `LEGION_DAEMON_PORT` env var (already works, daemon sets it in controller environment).
+- **User → daemon**: CLI reads `legions.json` to find port by project ID.
+
+```bash
+legion start sjawhar/42          # Auto-assigns port, writes legions.json
+legion status sjawhar/42         # Reads legions.json → port 13370
+legion stop sjawhar/42           # Reads legions.json → port 13370
+```
+
+## Controller Changes
+
+Minimal. The controller already includes repo info in dispatch prompts.
+
+### What changes
+
+- **Cleanup step** (step 6): No longer uses `WORKSPACES_DIR=$(dirname "$LEGION_DIR")`. Instead calls a daemon cleanup endpoint or new CLI command, since the daemon knows where workspaces live.
+- **Working directory**: Controller runs in a generic directory (e.g., the state dir), not a repo. It's a coordinator, not a coder.
+- **Remove `LEGION_DIR` references** from the skill.
+
+### What stays the same
+
+- Dispatch/resume prompt format (already includes backend and repo).
+- Controller loop algorithm.
+- State machine routing.
+
+## Worker Changes
+
+**None.** Workers already:
+- Receive issue ID, mode, backend via prompt.
+- Operate in whatever workspace the daemon placed them in.
+- Use jj commands relative to their working directory.
+- Push via `jj git push`.
+
+Workers don't know or care where on disk their workspace lives.
+
+## Component Change Summary
+
+| File | Change |
+|------|--------|
+| `config.ts` | XDG path resolution, auto port assignment, remove `LEGION_DIR` as required |
+| `cli/index.ts` | Read/write `legions.json`, remove workspace creation (daemon handles it), rename team→legion |
+| `server.ts` | `POST /workers` resolves repo + workspace internally, add cleanup endpoint |
+| `index.ts` | Controller runs in generic working dir, register/deregister in `legions.json` |
+| `serve-manager.ts` | New functions for repo cloning, workspace creation |
+| Controller skill | Remove `LEGION_DIR` references, use daemon for cleanup |
+| Worker skill | No changes |
+
+## Migration
+
+No migration. Clean break. Users `rm -rf ~/.legion` and start fresh. All work-in-progress is pushed to GitHub; repo clones are re-created on demand.
+
+## What Stays the Same
+
+- Worker dispatch/resume protocol
+- Session ID computation (deterministic UUIDv5)
+- Worker entry schema (`workspace` field points to new location for new workers)
+- Controller loop algorithm
+- All worker workflows (architect, plan, implement, test, review, merge)

--- a/docs/plans/2026-03-12-workspace-management-impl.md
+++ b/docs/plans/2026-03-12-workspace-management-impl.md
@@ -1,0 +1,962 @@
+# First-Class Workspace Management — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Isolate Legion workspaces from personal jj repos, support multiple repos per project, use XDG-compliant directories, rename "team" to "legion."
+
+**Architecture:** New modules for XDG paths, legions registry, and repo management sit below the daemon. The server's `POST /workers` delegates to repo-manager for cloning and workspace creation. CLI dispatch becomes a thin client passing `{issueId, mode, repo}`. `legions.json` tracks running daemon instances for multi-legion port discovery.
+
+**Tech Stack:** TypeScript/Bun, jj CLI for VCS, zod for validation, Bun test for TDD.
+
+**Design Doc:** `docs/plans/2026-03-12-workspace-management-design.md`
+
+---
+
+## Task 1: XDG Path Resolution
+
+New module that computes all Legion directory paths from XDG environment variables.
+
+**Files:**
+- Create: `packages/daemon/src/daemon/paths.ts`
+- Create: `packages/daemon/src/daemon/__tests__/paths.test.ts`
+
+**Step 1: Write failing tests**
+
+```typescript
+// packages/daemon/src/daemon/__tests__/paths.test.ts
+import { describe, expect, it } from "bun:test";
+import { resolveLegionPaths } from "../paths";
+
+describe("resolveLegionPaths", () => {
+  it("uses XDG defaults when env vars unset", () => {
+    const paths = resolveLegionPaths({}, "/home/testuser");
+    expect(paths.dataDir).toBe("/home/testuser/.local/share/legion");
+    expect(paths.stateDir).toBe("/home/testuser/.local/state/legion");
+    expect(paths.reposDir).toBe("/home/testuser/.local/share/legion/repos");
+    expect(paths.workspacesDir).toBe("/home/testuser/.local/share/legion/workspaces");
+    expect(paths.legionsFile).toBe("/home/testuser/.local/state/legion/legions.json");
+  });
+
+  it("respects XDG_DATA_HOME", () => {
+    const paths = resolveLegionPaths({ XDG_DATA_HOME: "/custom/data" }, "/home/testuser");
+    expect(paths.dataDir).toBe("/custom/data/legion");
+    expect(paths.reposDir).toBe("/custom/data/legion/repos");
+  });
+
+  it("respects XDG_STATE_HOME", () => {
+    const paths = resolveLegionPaths({ XDG_STATE_HOME: "/custom/state" }, "/home/testuser");
+    expect(paths.stateDir).toBe("/custom/state/legion");
+    expect(paths.legionsFile).toBe("/custom/state/legion/legions.json");
+  });
+
+  it("computes legion-specific paths", () => {
+    const paths = resolveLegionPaths({}, "/home/testuser");
+    const legion = paths.forLegion("sjawhar/42");
+    expect(legion.legionStateDir).toBe("/home/testuser/.local/state/legion/legions/sjawhar/42");
+    expect(legion.workersFile).toBe("/home/testuser/.local/state/legion/legions/sjawhar/42/workers.json");
+    expect(legion.logDir).toBe("/home/testuser/.local/state/legion/legions/sjawhar/42/logs");
+    expect(legion.workspacesDir).toBe("/home/testuser/.local/share/legion/workspaces/sjawhar/42");
+  });
+
+  it("computes repo clone path", () => {
+    const paths = resolveLegionPaths({}, "/home/testuser");
+    expect(paths.repoClonePath("github.com", "acme", "widgets")).toBe(
+      "/home/testuser/.local/share/legion/repos/github.com/acme/widgets"
+    );
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `bun test packages/daemon/src/daemon/__tests__/paths.test.ts`
+Expected: FAIL — module not found
+
+**Step 3: Implement paths module**
+
+```typescript
+// packages/daemon/src/daemon/paths.ts
+import path from "node:path";
+
+export interface LegionPaths {
+  dataDir: string;
+  stateDir: string;
+  reposDir: string;
+  workspacesDir: string;
+  legionsFile: string;
+  forLegion(projectId: string): LegionInstancePaths;
+  repoClonePath(host: string, owner: string, repo: string): string;
+}
+
+export interface LegionInstancePaths {
+  legionStateDir: string;
+  workersFile: string;
+  logDir: string;
+  workspacesDir: string;
+}
+
+export function resolveLegionPaths(
+  env: Record<string, string | undefined>,
+  homeDir: string,
+): LegionPaths {
+  const dataHome = env.XDG_DATA_HOME ?? path.join(homeDir, ".local", "share");
+  const stateHome = env.XDG_STATE_HOME ?? path.join(homeDir, ".local", "state");
+
+  const dataDir = path.join(dataHome, "legion");
+  const stateDir = path.join(stateHome, "legion");
+  const reposDir = path.join(dataDir, "repos");
+  const workspacesDir = path.join(dataDir, "workspaces");
+  const legionsFile = path.join(stateDir, "legions.json");
+
+  return {
+    dataDir,
+    stateDir,
+    reposDir,
+    workspacesDir,
+    legionsFile,
+    forLegion(projectId: string): LegionInstancePaths {
+      const legionStateDir = path.join(stateDir, "legions", projectId);
+      return {
+        legionStateDir,
+        workersFile: path.join(legionStateDir, "workers.json"),
+        logDir: path.join(legionStateDir, "logs"),
+        workspacesDir: path.join(workspacesDir, projectId),
+      };
+    },
+    repoClonePath(host: string, owner: string, repo: string): string {
+      return path.join(reposDir, host, owner, repo);
+    },
+  };
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `bun test packages/daemon/src/daemon/__tests__/paths.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+jj describe -m "feat: add XDG path resolution module for Legion directories"
+jj new
+```
+
+---
+
+## Task 2: Legions Registry
+
+New module for reading/writing `legions.json` — tracks running daemon instances with ports.
+
+**Files:**
+- Create: `packages/daemon/src/daemon/legions-registry.ts`
+- Create: `packages/daemon/src/daemon/__tests__/legions-registry.test.ts`
+- Modify: `packages/daemon/src/daemon/schemas.ts` — add `LegionEntrySchema`
+
+**Step 1: Write failing tests**
+
+```typescript
+// packages/daemon/src/daemon/__tests__/legions-registry.test.ts
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  readLegionsRegistry,
+  writeLegionEntry,
+  removeLegionEntry,
+  allocatePort,
+  findLegionByProjectId,
+} from "../legions-registry";
+
+describe("legions-registry", () => {
+  let tempDir: string | null = null;
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  it("returns empty registry when file missing", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-reg-"));
+    const registry = await readLegionsRegistry(path.join(tempDir, "legions.json"));
+    expect(registry).toEqual({});
+  });
+
+  it("writes and reads a legion entry", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-reg-"));
+    const filePath = path.join(tempDir, "legions.json");
+    const entry = { port: 13370, servePort: 13381, pid: 1234, startedAt: "2026-03-12T00:00:00Z" };
+
+    await writeLegionEntry(filePath, "sjawhar/42", entry);
+    const registry = await readLegionsRegistry(filePath);
+
+    expect(registry["sjawhar/42"]).toEqual(entry);
+  });
+
+  it("removes a legion entry", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-reg-"));
+    const filePath = path.join(tempDir, "legions.json");
+    await writeLegionEntry(filePath, "sjawhar/42", {
+      port: 13370, servePort: 13381, pid: 1234, startedAt: "2026-03-12T00:00:00Z",
+    });
+
+    await removeLegionEntry(filePath, "sjawhar/42");
+    const registry = await readLegionsRegistry(filePath);
+
+    expect(registry["sjawhar/42"]).toBeUndefined();
+  });
+
+  it("allocates next available port", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-reg-"));
+    const filePath = path.join(tempDir, "legions.json");
+    await writeLegionEntry(filePath, "proj/1", {
+      port: 13370, servePort: 13381, pid: 1234, startedAt: "2026-03-12T00:00:00Z",
+    });
+
+    const registry = await readLegionsRegistry(filePath);
+    const { daemonPort, servePort } = allocatePort(registry);
+
+    expect(daemonPort).toBe(13371);
+    expect(servePort).toBe(13382);
+  });
+
+  it("reclaims port from dead PID", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-reg-"));
+    const filePath = path.join(tempDir, "legions.json");
+    // Use PID 999999999 which should not exist
+    await writeLegionEntry(filePath, "proj/1", {
+      port: 13370, servePort: 13381, pid: 999999999, startedAt: "2026-03-12T00:00:00Z",
+    });
+
+    const registry = await readLegionsRegistry(filePath);
+    const { daemonPort } = allocatePort(registry);
+
+    expect(daemonPort).toBe(13370); // Reclaimed
+  });
+
+  it("findLegionByProjectId returns entry when it exists", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-reg-"));
+    const filePath = path.join(tempDir, "legions.json");
+    await writeLegionEntry(filePath, "sjawhar/42", {
+      port: 13370, servePort: 13381, pid: process.pid, startedAt: "2026-03-12T00:00:00Z",
+    });
+
+    const entry = await findLegionByProjectId(filePath, "sjawhar/42");
+    expect(entry).toBeDefined();
+    expect(entry!.port).toBe(13370);
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `bun test packages/daemon/src/daemon/__tests__/legions-registry.test.ts`
+Expected: FAIL — module not found
+
+**Step 3: Add schema**
+
+Add `LegionEntrySchema` to `packages/daemon/src/daemon/schemas.ts`:
+
+```typescript
+export const LegionEntrySchema = z.object({
+  port: z.number(),
+  servePort: z.number(),
+  pid: z.number(),
+  startedAt: z.string(),
+});
+
+export const LegionsRegistrySchema = z.record(z.string(), LegionEntrySchema);
+```
+
+**Step 4: Implement legions-registry module**
+
+```typescript
+// packages/daemon/src/daemon/legions-registry.ts
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { LegionsRegistrySchema } from "./schemas";
+
+export interface LegionEntry {
+  port: number;
+  servePort: number;
+  pid: number;
+  startedAt: string;
+}
+
+export type LegionsRegistry = Record<string, LegionEntry>;
+
+const BASE_DAEMON_PORT = 13370;
+const BASE_SERVE_PORT = 13381;
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function readLegionsRegistry(filePath: string): Promise<LegionsRegistry> {
+  try {
+    const raw = await readFile(filePath, "utf-8");
+    if (!raw.trim()) return {};
+    const parsed = JSON.parse(raw);
+    const result = LegionsRegistrySchema.safeParse(parsed);
+    return result.success ? result.data : {};
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === "ENOENT") return {};
+    throw error;
+  }
+}
+
+export async function writeLegionEntry(
+  filePath: string,
+  projectId: string,
+  entry: LegionEntry,
+): Promise<void> {
+  const registry = await readLegionsRegistry(filePath);
+  registry[projectId] = entry;
+  await writeRegistry(filePath, registry);
+}
+
+export async function removeLegionEntry(filePath: string, projectId: string): Promise<void> {
+  const registry = await readLegionsRegistry(filePath);
+  delete registry[projectId];
+  await writeRegistry(filePath, registry);
+}
+
+export function allocatePort(
+  registry: LegionsRegistry,
+): { daemonPort: number; servePort: number } {
+  const usedDaemonPorts = new Set<number>();
+  const usedServePorts = new Set<number>();
+
+  for (const entry of Object.values(registry)) {
+    if (isPidAlive(entry.pid)) {
+      usedDaemonPorts.add(entry.port);
+      usedServePorts.add(entry.servePort);
+    }
+  }
+
+  let daemonPort = BASE_DAEMON_PORT;
+  while (usedDaemonPorts.has(daemonPort)) daemonPort++;
+
+  let servePort = BASE_SERVE_PORT;
+  while (usedServePorts.has(servePort)) servePort++;
+
+  return { daemonPort, servePort };
+}
+
+export async function findLegionByProjectId(
+  filePath: string,
+  projectId: string,
+): Promise<LegionEntry | undefined> {
+  const registry = await readLegionsRegistry(filePath);
+  return registry[projectId];
+}
+
+async function writeRegistry(filePath: string, registry: LegionsRegistry): Promise<void> {
+  const dir = path.dirname(filePath);
+  await mkdir(dir, { recursive: true });
+  const tempPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  await writeFile(tempPath, JSON.stringify(registry, null, 2), "utf-8");
+  await rename(tempPath, filePath);
+}
+```
+
+**Step 5: Run tests to verify they pass**
+
+Run: `bun test packages/daemon/src/daemon/__tests__/legions-registry.test.ts`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+jj describe -m "feat: add legions registry for tracking daemon instances"
+jj new
+```
+
+---
+
+## Task 3: Repo Manager
+
+New module that clones repos and creates jj workspaces. Shells out to `jj` CLI.
+
+**Files:**
+- Create: `packages/daemon/src/daemon/repo-manager.ts`
+- Create: `packages/daemon/src/daemon/__tests__/repo-manager.test.ts`
+
+**Step 1: Write failing tests**
+
+Tests use DI for the jj command runner to avoid real cloning in tests.
+
+```typescript
+// packages/daemon/src/daemon/__tests__/repo-manager.test.ts
+import { describe, expect, it } from "bun:test";
+import {
+  parseIssueRepo,
+  resolveWorkspacePath,
+  type RepoManagerDeps,
+  ensureRepoClone,
+  ensureWorkspace,
+} from "../repo-manager";
+import type { LegionPaths } from "../paths";
+import { resolveLegionPaths } from "../paths";
+
+describe("parseIssueRepo", () => {
+  it("parses explicit owner/repo", () => {
+    const result = parseIssueRepo("acme/widgets");
+    expect(result).toEqual({ host: "github.com", owner: "acme", repo: "widgets" });
+  });
+
+  it("returns null for invalid repo string", () => {
+    expect(parseIssueRepo("")).toBeNull();
+    expect(parseIssueRepo("noslash")).toBeNull();
+  });
+});
+
+describe("resolveWorkspacePath", () => {
+  it("builds workspace path from paths + projectId + issueId", () => {
+    const paths = resolveLegionPaths({}, "/home/test");
+    const result = resolveWorkspacePath(paths, "sjawhar/42", "acme-widgets-7");
+    expect(result).toBe("/home/test/.local/share/legion/workspaces/sjawhar/42/acme-widgets-7");
+  });
+});
+
+describe("ensureRepoClone", () => {
+  it("clones when directory does not exist", async () => {
+    const commands: string[][] = [];
+    const deps: RepoManagerDeps = {
+      runJj: async (args) => { commands.push(args); return { exitCode: 0, stdout: "", stderr: "" }; },
+      exists: async () => false,
+    };
+
+    const paths = resolveLegionPaths({}, "/home/test");
+    await ensureRepoClone(paths, { host: "github.com", owner: "acme", repo: "widgets" }, deps);
+
+    expect(commands[0]).toContain("git");
+    expect(commands[0]).toContain("clone");
+    expect(commands[0]).toContain("https://github.com/acme/widgets");
+  });
+
+  it("fetches when directory already exists", async () => {
+    const commands: string[][] = [];
+    const deps: RepoManagerDeps = {
+      runJj: async (args) => { commands.push(args); return { exitCode: 0, stdout: "", stderr: "" }; },
+      exists: async () => true,
+    };
+
+    const paths = resolveLegionPaths({}, "/home/test");
+    await ensureRepoClone(paths, { host: "github.com", owner: "acme", repo: "widgets" }, deps);
+
+    expect(commands[0]).toContain("git");
+    expect(commands[0]).toContain("fetch");
+  });
+});
+
+describe("ensureWorkspace", () => {
+  it("creates jj workspace when it does not exist", async () => {
+    const commands: string[][] = [];
+    const deps: RepoManagerDeps = {
+      runJj: async (args) => { commands.push(args); return { exitCode: 0, stdout: "", stderr: "" }; },
+      exists: async (p) => p.includes("repos/"), // repo exists, workspace does not
+    };
+
+    const paths = resolveLegionPaths({}, "/home/test");
+    const repo = { host: "github.com", owner: "acme", repo: "widgets" };
+    const wsPath = await ensureWorkspace(paths, "sjawhar/42", "acme-widgets-7", repo, deps);
+
+    expect(wsPath).toBe("/home/test/.local/share/legion/workspaces/sjawhar/42/acme-widgets-7");
+    const wsCmd = commands.find((c) => c.includes("workspace"));
+    expect(wsCmd).toBeDefined();
+    expect(wsCmd).toContain("add");
+  });
+
+  it("skips workspace creation when it already exists", async () => {
+    const commands: string[][] = [];
+    const deps: RepoManagerDeps = {
+      runJj: async (args) => { commands.push(args); return { exitCode: 0, stdout: "", stderr: "" }; },
+      exists: async () => true,
+    };
+
+    const paths = resolveLegionPaths({}, "/home/test");
+    const repo = { host: "github.com", owner: "acme", repo: "widgets" };
+    await ensureWorkspace(paths, "sjawhar/42", "acme-widgets-7", repo, deps);
+
+    const wsCmd = commands.find((c) => c.includes("workspace"));
+    expect(wsCmd).toBeUndefined(); // No workspace add needed
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `bun test packages/daemon/src/daemon/__tests__/repo-manager.test.ts`
+Expected: FAIL
+
+**Step 3: Implement repo-manager**
+
+```typescript
+// packages/daemon/src/daemon/repo-manager.ts
+import path from "node:path";
+import type { LegionPaths } from "./paths";
+
+export interface RepoRef {
+  host: string;
+  owner: string;
+  repo: string;
+}
+
+export interface JjResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface RepoManagerDeps {
+  runJj: (args: string[]) => Promise<JjResult>;
+  exists: (path: string) => Promise<boolean>;
+}
+
+const defaultDeps: RepoManagerDeps = {
+  runJj: async (args) => {
+    const result = Bun.spawnSync(["jj", ...args], {
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 120_000,
+    });
+    return {
+      exitCode: result.exitCode,
+      stdout: result.stdout.toString(),
+      stderr: result.stderr.toString(),
+    };
+  },
+  exists: async (p) => {
+    const { existsSync } = await import("node:fs");
+    return existsSync(p);
+  },
+};
+
+export function parseIssueRepo(repoStr: string): RepoRef | null {
+  const parts = repoStr.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+  return { host: "github.com", owner: parts[0], repo: parts[1] };
+}
+
+export function resolveWorkspacePath(
+  paths: LegionPaths,
+  projectId: string,
+  issueId: string,
+): string {
+  return path.join(paths.forLegion(projectId).workspacesDir, issueId);
+}
+
+export async function ensureRepoClone(
+  paths: LegionPaths,
+  repo: RepoRef,
+  deps: RepoManagerDeps = defaultDeps,
+): Promise<string> {
+  const clonePath = paths.repoClonePath(repo.host, repo.owner, repo.repo);
+
+  if (await deps.exists(clonePath)) {
+    const result = await deps.runJj(["git", "fetch", "-R", clonePath]);
+    if (result.exitCode !== 0) {
+      console.warn(`[repo-manager] jj git fetch failed for ${clonePath}: ${result.stderr}`);
+    }
+  } else {
+    const url = `https://${repo.host}/${repo.owner}/${repo.repo}`;
+    const result = await deps.runJj(["git", "clone", url, clonePath]);
+    if (result.exitCode !== 0) {
+      throw new Error(`Failed to clone ${url}: ${result.stderr}`);
+    }
+  }
+
+  return clonePath;
+}
+
+export async function ensureWorkspace(
+  paths: LegionPaths,
+  projectId: string,
+  issueId: string,
+  repo: RepoRef,
+  deps: RepoManagerDeps = defaultDeps,
+): Promise<string> {
+  const clonePath = await ensureRepoClone(paths, repo, deps);
+  const workspacePath = resolveWorkspacePath(paths, projectId, issueId);
+
+  if (!(await deps.exists(workspacePath))) {
+    const result = await deps.runJj([
+      "workspace", "add", workspacePath,
+      "--name", issueId.toLowerCase(),
+      "-R", clonePath,
+    ]);
+    if (result.exitCode !== 0) {
+      throw new Error(`Failed to create workspace ${workspacePath}: ${result.stderr}`);
+    }
+  }
+
+  return workspacePath;
+}
+
+export async function cleanupWorkspace(
+  paths: LegionPaths,
+  projectId: string,
+  issueId: string,
+  repo: RepoRef,
+  deps: RepoManagerDeps = defaultDeps,
+): Promise<void> {
+  const clonePath = paths.repoClonePath(repo.host, repo.owner, repo.repo);
+  const workspacePath = resolveWorkspacePath(paths, projectId, issueId);
+
+  // Forget workspace in jj
+  await deps.runJj(["workspace", "forget", issueId.toLowerCase(), "-R", clonePath]);
+
+  // Remove directory
+  const { rm } = await import("node:fs/promises");
+  await rm(workspacePath, { recursive: true, force: true });
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `bun test packages/daemon/src/daemon/__tests__/repo-manager.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+jj describe -m "feat: add repo manager for cloning repos and creating jj workspaces"
+jj new
+```
+
+---
+
+## Task 4: Update DaemonConfig to Use XDG Paths
+
+Wire `paths.ts` into `config.ts`. Replace hardcoded `~/.legion` paths.
+
+**Files:**
+- Modify: `packages/daemon/src/daemon/config.ts`
+- Modify: `packages/daemon/src/daemon/__tests__/config.test.ts`
+
+**Step 1: Update config.ts**
+
+Add `LegionPaths` to `DaemonConfig`. Replace `resolveStateFilePath` with paths from `resolveLegionPaths`. Keep `legionDir` temporarily for backward compat but deprecate it. Add `paths` field to `DaemonConfig`.
+
+Key changes:
+- Add `paths: LegionPaths` to `DaemonConfig`
+- `stateFilePath` and `logDir` computed from `paths.forLegion(teamId)` when teamId is available
+- `loadConfig()` calls `resolveLegionPaths(env, os.homedir())`
+
+**Step 2: Update config tests**
+
+Update expectations: `stateFilePath` should now point to `~/.local/state/legion/legions/<teamId>/workers.json` instead of `~/.legion/daemon/workers.json`.
+
+**Step 3: Run tests, fix any breakage**
+
+Run: `bun test packages/daemon/src/daemon/__tests__/config.test.ts`
+
+**Step 4: Commit**
+
+```bash
+jj describe -m "feat: wire XDG paths into DaemonConfig"
+jj new
+```
+
+---
+
+## Task 5: Server — POST /workers Resolves Workspace Internally
+
+Change `POST /workers` to accept an optional `repo` param and delegate to repo-manager. Workspace path is computed by the daemon, not passed by the caller.
+
+**Files:**
+- Modify: `packages/daemon/src/daemon/server.ts`
+- Modify: `packages/daemon/src/daemon/server.ts:ServerOptions` — add `paths` and `projectId`
+- Modify: `packages/daemon/src/daemon/__tests__/server.test.ts`
+
+**Step 1: Update ServerOptions**
+
+Add to `ServerOptions`:
+```typescript
+paths: LegionPaths;
+projectId: string;
+```
+
+**Step 2: Update POST /workers handler**
+
+Change the handler to:
+- Accept `{issueId, mode}` (required) + `repo` (optional, `"owner/repo"` format) + `workspace` (optional, for backward compat)
+- If `repo` is provided: use `parseIssueRepo` + `ensureWorkspace` to compute workspace path
+- If `workspace` is provided (legacy): use it directly
+- If neither: return `badRequest("missing repo or workspace")`
+
+**Step 3: Add cleanup endpoint**
+
+Add `DELETE /workers/:id/workspace` endpoint that calls `cleanupWorkspace()`.
+
+**Step 4: Update server tests**
+
+Add tests for the new repo-based workspace resolution flow. Use DI — pass a mock `repoManager` or use the existing adapter pattern.
+
+**Step 5: Run all server tests**
+
+Run: `bun test packages/daemon/src/daemon/__tests__/server.test.ts`
+
+**Step 6: Commit**
+
+```bash
+jj describe -m "feat: POST /workers resolves workspace from repo param"
+jj new
+```
+
+---
+
+## Task 6: Daemon Lifecycle — Legions Registry Integration
+
+On `startDaemon()`: register in `legions.json`. On shutdown: deregister. Controller runs in a generic working directory.
+
+**Files:**
+- Modify: `packages/daemon/src/daemon/index.ts`
+- Modify: `packages/daemon/src/daemon/__tests__/index.test.ts`
+
+**Step 1: Update startDaemon()**
+
+- After server starts, call `writeLegionEntry(paths.legionsFile, projectId, { port, servePort, pid, startedAt })`
+- In `shutdown()`, call `removeLegionEntry(paths.legionsFile, projectId)`
+- Controller session workspace: use `paths.forLegion(projectId).legionStateDir` instead of `config.legionDir`
+- Pass `paths` and `projectId` to `startServer()`
+
+**Step 2: Update buildControllerEnv()**
+
+- Remove `LEGION_DIR` (controller no longer needs a repo path)
+- Keep `LEGION_TEAM_ID`, `LEGION_ISSUE_BACKEND`, `LEGION_DAEMON_PORT`, `LEGION_SHORT_ID`
+
+**Step 3: Update tests**
+
+Mock `writeLegionEntry`/`removeLegionEntry` or use temp dirs. Verify registry is written on start and cleaned on shutdown.
+
+**Step 4: Run tests**
+
+Run: `bun test packages/daemon/src/daemon/__tests__/index.test.ts`
+
+**Step 5: Commit**
+
+```bash
+jj describe -m "feat: register/deregister daemon in legions.json on start/stop"
+jj new
+```
+
+---
+
+## Task 7: CLI — Dispatch Uses Repo, Port Discovery from Registry
+
+Make `legion dispatch` pass `repo` to daemon instead of creating workspaces. CLI commands discover port from `legions.json`.
+
+**Files:**
+- Modify: `packages/daemon/src/cli/index.ts`
+- Modify: `packages/daemon/src/cli/team-resolver.ts` — update cache path to XDG
+- Modify: `packages/daemon/src/cli/__tests__/index.test.ts`
+- Modify: `packages/daemon/src/cli/__tests__/team-resolver.test.ts`
+
+**Step 1: Add `--repo` flag to dispatchCommand**
+
+```typescript
+repo: { type: "string", alias: "r", description: "Repository (owner/repo)" },
+```
+
+**Step 2: Update cmdDispatch()**
+
+- Remove jj workspace creation logic (lines 309-319 of current index.ts)
+- POST to daemon with `{issueId, mode, repo}` instead of `{issueId, mode, workspace}`
+- `legionDir` and workspace resolution no longer needed
+
+**Step 3: Update port discovery**
+
+Add a `getDaemonPortForProject(projectId)` function:
+- Check `LEGION_DAEMON_PORT` env var first (controller path)
+- Fall back to reading `legions.json` and looking up by project ID
+- Fall back to default port 13370
+
+Update `cmdStatus`, `cmdStop`, `cmdAttach` to use this.
+
+**Step 4: Rename team → legion in CLI text**
+
+Update help text, console.log messages, command descriptions. Rename `teamsCommand` → keep command name `teams` for now (avoid breaking scripts) but update the description.
+
+**Step 5: Update team-resolver cache path**
+
+Change default cache dir from `~/.legion` to XDG state dir.
+
+**Step 6: Run CLI tests**
+
+Run: `bun test packages/daemon/src/cli/__tests__/`
+
+**Step 7: Commit**
+
+```bash
+jj describe -m "feat: CLI dispatch passes repo to daemon, port discovery from legions.json"
+jj new
+```
+
+---
+
+## Task 8: Update Controller Skill
+
+Remove `LEGION_DIR` references, add `--repo` to dispatch commands, update cleanup.
+
+**Files:**
+- Modify: `.opencode/skills/legion-controller/SKILL.md`
+- Modify: `.claude/skills/legion-controller/SKILL.md` (mirror)
+
+**Step 1: Update Environment section**
+
+Remove `LEGION_DIR` from required env vars.
+
+**Step 2: Update dispatch examples**
+
+Change from:
+```bash
+legion dispatch "$ISSUE_IDENTIFIER" "$MODE" \
+  --prompt "..."
+```
+
+To:
+```bash
+legion dispatch "$ISSUE_IDENTIFIER" "$MODE" \
+  --repo "$OWNER/$REPO" \
+  --prompt "..."
+```
+
+The controller already derives `$OWNER/$REPO` from the issue identifier (format: `owner-repo-number`). Document this derivation.
+
+**Step 3: Update cleanup step (step 6)**
+
+Replace:
+```bash
+WORKSPACES_DIR=$(dirname "$LEGION_DIR")
+ISSUE_LOWER=$(echo "$ISSUE_IDENTIFIER" | tr '[:upper:]' '[:lower:]')
+jj workspace forget "$ISSUE_LOWER" -R "$LEGION_DIR"
+rm -rf "$WORKSPACES_DIR/$ISSUE_LOWER"
+```
+
+With:
+```bash
+legion cleanup "$ISSUE_IDENTIFIER" --repo "$OWNER/$REPO"
+```
+
+Or use the daemon HTTP endpoint:
+```bash
+curl -s -X DELETE "http://127.0.0.1:$LEGION_DAEMON_PORT/workers/$WORKER_ID/workspace" \
+  -H 'Content-Type: application/json' \
+  -d '{"repo": "'"$OWNER/$REPO"'"}'
+```
+
+**Step 4: Update heartbeat path**
+
+Change from:
+```bash
+mkdir -p ~/.legion/$LEGION_SHORT_ID && touch ~/.legion/$LEGION_SHORT_ID/heartbeat
+```
+
+To: let the daemon handle heartbeat writing (it already knows its state dir), or update to use the new XDG path. The daemon writes heartbeat to `~/.local/state/legion/legions/<project-id>/heartbeat`.
+
+**Step 5: Commit**
+
+```bash
+jj describe -m "feat: update controller skill for multi-repo workspace management"
+jj new
+```
+
+---
+
+## Task 9: Remove Legacy Code & Update Remaining Tests
+
+Clean up old `~/.legion` references, remove `loadTeamsCache`, update integration tests.
+
+**Files:**
+- Modify: `packages/daemon/src/cli/index.ts` — remove `loadTeamsCache` function
+- Modify: `packages/daemon/src/daemon/config.ts` — remove old `resolveStateFilePath`
+- Modify: `packages/daemon/src/__tests__/integration.test.ts`
+- Modify: `packages/daemon/src/daemon/__tests__/session-id-contract.test.ts` (if affected)
+
+**Step 1: Remove loadTeamsCache()**
+
+This function reads `~/.legion/teams.json`. Replace with `readLegionsRegistry` in the `teamsCommand`.
+
+**Step 2: Remove resolveStateFilePath()**
+
+This function hardcoded `~/.legion/daemon/workers.json`. State file paths now come from `paths.forLegion(projectId).workersFile`.
+
+**Step 3: Update integration tests**
+
+Ensure integration tests use the new XDG paths and temp directories.
+
+**Step 4: Run full test suite**
+
+Run: `bun test`
+Expected: All tests pass
+
+**Step 5: Lint and type check**
+
+Run: `bunx biome check src/ && bunx tsc --noEmit`
+Expected: No errors
+
+**Step 6: Commit**
+
+```bash
+jj describe -m "refactor: remove legacy ~/.legion paths and loadTeamsCache"
+jj new
+```
+
+---
+
+## Task 10: End-to-End Verification
+
+Verify the complete flow works: start daemon, dispatch with repo, workspace created in XDG dir.
+
+**Step 1: Manual smoke test**
+
+```bash
+# Verify XDG paths
+ls ~/.local/share/legion/    # Should not exist yet
+ls ~/.local/state/legion/    # Should not exist yet
+
+# Start a legion
+LEGION_ISSUE_BACKEND=github legion start sjawhar/2
+
+# Check legions.json was created
+cat ~/.local/state/legion/legions.json
+
+# Dispatch a worker (from another terminal, or via controller)
+legion dispatch sjawhar-legion-93 implement --repo sjawhar/legion
+
+# Verify repo was cloned
+ls ~/.local/share/legion/repos/github.com/sjawhar/legion/
+
+# Verify workspace was created
+ls ~/.local/share/legion/workspaces/sjawhar-2/sjawhar-legion-93/
+
+# Verify personal jj repo is NOT polluted
+cd ~/legion/default && jj workspace list  # Should NOT show sjawhar-legion-93
+
+# Stop
+legion stop sjawhar/2
+cat ~/.local/state/legion/legions.json  # Entry should be removed
+```
+
+**Step 2: Clean up old state**
+
+```bash
+rm -rf ~/.legion
+```
+
+**Step 3: Final commit**
+
+```bash
+jj describe -m "docs: workspace management implementation complete"
+jj new
+```

--- a/packages/daemon/src/__tests__/integration.test.ts
+++ b/packages/daemon/src/__tests__/integration.test.ts
@@ -40,7 +40,7 @@ async function withTestServer(run: (ctx: TestServerContext) => Promise<void>): P
   const { server, stop } = startServer({
     port: randomPort(),
     hostname: "127.0.0.1",
-    teamId: TEAM_ID,
+    legionId: TEAM_ID,
     legionDir: tempDir,
     adapter,
     stateFilePath,

--- a/packages/daemon/src/cli/__tests__/index.test.ts
+++ b/packages/daemon/src/cli/__tests__/index.test.ts
@@ -25,6 +25,7 @@ mock.module("node:child_process", () => ({
   },
 }));
 
+import { resolveLegionPaths } from "../../daemon/paths";
 import {
   attachCommand,
   CliError,
@@ -33,13 +34,13 @@ import {
   cmdResetCrashes,
   dispatchCommand,
   getDaemonPort,
-  loadTeamsCache,
+  legionsCommand,
+  loadLegionsCache,
   promptCommand,
   resetCrashesCommand,
   startCommand,
   statusCommand,
   stopCommand,
-  teamsCommand,
 } from "../index";
 
 interface CommandWithArgs {
@@ -68,8 +69,6 @@ interface RunnableCommand {
 
 type FetchCall = [string | URL, RequestInit?];
 type FetchMock = ReturnType<typeof mock> & typeof fetch;
-type SpawnSyncMock = ReturnType<typeof mock> & typeof Bun.spawnSync;
-type SpawnSyncCall = Parameters<typeof Bun.spawnSync>;
 
 function installFetchMock(
   impl: (input: string | URL, init?: RequestInit) => Promise<Response>
@@ -79,25 +78,6 @@ function installFetchMock(
   }) as FetchMock;
   globalThis.fetch = fetchMock;
   return fetchMock;
-}
-
-function installSpawnSyncMock(
-  impl?: (...args: Parameters<typeof Bun.spawnSync>) => ReturnType<typeof Bun.spawnSync>
-): SpawnSyncMock {
-  const implementation =
-    impl ??
-    ((..._args: Parameters<typeof Bun.spawnSync>): ReturnType<typeof Bun.spawnSync> =>
-      ({
-        exitCode: 0,
-        stdout: Buffer.from(""),
-        stderr: Buffer.from(""),
-        success: true,
-        pid: 0,
-        resourceUsage: {} as ReturnType<typeof Bun.spawnSync>["resourceUsage"],
-      }) as ReturnType<typeof Bun.spawnSync>);
-  const spawnSyncMock = mock(implementation) as SpawnSyncMock;
-  Bun.spawnSync = spawnSyncMock;
-  return spawnSyncMock;
 }
 
 async function runCommand(command: unknown, args: Record<string, unknown>): Promise<void> {
@@ -173,7 +153,7 @@ describe("citty command definitions", () => {
   });
 
   test("teams command args are defined", async () => {
-    const args = await resolveArgs(teamsCommand);
+    const args = await resolveArgs(legionsCommand);
     const all = args.all as BooleanArg;
     expect(all.type).toBe("boolean");
     expect(all.default).toBe(false);
@@ -185,6 +165,7 @@ describe("citty command definitions", () => {
     const mode = args.mode as PositionalArg;
     const prompt = args.prompt as StringArg;
     const workspace = args.workspace as StringArg;
+    const repo = args.repo as StringArg;
     expect(issue.type).toBe("positional");
     expect(issue.required).toBe(true);
     expect(mode.type).toBe("positional");
@@ -192,6 +173,8 @@ describe("citty command definitions", () => {
     expect(prompt.type).toBe("string");
     expect(workspace.type).toBe("string");
     expect(workspace.alias).toBe("w");
+    expect(repo.type).toBe("string");
+    expect(repo.alias).toBe("r");
   });
 
   test("prompt command args are defined", async () => {
@@ -219,46 +202,24 @@ describe("citty command definitions", () => {
 
 describe("cmdDispatch", () => {
   const originalFetch = globalThis.fetch;
-  const originalSpawnSync = Bun.spawnSync;
   const originalLog = console.log;
   const originalError = console.error;
   const originalWarn = console.warn;
-  const tempDirs: string[] = [];
-
-  const createTempDir = () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legion-dispatch-"));
-    tempDirs.push(dir);
-    return dir;
-  };
 
   beforeEach(() => {
     console.log = mock(() => {}) as typeof console.log;
     console.error = mock(() => {}) as typeof console.error;
     console.warn = mock(() => {}) as typeof console.warn;
-    installSpawnSyncMock();
   });
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
-    Bun.spawnSync = originalSpawnSync;
     console.log = originalLog;
     console.error = originalError;
     console.warn = originalWarn;
-    while (tempDirs.length > 0) {
-      const dir = tempDirs.pop();
-      if (dir && fs.existsSync(dir)) {
-        fs.rmSync(dir, { recursive: true, force: true });
-      }
-    }
   });
 
-  it("dispatches worker via daemon API and sends initial prompt", async () => {
-    const tempDir = createTempDir();
-    const legionDir = path.join(tempDir, "legion");
-    const workspacePath = path.join(tempDir, "leg-42");
-    fs.mkdirSync(legionDir);
-    fs.mkdirSync(workspacePath);
-
+  it("dispatches worker via daemon API with repo and sends initial prompt", async () => {
     const fetchMock = installFetchMock((input: string | URL) => {
       const url = input.toString();
       if (url.endsWith("/health")) {
@@ -282,7 +243,10 @@ describe("cmdDispatch", () => {
       }
       return Promise.reject(new Error(`Unexpected fetch: ${url}`));
     });
-    await cmdDispatch("LEG-42", "implement", { legionDir, daemonPort: 13371 });
+    await cmdDispatch("LEG-42", "implement", {
+      daemonPort: 13371,
+      repo: "sjawhar/legion",
+    });
 
     expect(fetchMock.mock.calls.length).toBe(3);
     const [postUrl, postInit] = fetchMock.mock.calls[1] as FetchCall;
@@ -292,9 +256,13 @@ describe("cmdDispatch", () => {
     const body = JSON.parse(postInitResolved.body as string) as {
       issueId: string;
       mode: string;
-      workspace: string;
+      repo: string;
     };
-    expect(body).toEqual({ issueId: "LEG-42", mode: "implement", workspace: workspacePath });
+    expect(body).toEqual({
+      issueId: "LEG-42",
+      mode: "implement",
+      repo: "sjawhar/legion",
+    });
 
     const [promptUrl, promptInit] = fetchMock.mock.calls[2] as FetchCall;
     expect(promptUrl.toString()).toBe("http://127.0.0.1:13371/workers/leg-42-implement/prompt");
@@ -303,13 +271,7 @@ describe("cmdDispatch", () => {
     });
   });
 
-  it("derives workspace path from legionDir and issue identifier", async () => {
-    const tempDir = createTempDir();
-    const legionDir = path.join(tempDir, "legion");
-    const workspacePath = path.join(tempDir, "leg-42");
-    fs.mkdirSync(legionDir);
-    fs.mkdirSync(workspacePath);
-
+  it("uses workspace for backward compatibility when provided", async () => {
     const fetchMock = installFetchMock((input: string | URL) => {
       const url = input.toString();
       if (url.endsWith("/health")) {
@@ -322,7 +284,10 @@ describe("cmdDispatch", () => {
         })
       );
     });
-    await cmdDispatch("LEG-42", "implement", { legionDir, daemonPort: 13372 });
+    await cmdDispatch("LEG-42", "implement", {
+      daemonPort: 13372,
+      workspace: "/tmp/legacy-workspace",
+    });
 
     const [, postInit] = fetchMock.mock.calls[1] as FetchCall;
     const body = JSON.parse((postInit as RequestInit).body as string) as {
@@ -330,32 +295,34 @@ describe("cmdDispatch", () => {
       mode: string;
       workspace: string;
     };
-    expect(body.workspace).toBe(workspacePath);
+    expect(body.workspace).toBe("/tmp/legacy-workspace");
+  });
+
+  it("fails when neither repo nor workspace is provided", () => {
+    installFetchMock((input: string | URL) => {
+      const url = input.toString();
+      if (url.endsWith("/health")) {
+        return Promise.resolve(new Response(JSON.stringify({ status: "ok" }), { status: 200 }));
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+
+    return expect(cmdDispatch("LEG-42", "implement", { daemonPort: 13372 })).rejects.toThrow(
+      "Either --repo or --workspace is required"
+    );
   });
 
   it("fails gracefully when daemon is not running", async () => {
-    const tempDir = createTempDir();
-    const legionDir = path.join(tempDir, "legion");
-    const workspacePath = path.join(tempDir, "leg-42");
-    fs.mkdirSync(legionDir);
-    fs.mkdirSync(workspacePath);
-
     installFetchMock(() => {
       throw new Error("ECONNREFUSED");
     });
 
     return expect(
-      cmdDispatch("LEG-42", "implement", { legionDir, daemonPort: 13373 })
+      cmdDispatch("LEG-42", "implement", { daemonPort: 13373, repo: "sjawhar/legion" })
     ).rejects.toThrow(CliError);
   });
 
   it("reports 409 when worker already exists", async () => {
-    const tempDir = createTempDir();
-    const legionDir = path.join(tempDir, "legion");
-    const workspacePath = path.join(tempDir, "leg-42");
-    fs.mkdirSync(legionDir);
-    fs.mkdirSync(workspacePath);
-
     const fetchMock = installFetchMock((input: string | URL) => {
       const url = input.toString();
       if (url.endsWith("/health")) {
@@ -373,18 +340,12 @@ describe("cmdDispatch", () => {
         )
       );
     });
-    await cmdDispatch("LEG-42", "implement", { legionDir, daemonPort: 13374 });
+    await cmdDispatch("LEG-42", "implement", { daemonPort: 13374, repo: "sjawhar/legion" });
 
     expect(fetchMock.mock.calls.length).toBe(2);
   });
 
   it("reports 429 when crash limit exceeded", async () => {
-    const tempDir = createTempDir();
-    const legionDir = path.join(tempDir, "legion");
-    const workspacePath = path.join(tempDir, "leg-42");
-    fs.mkdirSync(legionDir);
-    fs.mkdirSync(workspacePath);
-
     installFetchMock((input: string | URL) => {
       const url = input.toString();
       if (url.endsWith("/health")) {
@@ -404,53 +365,11 @@ describe("cmdDispatch", () => {
     });
 
     return expect(
-      cmdDispatch("LEG-42", "implement", { legionDir, daemonPort: 13375 })
+      cmdDispatch("LEG-42", "implement", { daemonPort: 13375, repo: "sjawhar/legion" })
     ).rejects.toThrow(CliError);
   });
 
-  it("creates jj workspace when directory does not exist", async () => {
-    const tempDir = createTempDir();
-    const legionDir = path.join(tempDir, "legion");
-    fs.mkdirSync(legionDir);
-    // Do NOT create workspacePath — force jj workspace creation path
-
-    installFetchMock((input: string | URL) => {
-      const url = input.toString();
-      if (url.endsWith("/health")) {
-        return Promise.resolve(new Response(JSON.stringify({ status: "ok" }), { status: 200 }));
-      }
-      return Promise.resolve(
-        new Response(JSON.stringify({ id: "leg-42-implement", port: 18000, sessionId: "s-5" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        })
-      );
-    });
-
-    await cmdDispatch("LEG-42", "implement", { legionDir, daemonPort: 13376 });
-
-    const spawnCalls = (Bun.spawnSync as SpawnSyncMock).mock.calls;
-    expect(spawnCalls.length).toBe(1);
-    const spawnCall = spawnCalls[0] as SpawnSyncCall;
-    expect(spawnCall[0]).toEqual([
-      "jj",
-      "workspace",
-      "add",
-      path.join(tempDir, "leg-42"),
-      "--name",
-      "leg-42",
-      "-R",
-      legionDir,
-    ]);
-  });
-
   it("warns but succeeds when prompt delivery fails", async () => {
-    const tempDir = createTempDir();
-    const legionDir = path.join(tempDir, "legion");
-    const workspacePath = path.join(tempDir, "leg-42");
-    fs.mkdirSync(legionDir);
-    fs.mkdirSync(workspacePath);
-
     installFetchMock((input: string | URL) => {
       const url = input.toString();
       if (url.endsWith("/health")) {
@@ -470,7 +389,10 @@ describe("cmdDispatch", () => {
       return Promise.reject(new Error(`Unexpected fetch: ${url}`));
     });
 
-    await cmdDispatch("LEG-42", "implement", { legionDir, daemonPort: 13377 });
+    await cmdDispatch("LEG-42", "implement", {
+      daemonPort: 13377,
+      repo: "sjawhar/legion",
+    });
 
     const warnCalls = (console.warn as ReturnType<typeof mock>).mock.calls.flat();
     expect(warnCalls).toContain("Worker spawned but prompt delivery failed. Send manually:");
@@ -489,10 +411,6 @@ describe("cmdDispatch", () => {
   });
 
   it("fails when daemon health check is unhealthy", () => {
-    const tempDir = createTempDir();
-    const legionDir = path.join(tempDir, "legion");
-    fs.mkdirSync(legionDir);
-
     installFetchMock((input: string | URL) => {
       const url = input.toString();
       if (url.endsWith("/health")) {
@@ -502,47 +420,11 @@ describe("cmdDispatch", () => {
     });
 
     return expect(
-      cmdDispatch("LEG-42", "implement", { legionDir, daemonPort: 13382 })
+      cmdDispatch("LEG-42", "implement", { daemonPort: 13382, repo: "sjawhar/legion" })
     ).rejects.toThrow("Daemon is not healthy");
   });
 
-  it("fails when jj workspace creation fails", () => {
-    const tempDir = createTempDir();
-    const legionDir = path.join(tempDir, "legion");
-    fs.mkdirSync(legionDir);
-
-    installSpawnSyncMock(
-      (..._args: Parameters<typeof Bun.spawnSync>): ReturnType<typeof Bun.spawnSync> =>
-        ({
-          exitCode: 1,
-          stdout: Buffer.from(""),
-          stderr: Buffer.from("jj failed"),
-          success: false,
-          pid: 0,
-          resourceUsage: {} as ReturnType<typeof Bun.spawnSync>["resourceUsage"],
-        }) as ReturnType<typeof Bun.spawnSync>
-    );
-
-    installFetchMock((input: string | URL) => {
-      const url = input.toString();
-      if (url.endsWith("/health")) {
-        return Promise.resolve(new Response(JSON.stringify({ status: "ok" }), { status: 200 }));
-      }
-      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
-    });
-
-    return expect(
-      cmdDispatch("LEG-42", "implement", { legionDir, daemonPort: 13383 })
-    ).rejects.toThrow("Failed to create workspace: jj failed");
-  });
-
   it("fails when daemon worker creation cannot connect", () => {
-    const tempDir = createTempDir();
-    const legionDir = path.join(tempDir, "legion");
-    const workspacePath = path.join(tempDir, "leg-42");
-    fs.mkdirSync(legionDir);
-    fs.mkdirSync(workspacePath);
-
     installFetchMock((input: string | URL) => {
       const url = input.toString();
       if (url.endsWith("/health")) {
@@ -555,17 +437,11 @@ describe("cmdDispatch", () => {
     });
 
     return expect(
-      cmdDispatch("LEG-42", "implement", { legionDir, daemonPort: 13384 })
+      cmdDispatch("LEG-42", "implement", { daemonPort: 13384, repo: "sjawhar/legion" })
     ).rejects.toThrow("Could not connect to daemon");
   });
 
   it("fails when daemon returns non-JSON response", () => {
-    const tempDir = createTempDir();
-    const legionDir = path.join(tempDir, "legion");
-    const workspacePath = path.join(tempDir, "leg-42");
-    fs.mkdirSync(legionDir);
-    fs.mkdirSync(workspacePath);
-
     installFetchMock((input: string | URL) => {
       const url = input.toString();
       if (url.endsWith("/health")) {
@@ -578,17 +454,11 @@ describe("cmdDispatch", () => {
     });
 
     return expect(
-      cmdDispatch("LEG-42", "implement", { legionDir, daemonPort: 13385 })
+      cmdDispatch("LEG-42", "implement", { daemonPort: 13385, repo: "sjawhar/legion" })
     ).rejects.toThrow("Daemon returned non-JSON response (status 200)");
   });
 
   it("fails when daemon returns non-OK status", () => {
-    const tempDir = createTempDir();
-    const legionDir = path.join(tempDir, "legion");
-    const workspacePath = path.join(tempDir, "leg-42");
-    fs.mkdirSync(legionDir);
-    fs.mkdirSync(workspacePath);
-
     installFetchMock((input: string | URL) => {
       const url = input.toString();
       if (url.endsWith("/health")) {
@@ -606,7 +476,7 @@ describe("cmdDispatch", () => {
     });
 
     return expect(
-      cmdDispatch("LEG-42", "implement", { legionDir, daemonPort: 13386 })
+      cmdDispatch("LEG-42", "implement", { daemonPort: 13386, repo: "sjawhar/legion" })
     ).rejects.toThrow('Failed to dispatch: {"error":"nope"}');
   });
 });
@@ -1068,24 +938,172 @@ describe("cmdResetCrashes", () => {
 });
 
 describe("getDaemonPort", () => {
-  test("returns default port when env unset", () => {
-    expect(getDaemonPort({} as NodeJS.ProcessEnv)).toBe(13370);
+  test("returns default port when env unset", async () => {
+    expect(await getDaemonPort()).toBe(13370);
   });
 
-  test("returns env port when valid", () => {
-    expect(getDaemonPort({ LEGION_DAEMON_PORT: "14400" } as NodeJS.ProcessEnv)).toBe(14400);
+  test("returns env port when valid", async () => {
+    const originalPort = process.env.LEGION_DAEMON_PORT;
+    process.env.LEGION_DAEMON_PORT = "14400";
+    try {
+      expect(await getDaemonPort()).toBe(14400);
+    } finally {
+      if (originalPort === undefined) {
+        delete process.env.LEGION_DAEMON_PORT;
+      } else {
+        process.env.LEGION_DAEMON_PORT = originalPort;
+      }
+    }
   });
 
-  test("falls back when env port invalid", () => {
-    expect(getDaemonPort({ LEGION_DAEMON_PORT: "not-a-number" } as NodeJS.ProcessEnv)).toBe(13370);
+  test("falls back when env port invalid", async () => {
+    const originalPort = process.env.LEGION_DAEMON_PORT;
+    process.env.LEGION_DAEMON_PORT = "not-a-number";
+    try {
+      expect(await getDaemonPort()).toBe(13370);
+    } finally {
+      if (originalPort === undefined) {
+        delete process.env.LEGION_DAEMON_PORT;
+      } else {
+        process.env.LEGION_DAEMON_PORT = originalPort;
+      }
+    }
+  });
+
+  test("reads daemon port from legions registry when projectId provided", async () => {
+    const stateHome = fs.mkdtempSync(path.join(os.tmpdir(), "legion-state-home-"));
+    const originalStateHome = process.env.XDG_STATE_HOME;
+    const originalPort = process.env.LEGION_DAEMON_PORT;
+
+    delete process.env.LEGION_DAEMON_PORT;
+    process.env.XDG_STATE_HOME = stateHome;
+    const legionsFile = path.join(stateHome, "legion", "legions.json");
+    fs.mkdirSync(path.dirname(legionsFile), { recursive: true });
+    fs.writeFileSync(
+      legionsFile,
+      JSON.stringify(
+        {
+          "sjawhar/42": {
+            port: 15555,
+            servePort: 15566,
+            pid: process.pid,
+            startedAt: "2026-01-01T00:00:00.000Z",
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    try {
+      expect(await getDaemonPort("sjawhar/42")).toBe(15555);
+    } finally {
+      fs.rmSync(stateHome, { recursive: true, force: true });
+      if (originalStateHome === undefined) {
+        delete process.env.XDG_STATE_HOME;
+      } else {
+        process.env.XDG_STATE_HOME = originalStateHome;
+      }
+      if (originalPort === undefined) {
+        delete process.env.LEGION_DAEMON_PORT;
+      } else {
+        process.env.LEGION_DAEMON_PORT = originalPort;
+      }
+    }
+  });
+
+  describe("characterization: getDaemonPort", () => {
+    test("returns port from registry when project entry exists", async () => {
+      const stateHome = fs.mkdtempSync(path.join(os.tmpdir(), "legion-state-home-"));
+      const originalStateHome = process.env.XDG_STATE_HOME;
+      const originalPort = process.env.LEGION_DAEMON_PORT;
+
+      delete process.env.LEGION_DAEMON_PORT;
+      process.env.XDG_STATE_HOME = stateHome;
+      const legionsFile = path.join(stateHome, "legion", "legions.json");
+      fs.mkdirSync(path.dirname(legionsFile), { recursive: true });
+      fs.writeFileSync(
+        legionsFile,
+        JSON.stringify(
+          {
+            "acme/77": {
+              port: 16666,
+              servePort: 17777,
+              pid: process.pid,
+              startedAt: "2026-01-01T00:00:00.000Z",
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      try {
+        expect(await getDaemonPort("acme/77")).toBe(16666);
+      } finally {
+        fs.rmSync(stateHome, { recursive: true, force: true });
+        if (originalStateHome === undefined) {
+          delete process.env.XDG_STATE_HOME;
+        } else {
+          process.env.XDG_STATE_HOME = originalStateHome;
+        }
+        if (originalPort === undefined) {
+          delete process.env.LEGION_DAEMON_PORT;
+        } else {
+          process.env.LEGION_DAEMON_PORT = originalPort;
+        }
+      }
+    });
+
+    test("returns default port when registry has no project entry", async () => {
+      const stateHome = fs.mkdtempSync(path.join(os.tmpdir(), "legion-state-home-"));
+      const originalStateHome = process.env.XDG_STATE_HOME;
+      const originalPort = process.env.LEGION_DAEMON_PORT;
+
+      delete process.env.LEGION_DAEMON_PORT;
+      process.env.XDG_STATE_HOME = stateHome;
+      const legionsFile = path.join(stateHome, "legion", "legions.json");
+      fs.mkdirSync(path.dirname(legionsFile), { recursive: true });
+      fs.writeFileSync(
+        legionsFile,
+        JSON.stringify(
+          {
+            "acme/77": {
+              port: 16666,
+              servePort: 17777,
+              pid: process.pid,
+              startedAt: "2026-01-01T00:00:00.000Z",
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      try {
+        expect(await getDaemonPort("missing/project")).toBe(13370);
+      } finally {
+        fs.rmSync(stateHome, { recursive: true, force: true });
+        if (originalStateHome === undefined) {
+          delete process.env.XDG_STATE_HOME;
+        } else {
+          process.env.XDG_STATE_HOME = originalStateHome;
+        }
+        if (originalPort === undefined) {
+          delete process.env.LEGION_DAEMON_PORT;
+        } else {
+          process.env.LEGION_DAEMON_PORT = originalPort;
+        }
+      }
+    });
   });
 });
 
-describe("loadTeamsCache", () => {
+describe("loadLegionsCache", () => {
   test("returns null when cache missing", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "legion-cache-"));
     try {
-      expect(loadTeamsCache(tempDir)).toBeNull();
+      expect(loadLegionsCache(tempDir)).toBeNull();
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
@@ -1094,16 +1112,95 @@ describe("loadTeamsCache", () => {
   test("loads teams cache from disk", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "legion-cache-"));
     try {
-      const cacheFile = path.join(tempDir, "teams.json");
+      const cacheFile = path.join(tempDir, "project-cache.json");
       const payload = {
         LEG: { id: "uuid-123", name: "Legion" },
       };
       fs.writeFileSync(cacheFile, JSON.stringify(payload, null, 2));
 
-      const result = loadTeamsCache(tempDir);
+      const result = loadLegionsCache(tempDir);
       expect(result).toEqual(payload);
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("CLI XDG path migration", () => {
+  const originalFetch = globalThis.fetch;
+  const originalLog = console.log;
+  const originalError = console.error;
+
+  beforeEach(() => {
+    console.log = mock(() => {}) as typeof console.log;
+    console.error = mock(() => {}) as typeof console.error;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    console.log = originalLog;
+    console.error = originalError;
+  });
+
+  test("cmdStart path derivation uses XDG, not legacy dotdir", () => {
+    const stateHome = fs.mkdtempSync(path.join(os.tmpdir(), "legion-xdg-start-"));
+    const originalStateHome = process.env.XDG_STATE_HOME;
+    process.env.XDG_STATE_HOME = stateHome;
+
+    try {
+      const legionId = "12345678-1234-1234-1234-123456789abc";
+      // This is the exact same call cmdStart makes after the XDG migration
+      const instancePaths = resolveLegionPaths(process.env, os.homedir()).forLegion(legionId);
+
+      // Verify paths are XDG-based, not legacy
+      expect(instancePaths.workersFile).toContain(stateHome);
+      expect(instancePaths.workersFile).not.toContain(".legion");
+      expect(instancePaths.legionStateDir).toContain(stateHome);
+      expect(instancePaths.legionStateDir).not.toContain(".legion");
+    } finally {
+      if (originalStateHome === undefined) {
+        delete process.env.XDG_STATE_HOME;
+      } else {
+        process.env.XDG_STATE_HOME = originalStateHome;
+      }
+      fs.rmSync(stateHome, { recursive: true, force: true });
+    }
+  });
+
+  test("cmdStatus reads state from XDG path, not legacy path", async () => {
+    const stateHome = fs.mkdtempSync(path.join(os.tmpdir(), "legion-xdg-status-"));
+    const originalStateHome = process.env.XDG_STATE_HOME;
+    process.env.XDG_STATE_HOME = stateHome;
+
+    try {
+      const legionId = "12345678-1234-1234-1234-123456789abc";
+      const legionStateDir = path.join(stateHome, "legion", "legions", legionId);
+      fs.mkdirSync(legionStateDir, { recursive: true });
+      const workersFile = path.join(legionStateDir, "workers.json");
+      fs.writeFileSync(workersFile, JSON.stringify([]));
+
+      // Mock fetch to simulate daemon not running
+      installFetchMock(() => {
+        throw new Error("ECONNREFUSED");
+      });
+
+      await runCommand(statusCommand, { team: legionId });
+
+      // Verify console.log mentions the XDG state file path
+      const logCalls = (console.log as ReturnType<typeof mock>).mock.calls.flat();
+      const stateFileLog = logCalls.find(
+        (line: unknown) => typeof line === "string" && line.includes("State file:")
+      ) as string | undefined;
+      expect(stateFileLog).toBeDefined();
+      expect(stateFileLog).toContain(stateHome);
+      expect(stateFileLog).not.toContain(".legion");
+    } finally {
+      if (originalStateHome === undefined) {
+        delete process.env.XDG_STATE_HOME;
+      } else {
+        process.env.XDG_STATE_HOME = originalStateHome;
+      }
+      fs.rmSync(stateHome, { recursive: true, force: true });
     }
   });
 });

--- a/packages/daemon/src/cli/__tests__/legion-resolver.test.ts
+++ b/packages/daemon/src/cli/__tests__/legion-resolver.test.ts
@@ -2,9 +2,9 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { resolveTeamId } from "../team-resolver";
+import { resolveLegionId } from "../legion-resolver";
 
-describe("resolveTeamId", () => {
+describe("resolveLegionId", () => {
   const originalHome = process.env.HOME;
   const originalFetch = globalThis.fetch;
   let testHome: string;
@@ -14,7 +14,7 @@ describe("resolveTeamId", () => {
   beforeEach(() => {
     testHome = path.join(os.tmpdir(), `legion-test-${Date.now()}-${Math.random()}`);
     testCacheDir = path.join(testHome, ".legion");
-    testCacheFile = path.join(testCacheDir, "teams.json");
+    testCacheFile = path.join(testCacheDir, "project-cache.json");
 
     fs.mkdirSync(testCacheDir, { recursive: true });
     process.env.HOME = testHome;
@@ -27,21 +27,45 @@ describe("resolveTeamId", () => {
     }
     process.env.HOME = originalHome;
     delete process.env.LINEAR_API_TOKEN;
+    delete process.env.XDG_STATE_HOME;
   });
 
   test("returns UUID as-is when given valid UUID", async () => {
     const uuid = "12345678-1234-1234-1234-123456789abc";
-    const result = await resolveTeamId(uuid, testCacheDir);
+    const result = await resolveLegionId(uuid, testCacheDir);
     expect(result).toBe(uuid);
+  });
+
+  test("uses XDG state dir for cache when cacheDir not provided", async () => {
+    const xdgStateHome = path.join(testHome, "xdg-state-home");
+    const cacheDir = path.join(xdgStateHome, "legion");
+    const cacheFile = path.join(cacheDir, "project-cache.json");
+    process.env.XDG_STATE_HOME = xdgStateHome;
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(
+      cacheFile,
+      JSON.stringify(
+        {
+          LEG: {
+            id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            name: "Legion",
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    await expect(resolveLegionId("LEG")).resolves.toBe("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
   });
 
   test("returns UUID as-is when given valid UUID (uppercase)", async () => {
     const uuid = "12345678-1234-1234-1234-123456789ABC";
-    const result = await resolveTeamId(uuid, testCacheDir);
+    const result = await resolveLegionId(uuid, testCacheDir);
     expect(result).toBe(uuid);
   });
 
-  test("resolves team key from cache file", async () => {
+  test("resolves legion key from cache file", async () => {
     const teams = {
       LEG: {
         id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
@@ -54,11 +78,11 @@ describe("resolveTeamId", () => {
     };
     fs.writeFileSync(testCacheFile, JSON.stringify(teams, null, 2));
 
-    const result = await resolveTeamId("LEG", testCacheDir);
+    const result = await resolveLegionId("LEG", testCacheDir);
     expect(result).toBe("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
   });
 
-  test("resolves team key case-insensitively from cache", async () => {
+  test("resolves legion key case-insensitively from cache", async () => {
     const teams = {
       LEG: {
         id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
@@ -67,11 +91,11 @@ describe("resolveTeamId", () => {
     };
     fs.writeFileSync(testCacheFile, JSON.stringify(teams, null, 2));
 
-    const result = await resolveTeamId("leg", testCacheDir);
+    const result = await resolveLegionId("leg", testCacheDir);
     expect(result).toBe("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
   });
 
-  test("throws error when team key not in cache and no API key", async () => {
+  test("throws error when legion key not in cache and no API key", async () => {
     const teams = {
       ENG: {
         id: "11111111-2222-3333-4444-555555555555",
@@ -80,14 +104,14 @@ describe("resolveTeamId", () => {
     };
     fs.writeFileSync(testCacheFile, JSON.stringify(teams, null, 2));
 
-    await expect(resolveTeamId("LEG", testCacheDir)).rejects.toThrow("'LEG' is not a UUID");
+    await expect(resolveLegionId("LEG", testCacheDir)).rejects.toThrow("'LEG' is not a UUID");
   });
 
   test("throws error when no cache file and no API key", async () => {
-    await expect(resolveTeamId("LEG", testCacheDir)).rejects.toThrow("'LEG' is not a UUID");
+    await expect(resolveLegionId("LEG", testCacheDir)).rejects.toThrow("'LEG' is not a UUID");
   });
 
-  test("looks up team via API when cache miss and API key present", async () => {
+  test("looks up legion via API when cache miss and API key present", async () => {
     process.env.LINEAR_API_TOKEN = "test-api-key";
 
     const mockFetch = mock(async (url: string, options?: RequestInit) => {
@@ -111,12 +135,12 @@ describe("resolveTeamId", () => {
 
     globalThis.fetch = mockFetch as unknown as typeof fetch;
 
-    const result = await resolveTeamId("LEG", testCacheDir);
+    const result = await resolveLegionId("LEG", testCacheDir);
     expect(result).toBe("fetched-uuid-1234");
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
-  test("throws error when API returns no team", async () => {
+  test("throws error when API returns no legion", async () => {
     process.env.LINEAR_API_TOKEN = "test-api-key";
 
     globalThis.fetch = mock(async () => {
@@ -132,8 +156,8 @@ describe("resolveTeamId", () => {
       );
     }) as unknown as typeof fetch;
 
-    await expect(resolveTeamId("NOTFOUND", testCacheDir)).rejects.toThrow(
-      "Team 'NOTFOUND' not found in Linear. Available team keys: (none)"
+    await expect(resolveLegionId("NOTFOUND", testCacheDir)).rejects.toThrow(
+      "Legion 'NOTFOUND' not found in Linear. Available legion keys: (none)"
     );
   });
 
@@ -165,8 +189,8 @@ describe("resolveTeamId", () => {
       );
     }) as unknown as typeof fetch;
 
-    await expect(resolveTeamId("NOTFOUND", testCacheDir)).rejects.toThrow(
-      "Available team keys: DES, ENG"
+    await expect(resolveLegionId("NOTFOUND", testCacheDir)).rejects.toThrow(
+      "Available legion keys: DES, ENG"
     );
   });
 
@@ -183,15 +207,15 @@ describe("resolveTeamId", () => {
       );
     }) as unknown as typeof fetch;
 
-    await expect(resolveTeamId("LEG", testCacheDir)).rejects.toThrow("auth error");
+    await expect(resolveLegionId("LEG", testCacheDir)).rejects.toThrow("auth error");
   });
 
   // NOTE: The real API query filters by a single key (teams(filter: { key: { eq: $key } })),
-  // so it returns at most 1 team. This test validates the merge/caching logic with multiple
-  // teams as a theoretical edge case — if the API filter is ever broadened, this ensures
+  // so it returns at most 1 legion. This test validates the merge/caching logic with multiple
+  // legions as a theoretical edge case — if the API filter is ever broadened, this ensures
   // cache merging still works correctly.
 
-  test("caches all returned teams after successful API lookup", async () => {
+  test("caches all returned legions after successful API lookup", async () => {
     process.env.LINEAR_API_TOKEN = "test-api-key";
 
     globalThis.fetch = mock(async () => {
@@ -210,7 +234,7 @@ describe("resolveTeamId", () => {
       );
     }) as unknown as typeof fetch;
 
-    const result = await resolveTeamId("LEG", testCacheDir);
+    const result = await resolveLegionId("LEG", testCacheDir);
     expect(result).toBe("fetched-uuid-1234");
 
     const cached = JSON.parse(fs.readFileSync(testCacheFile, "utf-8"));
@@ -220,7 +244,7 @@ describe("resolveTeamId", () => {
     });
   });
 
-  test("merges new teams with existing cache", async () => {
+  test("merges new legions with existing cache", async () => {
     process.env.LINEAR_API_TOKEN = "test-api-key";
 
     fs.writeFileSync(
@@ -247,7 +271,7 @@ describe("resolveTeamId", () => {
       );
     }) as unknown as typeof fetch;
 
-    const result = await resolveTeamId("LEG", testCacheDir);
+    const result = await resolveLegionId("LEG", testCacheDir);
     expect(result).toBe("leg-id");
 
     const cached = JSON.parse(fs.readFileSync(testCacheFile, "utf-8"));
@@ -257,7 +281,7 @@ describe("resolveTeamId", () => {
     });
   });
 
-  test("cache write failure still resolves team", async () => {
+  test("cache write failure still resolves legion", async () => {
     process.env.LINEAR_API_TOKEN = "test-api-key";
 
     globalThis.fetch = mock(async () => {
@@ -279,7 +303,7 @@ describe("resolveTeamId", () => {
     }) as typeof fs.writeFileSync;
 
     try {
-      await expect(resolveTeamId("LEG", testCacheDir)).resolves.toBe("leg-id");
+      await expect(resolveLegionId("LEG", testCacheDir)).resolves.toBe("leg-id");
     } finally {
       fs.writeFileSync = originalWriteFileSync;
     }
@@ -303,7 +327,7 @@ describe("resolveTeamId", () => {
       );
     }) as unknown as typeof fetch;
 
-    await expect(resolveTeamId("LEG", testCacheDir)).resolves.toBe("leg-id");
+    await expect(resolveLegionId("LEG", testCacheDir)).resolves.toBe("leg-id");
   });
 
   test("throws error when API response fails schema validation", async () => {
@@ -322,8 +346,8 @@ describe("resolveTeamId", () => {
       );
     }) as unknown as typeof fetch;
 
-    await expect(resolveTeamId("LEG", testCacheDir)).rejects.toThrow(
-      /Failed to look up team.*invalid response/s
+    await expect(resolveLegionId("LEG", testCacheDir)).rejects.toThrow(
+      /Failed to look up legion.*invalid response/s
     );
   });
 
@@ -334,12 +358,12 @@ describe("resolveTeamId", () => {
       throw new Error("Network error");
     }) as unknown as typeof fetch;
 
-    await expect(resolveTeamId("LEG", testCacheDir)).rejects.toThrow(
-      "Failed to look up team 'LEG'"
+    await expect(resolveLegionId("LEG", testCacheDir)).rejects.toThrow(
+      "Failed to look up legion 'LEG'"
     );
   });
 
-  test("prefers cache over API when team key exists in cache", async () => {
+  test("prefers cache over API when legion key exists in cache", async () => {
     process.env.LINEAR_API_TOKEN = "test-api-key";
 
     const teams = {
@@ -355,13 +379,16 @@ describe("resolveTeamId", () => {
     });
     globalThis.fetch = mockFetch as unknown as typeof fetch;
 
-    const result = await resolveTeamId("LEG", testCacheDir);
+    const result = await resolveLegionId("LEG", testCacheDir);
     expect(result).toBe("cached-uuid");
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
   test("returns GitHub project ref as-is when backend is github", async () => {
-    const result = await resolveTeamId("sjawhar/5", { cacheDir: testCacheDir, backend: "github" });
+    const result = await resolveLegionId("sjawhar/5", {
+      cacheDir: testCacheDir,
+      backend: "github",
+    });
     expect(result).toBe("sjawhar/5");
   });
 
@@ -372,14 +399,17 @@ describe("resolveTeamId", () => {
     });
     globalThis.fetch = mockFetch as unknown as typeof fetch;
 
-    const result = await resolveTeamId("my-org/42", { cacheDir: testCacheDir, backend: "github" });
+    const result = await resolveLegionId("my-org/42", {
+      cacheDir: testCacheDir,
+      backend: "github",
+    });
     expect(result).toBe("my-org/42");
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
   test("uses Linear resolution when backend is not specified (backward compat)", async () => {
     const uuid = "12345678-1234-1234-1234-123456789abc";
-    const result = await resolveTeamId(uuid, { cacheDir: testCacheDir });
+    const result = await resolveLegionId(uuid, { cacheDir: testCacheDir });
     expect(result).toBe(uuid);
   });
 
@@ -390,7 +420,7 @@ describe("resolveTeamId", () => {
         status: 200,
       });
     }) as unknown as typeof fetch;
-    await expect(resolveTeamId("LEG", testCacheDir)).rejects.toThrow("Authentication required");
+    await expect(resolveLegionId("LEG", testCacheDir)).rejects.toThrow("Authentication required");
   });
 
   test("throws descriptive error when Linear returns non-JSON response", async () => {
@@ -403,7 +433,7 @@ describe("resolveTeamId", () => {
       });
     }) as unknown as typeof fetch;
 
-    await expect(resolveTeamId("LEG", testCacheDir)).rejects.toThrow(/non-JSON response/);
+    await expect(resolveLegionId("LEG", testCacheDir)).rejects.toThrow(/non-JSON response/);
   });
 
   test("non-object cache file (JSON array) falls through to API", async () => {
@@ -424,7 +454,7 @@ describe("resolveTeamId", () => {
       );
     }) as unknown as typeof fetch;
 
-    const result = await resolveTeamId("LEG", testCacheDir);
+    const result = await resolveLegionId("LEG", testCacheDir);
     expect(result).toBe("leg-id");
   });
 });

--- a/packages/daemon/src/cli/index.ts
+++ b/packages/daemon/src/cli/index.ts
@@ -6,7 +6,9 @@ import path from "node:path";
 import { defineCommand, runMain } from "citty";
 import { type DaemonConfig, validateControllerPrompt } from "../daemon/config";
 import { startDaemon } from "../daemon/index";
-import { resolveTeamId } from "./team-resolver";
+import { findLegionByProjectId } from "../daemon/legions-registry";
+import { resolveLegionPaths } from "../daemon/paths";
+import { resolveLegionId } from "./legion-resolver";
 
 export class CliError extends Error {
   constructor(
@@ -21,7 +23,7 @@ export class CliError extends Error {
 const DEFAULT_DAEMON_PORT = 13370;
 const SAFE_IDENTIFIER_RE = /^[a-zA-Z0-9_-]+$/;
 
-interface TeamInfo {
+interface LegionInfo {
   id: string;
   name: string;
 }
@@ -37,10 +39,13 @@ interface WorkerStatusInfo extends WorkerInfo {
 }
 
 interface DispatchOptions {
+  // Legacy transition fallback for dispatching without explicit --workspace.
   legionDir?: string;
   daemonPort?: number;
   prompt?: string;
+  repo?: string;
   workspace?: string;
+  version?: number;
 }
 
 interface PromptOptions {
@@ -59,13 +64,23 @@ interface DaemonHealth {
   tmuxSession?: string;
 }
 
-export type TeamsCache = Record<string, TeamInfo>;
+export type LegionsCache = Record<string, LegionInfo>;
 
-export function getDaemonPort(env: NodeJS.ProcessEnv = process.env): number {
-  const raw = env.LEGION_DAEMON_PORT;
+export async function getDaemonPort(projectId?: string): Promise<number> {
+  const raw = process.env.LEGION_DAEMON_PORT;
   if (!raw) {
+    if (!projectId) {
+      return DEFAULT_DAEMON_PORT;
+    }
+
+    const paths = resolveLegionPaths(process.env, os.homedir());
+    const entry = await findLegionByProjectId(paths.legionsFile, projectId);
+    if (entry) {
+      return entry.port;
+    }
     return DEFAULT_DAEMON_PORT;
   }
+
   const parsed = Number(raw);
   if (!Number.isFinite(parsed)) {
     return DEFAULT_DAEMON_PORT;
@@ -73,8 +88,10 @@ export function getDaemonPort(env: NodeJS.ProcessEnv = process.env): number {
   return parsed;
 }
 
-export function loadTeamsCache(cacheDir = path.join(os.homedir(), ".legion")): TeamsCache | null {
-  const cacheFile = path.join(cacheDir, "teams.json");
+export function loadLegionsCache(
+  cacheDir = resolveLegionPaths(process.env, os.homedir()).stateDir
+): LegionsCache | null {
+  const cacheFile = path.join(cacheDir, "project-cache.json");
   if (!fs.existsSync(cacheFile)) {
     return null;
   }
@@ -86,35 +103,30 @@ export function loadTeamsCache(cacheDir = path.join(os.homedir(), ".legion")): T
 
   const parsed = JSON.parse(raw) as unknown;
   if (!parsed || typeof parsed !== "object") {
-    throw new Error(`Invalid teams cache at ${cacheFile}`);
+    throw new Error(`Invalid legions cache at ${cacheFile}`);
   }
 
-  return parsed as TeamsCache;
-}
-
-function resolveStateDir(teamId: string, stateDir?: string): string {
-  return stateDir ?? path.join(os.homedir(), ".legion", teamId);
+  return parsed as LegionsCache;
 }
 
 interface StartOptions {
   workspace: string;
-  stateDir?: string;
   prompt?: string;
   backend?: string;
   runtime?: string;
 }
 
 async function cmdStart(team: string, opts: StartOptions): Promise<void> {
-  const teamId = await resolveTeamId(team, { backend: opts.backend });
-  const resolvedStateDir = resolveStateDir(teamId, opts.stateDir);
+  const legionId = await resolveLegionId(team, { backend: opts.backend });
+  const instancePaths = resolveLegionPaths(process.env, os.homedir()).forLegion(legionId);
 
   validateControllerPrompt(opts.prompt);
 
-  console.log(`Starting Legion for team: ${teamId}`);
+  console.log(`Starting legion: ${legionId}`);
   console.log(`Workspace: ${opts.workspace}`);
-  console.log(`State directory: ${resolvedStateDir}`);
+  console.log(`State directory: ${instancePaths.legionStateDir}`);
 
-  fs.mkdirSync(resolvedStateDir, { recursive: true });
+  fs.mkdirSync(instancePaths.legionStateDir, { recursive: true });
 
   if (opts.backend) {
     process.env.LEGION_ISSUE_BACKEND = opts.backend;
@@ -124,9 +136,9 @@ async function cmdStart(team: string, opts: StartOptions): Promise<void> {
     process.env.LEGION_RUNTIME = opts.runtime;
   }
   const overrides: Partial<DaemonConfig> = {
-    teamId,
+    legionId,
     legionDir: opts.workspace,
-    stateFilePath: path.join(resolvedStateDir, "workers.json"),
+    stateFilePath: instancePaths.workersFile,
   };
   if (opts.prompt !== undefined) {
     overrides.controllerPrompt = opts.prompt;
@@ -141,19 +153,19 @@ async function cmdStart(team: string, opts: StartOptions): Promise<void> {
   await new Promise(() => {});
 }
 
-async function cmdStop(team: string, stateDir?: string, backend?: string): Promise<void> {
-  const teamId = await resolveTeamId(team, { backend });
-  const resolvedStateDir = resolveStateDir(teamId, stateDir);
+async function cmdStop(team: string, _stateDir?: string, backend?: string): Promise<void> {
+  const legionId = await resolveLegionId(team, { backend });
+  const instancePaths = resolveLegionPaths(process.env, os.homedir()).forLegion(legionId);
 
-  console.log(`Stopping Legion for team: ${teamId}`);
+  console.log(`Stopping legion: ${legionId}`);
 
-  const stateFilePath = path.join(resolvedStateDir, "workers.json");
+  const stateFilePath = instancePaths.workersFile;
   if (!fs.existsSync(stateFilePath)) {
     console.log("No state file found. Daemon may not be running.");
     return;
   }
 
-  const daemonPort = getDaemonPort();
+  const daemonPort = await getDaemonPort(legionId);
   try {
     const response = await fetch(`http://127.0.0.1:${daemonPort}/shutdown`, {
       method: "POST",
@@ -168,14 +180,14 @@ async function cmdStop(team: string, stateDir?: string, backend?: string): Promi
   }
 }
 
-async function cmdStatus(team: string, stateDir?: string, backend?: string): Promise<void> {
-  const teamId = await resolveTeamId(team, { backend });
-  const resolvedStateDir = resolveStateDir(teamId, stateDir);
+async function cmdStatus(team: string, _stateDir?: string, backend?: string): Promise<void> {
+  const legionId = await resolveLegionId(team, { backend });
+  const instancePaths = resolveLegionPaths(process.env, os.homedir()).forLegion(legionId);
 
-  console.log(`Legion Status: ${teamId}`);
+  console.log(`Legion Status: ${legionId}`);
   console.log("=".repeat(40));
 
-  const daemonPort = getDaemonPort();
+  const daemonPort = await getDaemonPort(legionId);
   try {
     const response = await fetch(`http://127.0.0.1:${daemonPort}/workers`);
     if (response.ok) {
@@ -192,7 +204,7 @@ async function cmdStatus(team: string, stateDir?: string, backend?: string): Pro
     console.log("Daemon: NOT RUNNING");
   }
 
-  const stateFilePath = path.join(resolvedStateDir, "workers.json");
+  const stateFilePath = instancePaths.workersFile;
   if (fs.existsSync(stateFilePath)) {
     const stat = fs.statSync(stateFilePath);
     const age = Math.floor((Date.now() - stat.mtimeMs) / 1000);
@@ -204,12 +216,12 @@ async function cmdStatus(team: string, stateDir?: string, backend?: string): Pro
 }
 
 async function cmdAttach(team: string, issue: string, backend?: string): Promise<void> {
-  const teamId = await resolveTeamId(team, { backend });
+  const legionId = await resolveLegionId(team, { backend });
 
   console.log(`Attaching to worker for issue: ${issue}`);
-  console.log(`Team: ${teamId}`);
+  console.log(`Legion: ${legionId}`);
 
-  const daemonPort = getDaemonPort();
+  const daemonPort = await getDaemonPort(legionId);
   try {
     const response = await fetch(`http://127.0.0.1:${daemonPort}/workers`);
     if (!response.ok) {
@@ -285,8 +297,7 @@ export async function cmdDispatch(
   if (!SAFE_IDENTIFIER_RE.test(mode)) {
     throw new CliError(`Invalid mode: ${mode} (must match [a-zA-Z0-9_-]+)`);
   }
-  const daemonPort = opts.daemonPort ?? getDaemonPort();
-  const legionDir = opts.legionDir ?? process.env.LEGION_DIR ?? process.cwd();
+  const daemonPort = opts.daemonPort ?? (await getDaemonPort());
   const baseUrl = `http://127.0.0.1:${daemonPort}`;
 
   // Verify daemon is reachable before creating workspace to avoid orphan directories
@@ -302,19 +313,16 @@ export async function cmdDispatch(
     throw new CliError(`Could not connect to daemon. Is it running?\nTried: ${baseUrl}/health`);
   }
 
-  const issueLower = issue.toLowerCase();
-  const workspacePath = opts.workspace ?? path.join(path.dirname(legionDir), issueLower);
-
-  if (!fs.existsSync(workspacePath)) {
-    console.log(`Creating workspace: ${workspacePath}`);
-    const jjResult = Bun.spawnSync(
-      ["jj", "workspace", "add", workspacePath, "--name", issueLower, "-R", legionDir],
-      { stdio: ["ignore", "pipe", "pipe"], timeout: 30_000 }
-    );
-    if (jjResult.exitCode !== 0) {
-      const stderr = jjResult.stderr.toString();
-      throw new CliError(`Failed to create workspace: ${stderr}`);
-    }
+  const body: Record<string, unknown> = { issueId: issue, mode, version: opts.version };
+  if (opts.repo) {
+    body.repo = opts.repo;
+  } else if (opts.workspace) {
+    body.workspace = opts.workspace;
+  } else if (opts.legionDir) {
+    // Legacy: map LEGION_DIR to workspace while repo-based dispatch migration completes.
+    body.workspace = opts.legionDir;
+  } else {
+    throw new CliError("Either --repo or --workspace is required");
   }
 
   let response: Response;
@@ -322,23 +330,23 @@ export async function cmdDispatch(
     response = await fetch(`${baseUrl}/workers`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ issueId: issue, mode, workspace: workspacePath }),
+      body: JSON.stringify(body),
     });
   } catch (_error) {
     throw new CliError(`Could not connect to daemon. Is it running?\nTried: ${baseUrl}/workers`);
   }
 
-  let body: Record<string, unknown>;
+  let responseBody: Record<string, unknown>;
   try {
-    body = (await response.json()) as Record<string, unknown>;
+    responseBody = (await response.json()) as Record<string, unknown>;
   } catch {
     throw new CliError(`Daemon returned non-JSON response (status ${response.status})`);
   }
 
   if (response.status === 409) {
-    console.log(`Worker already running: ${body.id}`);
-    console.log(`  port: ${body.port}`);
-    console.log(`  session: ${body.sessionId}`);
+    console.log(`Worker already running: ${responseBody.id}`);
+    console.log(`  port: ${responseBody.port}`);
+    console.log(`  session: ${responseBody.sessionId}`);
     console.log(
       `\nTo resume: legion prompt ${issue} "${
         opts.prompt ?? `/legion-worker ${mode} mode for ${issue}`
@@ -349,18 +357,18 @@ export async function cmdDispatch(
 
   if (response.status === 429) {
     throw new CliError(
-      `Crash limit exceeded for ${body.id} (${body.crashCount} crashes)\n` +
+      `Crash limit exceeded for ${responseBody.id} (${responseBody.crashCount} crashes)\n` +
         `Reset with: legion reset-crashes ${issue} ${mode}`
     );
   }
 
   if (!response.ok) {
-    throw new CliError(`Failed to dispatch: ${JSON.stringify(body)}`);
+    throw new CliError(`Failed to dispatch: ${JSON.stringify(responseBody)}`);
   }
 
-  const workerId = body.id as string;
-  const workerPort = body.port as number;
-  const sessionId = body.sessionId as string;
+  const workerId = responseBody.id as string;
+  const workerPort = responseBody.port as number;
+  const sessionId = responseBody.sessionId as string;
 
   console.log(`Worker dispatched: ${workerId}`);
   console.log(`  port: ${workerPort}`);
@@ -379,14 +387,14 @@ export async function cmdDispatch(
     console.warn(`  legion prompt ${issue} "${initialPrompt}"`);
   }
 
-  console.log(`\nTo attach: legion attach <team> ${issue}`);
+  console.log(`\nTo attach: legion attach <legion> ${issue}`);
 }
 
 export async function cmdPrompt(issue: string, prompt: string, opts: PromptOptions): Promise<void> {
   if (!SAFE_IDENTIFIER_RE.test(issue)) {
     throw new CliError(`Invalid issue identifier: ${issue} (must match [a-zA-Z0-9_-]+)`);
   }
-  const daemonPort = opts.daemonPort ?? getDaemonPort();
+  const daemonPort = opts.daemonPort ?? (await getDaemonPort());
   const baseUrl = `http://127.0.0.1:${daemonPort}`;
 
   let workers: WorkerStatusInfo[];
@@ -471,7 +479,7 @@ export async function cmdResetCrashes(
   if (!SAFE_IDENTIFIER_RE.test(mode)) {
     throw new CliError(`Invalid mode: ${mode} (must match [a-zA-Z0-9_-]+)`);
   }
-  const daemonPort = opts?.daemonPort ?? getDaemonPort();
+  const daemonPort = opts?.daemonPort ?? (await getDaemonPort());
   const workerId = `${issue.toLowerCase()}-${mode}`;
 
   try {
@@ -521,18 +529,20 @@ async function checkDaemonHealth(port: number): Promise<DaemonHealth> {
   }
 }
 
-async function cmdTeams(includeAll: boolean): Promise<void> {
-  const cache = loadTeamsCache();
+async function cmdLegions(includeAll: boolean): Promise<void> {
+  const cache = loadLegionsCache();
   if (!cache || Object.keys(cache).length === 0) {
-    console.log("No teams cached. Start a swarm first.");
+    console.log("No legions cached. Start a swarm first.");
     return;
   }
 
-  const daemonPort = getDaemonPort();
-  const health = await checkDaemonHealth(daemonPort);
   const entries = await Promise.all(
     Object.entries(cache).map(async ([key, team]) => {
-      const stateFilePath = path.join(os.homedir(), ".legion", team.id, "workers.json");
+      const daemonPort = await getDaemonPort(team.id);
+      const health = await checkDaemonHealth(daemonPort);
+      const stateFilePath = resolveLegionPaths(process.env, os.homedir()).forLegion(
+        team.id
+      ).workersFile;
       if (!fs.existsSync(stateFilePath)) {
         return { key, team, running: false, workerCount: 0 };
       }
@@ -542,11 +552,11 @@ async function cmdTeams(includeAll: boolean): Promise<void> {
 
   const filtered = includeAll ? entries : entries.filter((entry) => entry.running);
   if (filtered.length === 0) {
-    console.log("No active daemons. Use --all to show cached teams.");
+    console.log("No active daemons. Use --all to show cached legions.");
     return;
   }
 
-  console.log("Teams:");
+  console.log("Legions:");
   for (const entry of filtered) {
     const status = entry.running ? `RUNNING (workers: ${entry.workerCount})` : "STOPPED";
     console.log(`  ${entry.key}: ${entry.team.name} (${entry.team.id}) - ${status}`);
@@ -569,7 +579,7 @@ async function cmdCollectState(backend: string): Promise<void> {
     throw new CliError("Failed to parse stdin as JSON");
   }
 
-  const daemonPort = getDaemonPort();
+  const daemonPort = await getDaemonPort();
   const baseUrl = `http://127.0.0.1:${daemonPort}`;
 
   try {
@@ -595,7 +605,7 @@ async function cmdCollectState(backend: string): Promise<void> {
 export const startCommand = defineCommand({
   meta: { name: "start", description: "Start the Legion swarm" },
   args: {
-    team: { type: "positional", description: "Team key or UUID", required: true },
+    team: { type: "positional", description: "Legion key or UUID", required: true },
     workspace: {
       type: "string",
       alias: "w",
@@ -622,7 +632,6 @@ export const startCommand = defineCommand({
   async run({ args }) {
     await cmdStart(args.team, {
       workspace: args.workspace,
-      stateDir: args["state-dir"],
       prompt: args.prompt,
       backend: args.backend,
       runtime: args.runtime,
@@ -633,7 +642,7 @@ export const startCommand = defineCommand({
 export const stopCommand = defineCommand({
   meta: { name: "stop", description: "Stop the Legion swarm" },
   args: {
-    team: { type: "positional", description: "Team key or UUID", required: true },
+    team: { type: "positional", description: "Legion key or UUID", required: true },
     "state-dir": { type: "string", description: "State directory path" },
     backend: {
       type: "string",
@@ -649,7 +658,7 @@ export const stopCommand = defineCommand({
 export const statusCommand = defineCommand({
   meta: { name: "status", description: "Show Legion swarm status" },
   args: {
-    team: { type: "positional", description: "Team key or UUID", required: true },
+    team: { type: "positional", description: "Legion key or UUID", required: true },
     "state-dir": { type: "string", description: "State directory path" },
     backend: {
       type: "string",
@@ -665,7 +674,7 @@ export const statusCommand = defineCommand({
 export const attachCommand = defineCommand({
   meta: { name: "attach", description: "Attach to a worker session" },
   args: {
-    team: { type: "positional", description: "Team key or UUID", required: true },
+    team: { type: "positional", description: "Legion key or UUID", required: true },
     issue: { type: "positional", description: "Issue key or identifier", required: true },
     backend: {
       type: "string",
@@ -686,17 +695,17 @@ export const attachCommand = defineCommand({
   },
 });
 
-export const teamsCommand = defineCommand({
-  meta: { name: "teams", description: "List teams and their daemon status" },
+export const legionsCommand = defineCommand({
+  meta: { name: "teams", description: "List legions and their daemon status" },
   args: {
     all: {
       type: "boolean",
-      description: "Include cached teams without running daemons",
+      description: "Include cached legions without running daemons",
       default: false,
     },
   },
   async run({ args }) {
-    await cmdTeams(args.all);
+    await cmdLegions(args.all);
   },
 });
 
@@ -714,14 +723,24 @@ export const dispatchCommand = defineCommand({
       required: true,
     },
     prompt: { type: "string", description: "Custom initial prompt (default: /legion-worker)" },
+    repo: { type: "string", alias: "r", description: "Repository (owner/repo)" },
     workspace: { type: "string", alias: "w", description: "Override workspace path" },
+    version: { type: "string", description: "Session version (default: 0)" },
   },
   async run({ args }) {
     try {
+      const parsedVersion =
+        args.version !== undefined && args.version !== "" ? Number(args.version) : undefined;
+      if (parsedVersion !== undefined && (!Number.isInteger(parsedVersion) || parsedVersion < 0)) {
+        throw new CliError(`Invalid --version: ${args.version} (must be a non-negative integer)`);
+      }
       await cmdDispatch(args.issue, args.mode, {
+        // Legacy transition: keep LEGION_DIR fallback for users not passing --workspace.
         legionDir: process.env.LEGION_DIR,
         prompt: args.prompt,
+        repo: args.repo,
         workspace: args.workspace,
+        version: parsedVersion,
       });
     } catch (e) {
       if (e instanceof CliError) {
@@ -808,7 +827,7 @@ export const mainCommand = defineCommand({
     dispatch: dispatchCommand,
     prompt: promptCommand,
     "reset-crashes": resetCrashesCommand,
-    teams: teamsCommand,
+    teams: legionsCommand,
     "collect-state": collectStateCommand,
   },
 });

--- a/packages/daemon/src/cli/legion-resolver.ts
+++ b/packages/daemon/src/cli/legion-resolver.ts
@@ -1,49 +1,50 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { resolveLegionPaths } from "../daemon/paths";
 import { LinearTeamsResponseSchema } from "../daemon/schemas";
 
 // UUID regex pattern
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-interface TeamInfo {
+interface LegionInfo {
   id: string;
   name: string;
 }
 
-interface TeamsCache {
-  [key: string]: TeamInfo;
+interface LegionsCache {
+  [key: string]: LegionInfo;
 }
 
 /**
- * Resolve a team reference to a stable ID.
+ * Resolve a legion reference to a stable ID.
  *
- * For GitHub backend, the team ref (e.g., "owner/project-number") is already the ID.
- * For Linear backend, resolves team keys (e.g., "LEG") to UUIDs via cache or API.
+ * For GitHub backend, the legion ref (e.g., "owner/project-number") is already the ID.
+ * For Linear backend, resolves legion keys (e.g., "LEG") to UUIDs via cache or API.
  *
- * @param teamRef - Team identifier: UUID, team key (Linear), or owner/project-number (GitHub)
+ * @param legionRef - Legion identifier: UUID, team key (Linear), or owner/project-number (GitHub)
  * @param options - Optional cache directory and backend
- * @returns The team ID
- * @throws Error if team cannot be resolved
+ * @returns The legion ID
+ * @throws Error if legion cannot be resolved
  */
-export async function resolveTeamId(
-  teamRef: string,
+export async function resolveLegionId(
+  legionRef: string,
   options?: string | { cacheDir?: string; backend?: string }
 ): Promise<string> {
   const cacheDir = typeof options === "string" ? options : options?.cacheDir;
   const backend = typeof options === "string" ? undefined : options?.backend;
 
-  // GitHub backend: team ref is already the ID (owner/project-number)
+  // GitHub backend: legion ref is already the ID (owner/project-number)
   if (backend === "github") {
-    return teamRef;
+    return legionRef;
   }
 
-  if (UUID_PATTERN.test(teamRef)) {
-    return teamRef;
+  if (UUID_PATTERN.test(legionRef)) {
+    return legionRef;
   }
 
-  const resolvedCacheDir = cacheDir ?? path.join(os.homedir(), ".legion");
-  const cacheFile = path.join(resolvedCacheDir, "teams.json");
+  const resolvedCacheDir = cacheDir ?? resolveLegionPaths(process.env, os.homedir()).stateDir;
+  const cacheFile = path.join(resolvedCacheDir, "project-cache.json");
 
   if (fs.existsSync(cacheFile)) {
     try {
@@ -51,32 +52,32 @@ export async function resolveTeamId(
       if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
         throw new Error("Invalid cache format");
       }
-      const teams = raw as TeamsCache;
-      const keyUpper = teamRef.toUpperCase();
-      if (keyUpper in teams) {
-        const team = teams[keyUpper];
-        console.log(`Using cached: ${teamRef} → ${team.name} (${team.id})`);
-        return team.id;
+      const legions = raw as LegionsCache;
+      const keyUpper = legionRef.toUpperCase();
+      if (keyUpper in legions) {
+        const legion = legions[keyUpper];
+        console.log(`Using cached: ${legionRef} → ${legion.name} (${legion.id})`);
+        return legion.id;
       }
     } catch {}
   }
 
   const apiKey = process.env.LINEAR_API_TOKEN;
   if (apiKey) {
-    return await lookupTeamViaApi(teamRef, apiKey, resolvedCacheDir);
+    return await lookupLegionViaApi(legionRef, apiKey, resolvedCacheDir);
   }
 
   throw new Error(
-    `'${teamRef}' is not a UUID.\n` +
-      `Run 'legion teams' to cache team mappings, or set LINEAR_API_TOKEN.`
+    `'${legionRef}' is not a UUID.\n` +
+      `Run 'legion teams' to cache legion mappings, or set LINEAR_API_TOKEN.`
   );
 }
 
 /**
- * Look up team via Linear GraphQL API.
+ * Look up legion via Linear GraphQL API.
  */
-async function lookupTeamViaApi(
-  teamRef: string,
+async function lookupLegionViaApi(
+  legionRef: string,
   apiKey: string,
   cacheDir: string
 ): Promise<string> {
@@ -94,7 +95,7 @@ async function lookupTeamViaApi(
 
   const payload = JSON.stringify({
     query,
-    variables: { key: teamRef.toUpperCase() },
+    variables: { key: legionRef.toUpperCase() },
   });
 
   try {
@@ -131,44 +132,44 @@ async function lookupTeamViaApi(
       throw new Error("Linear API returned null data");
     }
 
-    const teamsByKey: TeamsCache = {};
+    const legionsByKey: LegionsCache = {};
     for (const node of parsed.data.data.teams.nodes) {
-      teamsByKey[node.key.toUpperCase()] = { id: node.id, name: node.name };
+      legionsByKey[node.key.toUpperCase()] = { id: node.id, name: node.name };
     }
 
-    const cacheFile = path.join(cacheDir, "teams.json");
-    let existingCache: TeamsCache = {};
+    const cacheFile = path.join(cacheDir, "project-cache.json");
+    let existingCache: LegionsCache = {};
     try {
       const raw: unknown = JSON.parse(fs.readFileSync(cacheFile, "utf-8"));
       if (typeof raw === "object" && raw !== null && !Array.isArray(raw)) {
-        existingCache = raw as TeamsCache;
+        existingCache = raw as LegionsCache;
       }
     } catch {}
 
-    const mergedCache: TeamsCache = { ...existingCache, ...teamsByKey };
+    const mergedCache: LegionsCache = { ...existingCache, ...legionsByKey };
 
     try {
       fs.mkdirSync(cacheDir, { recursive: true });
       fs.writeFileSync(cacheFile, JSON.stringify(mergedCache, null, 2));
     } catch (error) {
-      console.warn(`Failed to write team cache to ${cacheFile}: ${String(error)}`);
+      console.warn(`Failed to write legion cache to ${cacheFile}: ${String(error)}`);
     }
 
-    const keyUpper = teamRef.toUpperCase();
-    const team = parsed.data.data.teams.nodes.find((node) => node.key.toUpperCase() === keyUpper);
-    if (!team) {
+    const keyUpper = legionRef.toUpperCase();
+    const legion = parsed.data.data.teams.nodes.find((node) => node.key.toUpperCase() === keyUpper);
+    if (!legion) {
       const availableKeys = Object.keys(mergedCache).sort();
       const availableKeysMessage = availableKeys.length > 0 ? availableKeys.join(", ") : "(none)";
       throw new Error(
-        `Team '${teamRef}' not found in Linear. Available team keys: ${availableKeysMessage}`
+        `Legion '${legionRef}' not found in Linear. Available legion keys: ${availableKeysMessage}`
       );
     }
 
-    console.log(`Resolved: ${teamRef} → ${team.name} (${team.id})`);
-    return team.id;
+    console.log(`Resolved: ${legionRef} → ${legion.name} (${legion.id})`);
+    return legion.id;
   } catch (error) {
     throw new Error(
-      `Failed to look up team '${teamRef}': ${error instanceof Error ? error.message : String(error)}`
+      `Failed to look up legion '${legionRef}': ${error instanceof Error ? error.message : String(error)}`
     );
   }
 }

--- a/packages/daemon/src/daemon/AGENTS.md
+++ b/packages/daemon/src/daemon/AGENTS.md
@@ -27,7 +27,7 @@ HTTP server + shared `opencode serve` instance. One long-lived serve process han
 | `server.ts` | HTTP routing, request validation, in-memory worker map. `POST /workers` creates session on shared serve (instant). `DELETE /workers` removes tracking only. |
 | `serve-manager.ts` | `spawnSharedServe()` — runs one `opencode serve`. `waitForHealthy()` — polls readiness. `createSession()` — creates session on shared serve. `stopServe()` — graceful shutdown. `healthCheck()` — `/global/health`. |
 | `config.ts` | `DaemonConfig` interface, `loadConfig()` reads env vars. Defaults: daemon port 13370, shared serve port 13381 (`baseWorkerPort`), check interval 60s. **Controller mode:** `LEGION_CONTROLLER_SESSION_ID` env var (optional, must start with `ses_` if set, hard fails on invalid format). |
-| `state-file.ts` | `readStateFile()` / `writeStateFile()` — atomic JSON persistence to `~/.legion/{teamId}/workers.json`. Includes `controller?: ControllerState` field for controller lifecycle. Legacy `controller-controller` worker entries are stripped on read. |
+| `state-file.ts` | `readStateFile()` / `writeStateFile()` — atomic JSON persistence to `~/.legion/{legionId}/workers.json`. Includes `controller?: ControllerState` field for controller lifecycle. Legacy `controller-controller` worker entries are stripped on read. |
 | `ports.ts` | `isPortFree()` utility only. `PortAllocator` removed — all workers share one port. |
 
 ## Key Patterns
@@ -36,5 +36,5 @@ HTTP server + shared `opencode serve` instance. One long-lived serve process han
 - **DI in `startDaemon()`** — all deps passed via `overrides` param, enabling unit tests without spawning real processes
 - **Health tick** — every 60s, checks shared serve health. On failure: restart serve, re-create sessions for active workers.
 - **State persistence** — worker map persisted to disk, sessions re-created on daemon restart using deterministic IDs.
-- **Session IDs** — deterministic UUIDv5 from `computeSessionId(teamId, issueId, mode)`, enables idempotent session creation.
+- **Session IDs** — deterministic UUIDv5 from `computeSessionId(legionId, issueId, mode)`, enables idempotent session creation.
 - **Controller lifecycle** — runs as session on shared serve. For external mode, daemon stores session ID without spawning.

--- a/packages/daemon/src/daemon/__tests__/config.test.ts
+++ b/packages/daemon/src/daemon/__tests__/config.test.ts
@@ -8,25 +8,52 @@ describe("daemon config", () => {
     const config = loadConfig({});
 
     expect(config.daemonPort).toBe(13370);
-    expect(config.teamId).toBeUndefined();
+    expect(config.legionId).toBeUndefined();
     expect(config.legionDir).toBeUndefined();
     expect(config.checkIntervalMs).toBe(60_000);
     expect(config.baseWorkerPort).toBe(13381);
-    expect(config.stateFilePath).toBe(path.join(os.homedir(), ".legion", "daemon", "workers.json"));
+    expect(config.stateFilePath).toBe(
+      path.join(os.homedir(), ".local", "state", "legion", "daemon", "workers.json")
+    );
+    expect(config.logDir).toBe(
+      path.join(os.homedir(), ".local", "state", "legion", "daemon", "logs")
+    );
+    expect(config.paths).toEqual({
+      dataDir: path.join(os.homedir(), ".local", "share", "legion"),
+      stateDir: path.join(os.homedir(), ".local", "state", "legion"),
+      reposDir: path.join(os.homedir(), ".local", "share", "legion", "repos"),
+      workspacesDir: path.join(os.homedir(), ".local", "share", "legion", "workspaces"),
+      legionsFile: path.join(os.homedir(), ".local", "state", "legion", "legions.json"),
+      forLegion: expect.any(Function),
+      repoClonePath: expect.any(Function),
+    });
   });
 
   it("reads values from env vars", () => {
     const config = loadConfig({
       LEGION_DAEMON_PORT: "14000",
-      LEGION_TEAM_ID: "team-123",
+      LEGION_ID: "team-123",
       LEGION_DIR: "/tmp/legion",
     });
 
     expect(config.daemonPort).toBe(14000);
-    expect(config.teamId).toBe("team-123");
+    expect(config.legionId).toBe("team-123");
     expect(config.legionDir).toBe("/tmp/legion");
     expect(config.stateFilePath).toBe(
-      path.join("/tmp/legion", ".legion", "daemon", "workers.json")
+      path.join(os.homedir(), ".local", "state", "legion", "legions", "team-123", "workers.json")
+    );
+    expect(config.logDir).toBe(
+      path.join(os.homedir(), ".local", "state", "legion", "legions", "team-123", "logs")
+    );
+  });
+
+  it("falls back to daemon state path when legionId is not set", () => {
+    const config = loadConfig({ LEGION_DIR: "/tmp/legion" });
+
+    expect(config.legionDir).toBe("/tmp/legion");
+    expect(config.legionId).toBeUndefined();
+    expect(config.stateFilePath).toBe(
+      path.join(os.homedir(), ".local", "state", "legion", "daemon", "workers.json")
     );
   });
 
@@ -73,17 +100,17 @@ describe("daemon config", () => {
 
   describe("runtime config", () => {
     it("defaults to opencode", () => {
-      const config = loadConfig({ LEGION_TEAM_ID: "test" });
+      const config = loadConfig({ LEGION_ID: "test" });
       expect(config.runtime).toBe("opencode");
     });
 
     it("reads from LEGION_RUNTIME env var", () => {
-      const config = loadConfig({ LEGION_TEAM_ID: "test", LEGION_RUNTIME: "claude-code" });
+      const config = loadConfig({ LEGION_ID: "test", LEGION_RUNTIME: "claude-code" });
       expect(config.runtime).toBe("claude-code");
     });
 
     it("rejects invalid runtime values", () => {
-      expect(() => loadConfig({ LEGION_TEAM_ID: "test", LEGION_RUNTIME: "invalid" })).toThrow();
+      expect(() => loadConfig({ LEGION_ID: "test", LEGION_RUNTIME: "invalid" })).toThrow();
     });
   });
 });

--- a/packages/daemon/src/daemon/__tests__/index.test.ts
+++ b/packages/daemon/src/daemon/__tests__/index.test.ts
@@ -1,6 +1,9 @@
-import { afterEach, describe, expect, it, mock } from "bun:test";
+import { afterAll, afterEach, describe, expect, it, mock } from "bun:test";
+import { createServer } from "node:net";
+import { resolveLegionPaths } from "../paths";
 import type { RuntimeAdapter } from "../runtime/types";
 import type { WorkerEntry } from "../serve-manager";
+import type { ServerOptions } from "../server";
 import type { PersistedWorkerState } from "../state-file";
 
 const promptAsyncCalls: Array<{ sessionID: string; parts: unknown[] }> = [];
@@ -21,9 +24,25 @@ mock.module("@opencode-ai/sdk/v2", () => ({
   }),
 }));
 
+const writeLegionEntryCalls: Array<{
+  filePath: string;
+  projectId: string;
+  entry: { port: number; servePort: number; pid: number; startedAt: string };
+}> = [];
+const removeLegionEntryCalls: Array<{ filePath: string; projectId: string }> = [];
+let mockedRegistry: Record<
+  string,
+  { port: number; servePort: number; pid: number; startedAt: string }
+> = {};
+let mockedAllocatedPorts = { daemonPort: 13370, servePort: 13381 };
+
 import { startDaemon } from "../index";
 
 type TimeoutCallback = (...args: unknown[]) => Promise<void> | void;
+
+afterAll(() => {
+  mock.restore();
+});
 
 const baseEntry: WorkerEntry = {
   id: "eng-1-implement",
@@ -48,6 +67,14 @@ const secondEntry: WorkerEntry = {
 };
 
 const TEAM_ID = "123e4567-e89b-12d3-a456-426614174000";
+const TEST_PATHS = resolveLegionPaths(
+  {
+    XDG_DATA_HOME: "/tmp/legion-test-data",
+    XDG_STATE_HOME: "/tmp/legion-test-state",
+  },
+  "/tmp/legion-test-home"
+);
+const CONTROLLER_WORKSPACE = TEST_PATHS.forLegion(TEAM_ID).legionStateDir;
 const silentSetTimeout: typeof setTimeout = Object.assign(
   ((_callback: (...args: unknown[]) => void) => {
     return {} as ReturnType<typeof setTimeout>;
@@ -99,6 +126,53 @@ function makeAdapter(overrides?: {
   };
 }
 
+async function getFreePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Failed to obtain free port"));
+        return;
+      }
+      const { port } = address;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(port);
+      });
+    });
+  });
+}
+
+function startDaemonForTest(
+  overrides: Parameters<typeof startDaemon>[0],
+  deps?: Parameters<typeof startDaemon>[1]
+): Promise<Awaited<ReturnType<typeof startDaemon>>> {
+  return startDaemon(
+    {
+      paths: TEST_PATHS,
+      readLegionsRegistry: async () => mockedRegistry,
+      allocatePort: () => mockedAllocatedPorts,
+      writeLegionEntry: async (
+        filePath: string,
+        projectId: string,
+        entry: { port: number; servePort: number; pid: number; startedAt: string }
+      ) => {
+        writeLegionEntryCalls.push({ filePath, projectId, entry });
+      },
+      removeLegionEntry: async (filePath: string, projectId: string) => {
+        removeLegionEntryCalls.push({ filePath, projectId });
+      },
+      ...overrides,
+    },
+    deps
+  );
+}
+
 describe("daemon entry", () => {
   const originalOn = process.on;
   const originalExit = process.exit;
@@ -110,15 +184,140 @@ describe("daemon entry", () => {
     globalThis.fetch = originalFetch;
     promptAsyncCalls.length = 0;
     promptAsyncFailures = 0;
+    writeLegionEntryCalls.length = 0;
+    removeLegionEntryCalls.length = 0;
+    mockedRegistry = {};
+    mockedAllocatedPorts = { daemonPort: 13370, servePort: 13381 };
+  });
+
+  describe("port allocation", () => {
+    it("starts on base port 13370 when registry is empty", async () => {
+      const basePort = await getFreePort();
+      mockedRegistry = {};
+      mockedAllocatedPorts = { daemonPort: basePort, servePort: basePort + 100 };
+
+      const startServerCalls: ServerOptions[] = [];
+
+      await startDaemonForTest(
+        {
+          stateFilePath: "/tmp/daemon-workers.json",
+          legionId: TEAM_ID,
+          controllerSessionId: "ses_test",
+        },
+        {
+          readStateFile: async () => ({ workers: {}, crashHistory: {} }),
+          writeStateFile: async () => {},
+          adapter: makeAdapter(),
+          startServer: (opts) => {
+            startServerCalls.push(opts);
+            return {
+              server: { port: opts.port } as ReturnType<typeof Bun.serve>,
+              stop: () => {},
+            };
+          },
+          setTimeout: silentSetTimeout,
+          clearTimeout: noopClearTimeout,
+          fetch: originalFetch,
+        }
+      );
+
+      expect(startServerCalls).toHaveLength(1);
+      expect(startServerCalls[0].port).toBe(basePort);
+      expect(writeLegionEntryCalls[0].entry.port).toBe(basePort);
+    });
+
+    it("starts on 13371 when registry already uses 13370", async () => {
+      const occupiedPort = await getFreePort();
+      mockedRegistry = {
+        occupied: {
+          port: occupiedPort,
+          servePort: occupiedPort + 100,
+          pid: 9999,
+          startedAt: "2026-02-01T00:00:00.000Z",
+        },
+      };
+      mockedAllocatedPorts = { daemonPort: occupiedPort + 1, servePort: occupiedPort + 101 };
+
+      const startServerCalls: ServerOptions[] = [];
+
+      await startDaemonForTest(
+        {
+          stateFilePath: "/tmp/daemon-workers.json",
+          legionId: TEAM_ID,
+          controllerSessionId: "ses_test",
+        },
+        {
+          readStateFile: async () => ({ workers: {}, crashHistory: {} }),
+          writeStateFile: async () => {},
+          adapter: makeAdapter(),
+          startServer: (opts) => {
+            startServerCalls.push(opts);
+            return {
+              server: { port: opts.port } as ReturnType<typeof Bun.serve>,
+              stop: () => {},
+            };
+          },
+          setTimeout: silentSetTimeout,
+          clearTimeout: noopClearTimeout,
+          fetch: originalFetch,
+        }
+      );
+
+      expect(startServerCalls).toHaveLength(1);
+      expect(startServerCalls[0].port).toBe(occupiedPort + 1);
+      expect(writeLegionEntryCalls[0].entry.port).toBe(occupiedPort + 1);
+      expect(writeLegionEntryCalls[0].entry.servePort).toBe(occupiedPort + 101);
+    });
+
+    it("retries with next port when bind throws EADDRINUSE", async () => {
+      const initialPort = await getFreePort();
+      mockedAllocatedPorts = { daemonPort: initialPort, servePort: initialPort + 100 };
+
+      const startServerCalls: number[] = [];
+
+      await startDaemonForTest(
+        {
+          stateFilePath: "/tmp/daemon-workers.json",
+          legionId: TEAM_ID,
+          controllerSessionId: "ses_test",
+        },
+        {
+          readStateFile: async () => ({ workers: {}, crashHistory: {} }),
+          writeStateFile: async () => {},
+          adapter: makeAdapter(),
+          startServer: (opts) => {
+            if (opts.port === undefined) {
+              throw new Error("Expected daemon port to be set");
+            }
+            startServerCalls.push(opts.port);
+            if (opts.port === initialPort) {
+              const error = new Error("Address in use") as NodeJS.ErrnoException;
+              error.code = "EADDRINUSE";
+              throw error;
+            }
+            return {
+              server: { port: opts.port } as ReturnType<typeof Bun.serve>,
+              stop: () => {},
+            };
+          },
+          setTimeout: silentSetTimeout,
+          clearTimeout: noopClearTimeout,
+          fetch: originalFetch,
+        }
+      );
+
+      expect(startServerCalls).toEqual([initialPort, initialPort + 1]);
+      expect(writeLegionEntryCalls[0].entry.port).toBe(initialPort + 1);
+    });
   });
 
   it("re-creates sessions for persisted workers on startup", async () => {
     const createSessionCalls: Array<{ sessionId: string; workspace: string }> = [];
 
-    await startDaemon(
+    await startDaemonForTest(
       {
         stateFilePath: "/tmp/daemon-workers.json",
-        teamId: TEAM_ID,
+        legionId: TEAM_ID,
         controllerSessionId: "ses_test",
       },
       {
@@ -147,6 +346,59 @@ describe("daemon entry", () => {
     expect(workerSessions).toHaveLength(2);
   });
 
+  it("registers on start, deregisters on stop, and uses legion state dir for controller workspace", async () => {
+    const createSessionCalls: Array<{ sessionId: string; workspace: string }> = [];
+    const startServerCalls: ServerOptions[] = [];
+
+    const handle = await startDaemonForTest(
+      {
+        stateFilePath: "/tmp/daemon-workers.json",
+        legionId: TEAM_ID,
+        controllerSessionId: undefined,
+      },
+      {
+        readStateFile: async () => ({ workers: {}, crashHistory: {} }),
+        writeStateFile: async () => {},
+        adapter: makeAdapter({ createSessionCalls }),
+        startServer: (opts) => {
+          startServerCalls.push(opts);
+          return {
+            server: { port: 15555 } as ReturnType<typeof Bun.serve>,
+            stop: () => {},
+          };
+        },
+        setTimeout: silentSetTimeout,
+        clearTimeout: noopClearTimeout,
+        fetch: originalFetch,
+      }
+    );
+
+    expect(startServerCalls).toHaveLength(1);
+    expect(startServerCalls[0].paths).toBe(TEST_PATHS);
+    expect(startServerCalls[0].projectId).toBe(TEAM_ID);
+
+    expect(createSessionCalls).toHaveLength(1);
+    expect(createSessionCalls[0].workspace).toBe(CONTROLLER_WORKSPACE);
+
+    expect(writeLegionEntryCalls).toHaveLength(1);
+    expect(writeLegionEntryCalls[0].filePath).toBe(TEST_PATHS.legionsFile);
+    expect(writeLegionEntryCalls[0].projectId).toBe(TEAM_ID);
+    if (startServerCalls[0].port === undefined) {
+      throw new Error("Expected daemon port to be set");
+    }
+    expect(writeLegionEntryCalls[0].entry.port).toBe(startServerCalls[0].port);
+    expect(writeLegionEntryCalls[0].entry.servePort).toBeGreaterThanOrEqual(13381);
+    expect(typeof writeLegionEntryCalls[0].entry.pid).toBe("number");
+
+    await handle.stop();
+
+    expect(removeLegionEntryCalls).toHaveLength(1);
+    expect(removeLegionEntryCalls[0]).toEqual({
+      filePath: TEST_PATHS.legionsFile,
+      projectId: TEAM_ID,
+    });
+  });
+
   it("checks shared serve health and restarts on failure", async () => {
     let timeoutCallback: TimeoutCallback | null = null;
     const mockSetTimeout: typeof setTimeout = Object.assign(
@@ -160,11 +412,11 @@ describe("daemon entry", () => {
     let healthCallCount = 0;
     const createSessionCalls: Array<{ sessionId: string; workspace: string }> = [];
 
-    await startDaemon(
+    await startDaemonForTest(
       {
         stateFilePath: "/tmp/daemon-workers.json",
         checkIntervalMs: 1000,
-        teamId: TEAM_ID,
+        legionId: TEAM_ID,
         controllerSessionId: "ses_test",
       },
       {
@@ -215,11 +467,11 @@ describe("daemon entry", () => {
     let healthCallCount = 0;
     const createSessionCalls: Array<{ sessionId: string; workspace: string }> = [];
 
-    await startDaemon(
+    await startDaemonForTest(
       {
         stateFilePath: "/tmp/daemon-workers.json",
         checkIntervalMs: 1000,
-        teamId: TEAM_ID,
+        legionId: TEAM_ID,
         controllerSessionId: undefined,
       },
       {
@@ -278,10 +530,10 @@ describe("daemon entry", () => {
   it("appends controllerPrompt to initial /legion-controller prompt", async () => {
     promptAsyncCalls.length = 0;
 
-    await startDaemon(
+    await startDaemonForTest(
       {
         stateFilePath: "/tmp/daemon-workers.json",
-        teamId: TEAM_ID,
+        legionId: TEAM_ID,
         controllerSessionId: undefined,
         controllerPrompt: "Do not start new work. Focus on LEG-137 only.",
       },
@@ -309,10 +561,10 @@ describe("daemon entry", () => {
   it("sends plain /legion-controller when no controllerPrompt given", async () => {
     promptAsyncCalls.length = 0;
 
-    await startDaemon(
+    await startDaemonForTest(
       {
         stateFilePath: "/tmp/daemon-workers.json",
-        teamId: TEAM_ID,
+        legionId: TEAM_ID,
         controllerSessionId: undefined,
       },
       {
@@ -349,11 +601,11 @@ describe("daemon entry", () => {
     let healthCallCount = 0;
     const createSessionCalls: Array<{ sessionId: string; workspace: string }> = [];
 
-    await startDaemon(
+    await startDaemonForTest(
       {
         stateFilePath: "/tmp/daemon-workers.json",
         checkIntervalMs: 1000,
-        teamId: TEAM_ID,
+        legionId: TEAM_ID,
         controllerSessionId: undefined,
         controllerPrompt: "Do not start new work. Focus on LEG-137 only.",
       },
@@ -405,10 +657,10 @@ describe("daemon entry", () => {
   it("treats empty string controllerPrompt as no prompt", async () => {
     promptAsyncCalls.length = 0;
 
-    await startDaemon(
+    await startDaemonForTest(
       {
         stateFilePath: "/tmp/daemon-workers.json",
-        teamId: TEAM_ID,
+        legionId: TEAM_ID,
         controllerSessionId: undefined,
         controllerPrompt: "",
       },
@@ -449,10 +701,10 @@ describe("daemon entry", () => {
       { __promisify__: setTimeout.__promisify__ }
     );
 
-    await startDaemon(
+    await startDaemonForTest(
       {
         stateFilePath: "/tmp/daemon-workers.json",
-        teamId: TEAM_ID,
+        legionId: TEAM_ID,
         controllerSessionId: undefined,
       },
       {
@@ -493,10 +745,10 @@ describe("daemon entry", () => {
     const stopServeCalls: number[] = [];
     let startupHealthCheck = false;
 
-    await startDaemon(
+    await startDaemonForTest(
       {
         stateFilePath: "/tmp/daemon-workers.json",
-        teamId: TEAM_ID,
+        legionId: TEAM_ID,
         controllerSessionId: "ses_test",
       },
       {
@@ -563,10 +815,10 @@ describe("daemon entry", () => {
   it("preserves workers in state file when stopped via handle.stop()", async () => {
     let savedState: PersistedWorkerState | null = null;
 
-    const handle = await startDaemon(
+    const handle = await startDaemonForTest(
       {
         stateFilePath: "/tmp/daemon-workers.json",
-        teamId: TEAM_ID,
+        legionId: TEAM_ID,
         controllerSessionId: "ses_test",
       },
       {
@@ -614,10 +866,10 @@ describe("daemon entry", () => {
     const startCalls: Array<{ workspace: string; logDir?: string; env?: Record<string, string> }> =
       [];
 
-    await startDaemon(
+    await startDaemonForTest(
       {
         stateFilePath: "/tmp/daemon-workers.json",
-        teamId: TEAM_ID,
+        legionId: TEAM_ID,
         legionDir: "/test/legion",
         daemonPort: 13370,
         issueBackend: "linear",
@@ -644,11 +896,11 @@ describe("daemon entry", () => {
     expect(startCalls).toHaveLength(1);
     const opts = startCalls[0];
     expect(opts.env).toBeDefined();
-    expect(opts.env?.LEGION_TEAM_ID).toBe(TEAM_ID);
+    expect(opts.env?.LEGION_ID).toBe(TEAM_ID);
     expect(opts.env?.LEGION_ISSUE_BACKEND).toBe("linear");
-    expect(opts.env?.LEGION_DIR).toBe("/test/legion");
+    expect(opts.env?.LEGION_DIR).toBeUndefined();
     expect(opts.env?.LEGION_SHORT_ID).toBe(TEAM_ID.slice(0, 8));
-    expect(opts.env?.LEGION_DAEMON_PORT).toBe("13370");
+    expect(Number(opts.env?.LEGION_DAEMON_PORT)).toBeGreaterThanOrEqual(13370);
   });
 
   it("passes controller env vars to adapter.start on health restart", async () => {
@@ -665,10 +917,10 @@ describe("daemon entry", () => {
     const startCalls: Array<{ workspace: string; logDir?: string; env?: Record<string, string> }> =
       [];
 
-    await startDaemon(
+    await startDaemonForTest(
       {
         stateFilePath: "/tmp/daemon-workers.json",
-        teamId: TEAM_ID,
+        legionId: TEAM_ID,
         legionDir: "/test/legion",
         daemonPort: 13370,
         issueBackend: "github",
@@ -706,11 +958,11 @@ describe("daemon entry", () => {
     expect(startCalls.length).toBeGreaterThanOrEqual(2);
     const restartOpts = startCalls[1];
     expect(restartOpts.env).toBeDefined();
-    expect(restartOpts.env?.LEGION_TEAM_ID).toBe(TEAM_ID);
+    expect(restartOpts.env?.LEGION_ID).toBe(TEAM_ID);
     expect(restartOpts.env?.LEGION_ISSUE_BACKEND).toBe("github");
-    expect(restartOpts.env?.LEGION_DIR).toBe("/test/legion");
+    expect(restartOpts.env?.LEGION_DIR).toBeUndefined();
     expect(restartOpts.env?.LEGION_SHORT_ID).toBe(TEAM_ID.slice(0, 8));
-    expect(restartOpts.env?.LEGION_DAEMON_PORT).toBe("13370");
+    expect(Number(restartOpts.env?.LEGION_DAEMON_PORT)).toBeGreaterThanOrEqual(13370);
   });
 
   it("logs warning when worker session ID changes during startup re-creation", async () => {
@@ -721,10 +973,10 @@ describe("daemon entry", () => {
     }) as typeof console.warn;
 
     try {
-      await startDaemon(
+      await startDaemonForTest(
         {
           stateFilePath: "/tmp/daemon-workers.json",
-          teamId: TEAM_ID,
+          legionId: TEAM_ID,
           controllerSessionId: "ses_test",
         },
         {
@@ -781,11 +1033,11 @@ describe("daemon entry", () => {
     }) as typeof console.warn;
 
     try {
-      await startDaemon(
+      await startDaemonForTest(
         {
           stateFilePath: "/tmp/daemon-workers.json",
           checkIntervalMs: 1000,
-          teamId: TEAM_ID,
+          legionId: TEAM_ID,
           controllerSessionId: "ses_test",
         },
         {

--- a/packages/daemon/src/daemon/__tests__/legions-registry.test.ts
+++ b/packages/daemon/src/daemon/__tests__/legions-registry.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  allocatePort,
+  findLegionByProjectId,
+  isPidAlive,
+  readLegionsRegistry,
+  removeLegionEntry,
+  writeLegionEntry,
+} from "../legions-registry";
+
+describe("legions-registry", () => {
+  let tempDir: string | null = null;
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  it("returns empty registry when file missing", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-reg-"));
+    const registry = await readLegionsRegistry(path.join(tempDir, "legions.json"));
+    expect(registry).toEqual({});
+  });
+
+  it("writes and reads a legion entry", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-reg-"));
+    const filePath = path.join(tempDir, "legions.json");
+    const entry = {
+      port: 13370,
+      servePort: 13381,
+      pid: 1234,
+      startedAt: "2026-03-12T00:00:00Z",
+    };
+
+    await writeLegionEntry(filePath, "sjawhar/42", entry);
+    const registry = await readLegionsRegistry(filePath);
+
+    expect(registry["sjawhar/42"]).toEqual(entry);
+  });
+
+  it("returns empty registry when schema validation fails", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-reg-"));
+    const filePath = path.join(tempDir, "legions.json");
+
+    await writeFile(filePath, '{"bad":"data"}', "utf-8");
+    const registry = await readLegionsRegistry(filePath);
+
+    expect(registry).toEqual({});
+  });
+
+  it("writes atomically without leaving temp files", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-reg-"));
+    const filePath = path.join(tempDir, "legions.json");
+
+    await writeLegionEntry(filePath, "sjawhar/42", {
+      port: 13370,
+      servePort: 13381,
+      pid: process.pid,
+      startedAt: "2026-03-12T00:00:00Z",
+    });
+
+    const entries = await readdir(tempDir);
+    expect(entries).toEqual(["legions.json"]);
+  });
+
+  it("removes a legion entry", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-reg-"));
+    const filePath = path.join(tempDir, "legions.json");
+    await writeLegionEntry(filePath, "sjawhar/42", {
+      port: 13370,
+      servePort: 13381,
+      pid: 1234,
+      startedAt: "2026-03-12T00:00:00Z",
+    });
+
+    await removeLegionEntry(filePath, "sjawhar/42");
+    const registry = await readLegionsRegistry(filePath);
+
+    expect(registry["sjawhar/42"]).toBeUndefined();
+  });
+
+  it("allocates next available port", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-reg-"));
+    const filePath = path.join(tempDir, "legions.json");
+    await writeLegionEntry(filePath, "proj/1", {
+      port: 13370,
+      servePort: 13381,
+      pid: process.pid,
+      startedAt: "2026-03-12T00:00:00Z",
+    });
+
+    const registry = await readLegionsRegistry(filePath);
+    const { daemonPort, servePort } = allocatePort(registry);
+
+    expect(daemonPort).toBe(13371);
+    expect(servePort).toBe(13382);
+  });
+
+  it("reclaims port from dead PID", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-reg-"));
+    const filePath = path.join(tempDir, "legions.json");
+    await writeLegionEntry(filePath, "proj/1", {
+      port: 13370,
+      servePort: 13381,
+      pid: 999999999,
+      startedAt: "2026-03-12T00:00:00Z",
+    });
+
+    const registry = await readLegionsRegistry(filePath);
+    const { daemonPort } = allocatePort(registry);
+
+    expect(daemonPort).toBe(13370);
+  });
+
+  it("findLegionByProjectId returns entry when it exists", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-reg-"));
+    const filePath = path.join(tempDir, "legions.json");
+    await writeLegionEntry(filePath, "sjawhar/42", {
+      port: 13370,
+      servePort: 13381,
+      pid: process.pid,
+      startedAt: "2026-03-12T00:00:00Z",
+    });
+
+    const entry = await findLegionByProjectId(filePath, "sjawhar/42");
+    expect(entry).toBeDefined();
+    expect(entry?.port).toBe(13370);
+  });
+
+  describe("characterization: allocatePort", () => {
+    it("returns base ports when registry is empty", () => {
+      expect(allocatePort({})).toEqual({ daemonPort: 13370, servePort: 13381 });
+    });
+
+    it("returns next sequential ports when base ports are used by live processes", () => {
+      const { daemonPort, servePort } = allocatePort({
+        "proj/1": {
+          port: 13370,
+          servePort: 13381,
+          pid: process.pid,
+          startedAt: "2026-03-12T00:00:00Z",
+        },
+      });
+
+      expect(daemonPort).toBe(13371);
+      expect(servePort).toBe(13382);
+    });
+  });
+
+  describe("concurrent writes", () => {
+    it("preserves both entries for concurrent writes", async () => {
+      tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-reg-"));
+      const filePath = path.join(tempDir, "legions.json");
+
+      for (let i = 0; i < 50; i++) {
+        await rm(filePath, { force: true });
+        await Promise.all([
+          writeLegionEntry(filePath, "proj/a", {
+            port: 13370,
+            servePort: 13381,
+            pid: process.pid,
+            startedAt: "2026-03-12T00:00:00Z",
+          }),
+          writeLegionEntry(filePath, "proj/b", {
+            port: 13371,
+            servePort: 13382,
+            pid: process.pid,
+            startedAt: "2026-03-12T00:00:01Z",
+          }),
+        ]);
+
+        const registry = await readLegionsRegistry(filePath);
+        expect(registry["proj/a"]).toBeDefined();
+        expect(registry["proj/b"]).toBeDefined();
+      }
+    });
+
+    it("recovers stale lock from dead pid and writes successfully", async () => {
+      tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-reg-"));
+      const filePath = path.join(tempDir, "legions.json");
+      const lockPath = `${filePath}.lock`;
+
+      // Create stale lock file with dead PID
+      await writeFile(lockPath, JSON.stringify({ pid: 999999999, timestamp: Date.now() }), "utf-8");
+
+      await writeLegionEntry(filePath, "proj/stale", {
+        port: 13370,
+        servePort: 13381,
+        pid: process.pid,
+        startedAt: "2026-03-12T00:00:00Z",
+      });
+
+      const registry = await readLegionsRegistry(filePath);
+      expect(registry["proj/stale"]).toBeDefined();
+
+      const entries = await readdir(tempDir);
+      expect(entries).toEqual(["legions.json"]);
+
+      const written = await readFile(filePath, "utf-8");
+      expect(written).toContain("proj/stale");
+    });
+  });
+});
+
+describe("isPidAlive", () => {
+  it("returns true for current process PID (we are bun)", () => {
+    // Current process is bun — should return true
+    expect(isPidAlive(process.pid)).toBe(true);
+  });
+
+  it("returns false for non-existent PID", () => {
+    // PID 0 signals current process group, 999999 almost certainly doesn't exist
+    expect(isPidAlive(999999)).toBe(false);
+  });
+});

--- a/packages/daemon/src/daemon/__tests__/paths.test.ts
+++ b/packages/daemon/src/daemon/__tests__/paths.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "bun:test";
+import { resolveLegionPaths } from "../paths";
+
+describe("resolveLegionPaths", () => {
+  it("uses XDG defaults when env vars unset", () => {
+    const paths = resolveLegionPaths({}, "/home/testuser");
+    expect(paths.dataDir).toBe("/home/testuser/.local/share/legion");
+    expect(paths.stateDir).toBe("/home/testuser/.local/state/legion");
+    expect(paths.reposDir).toBe("/home/testuser/.local/share/legion/repos");
+    expect(paths.workspacesDir).toBe("/home/testuser/.local/share/legion/workspaces");
+    expect(paths.legionsFile).toBe("/home/testuser/.local/state/legion/legions.json");
+  });
+
+  it("respects XDG_DATA_HOME", () => {
+    const paths = resolveLegionPaths({ XDG_DATA_HOME: "/custom/data" }, "/home/testuser");
+    expect(paths.dataDir).toBe("/custom/data/legion");
+    expect(paths.reposDir).toBe("/custom/data/legion/repos");
+  });
+
+  it("respects XDG_STATE_HOME", () => {
+    const paths = resolveLegionPaths({ XDG_STATE_HOME: "/custom/state" }, "/home/testuser");
+    expect(paths.stateDir).toBe("/custom/state/legion");
+    expect(paths.legionsFile).toBe("/custom/state/legion/legions.json");
+  });
+
+  it("falls back to default when XDG_DATA_HOME is empty string", () => {
+    const paths = resolveLegionPaths({ XDG_DATA_HOME: "" }, "/home/testuser");
+    expect(paths.dataDir).toBe("/home/testuser/.local/share/legion");
+    expect(paths.reposDir).toBe("/home/testuser/.local/share/legion/repos");
+  });
+
+  it("falls back to default when XDG_STATE_HOME is relative path", () => {
+    const paths = resolveLegionPaths({ XDG_STATE_HOME: "relative/path" }, "/home/testuser");
+    expect(paths.stateDir).toBe("/home/testuser/.local/state/legion");
+    expect(paths.legionsFile).toBe("/home/testuser/.local/state/legion/legions.json");
+  });
+
+  it("computes legion-specific paths", () => {
+    const paths = resolveLegionPaths({}, "/home/testuser");
+    const legion = paths.forLegion("sjawhar/42");
+    expect(legion.legionStateDir).toBe("/home/testuser/.local/state/legion/legions/sjawhar/42");
+    expect(legion.workersFile).toBe(
+      "/home/testuser/.local/state/legion/legions/sjawhar/42/workers.json"
+    );
+    expect(legion.logDir).toBe("/home/testuser/.local/state/legion/legions/sjawhar/42/logs");
+    expect(legion.workspacesDir).toBe("/home/testuser/.local/share/legion/workspaces/sjawhar/42");
+  });
+
+  it("computes repo clone path", () => {
+    const paths = resolveLegionPaths({}, "/home/testuser");
+    expect(paths.repoClonePath("github.com", "acme", "widgets")).toBe(
+      "/home/testuser/.local/share/legion/repos/github.com/acme/widgets"
+    );
+  });
+});
+
+describe("path validation", () => {
+  it("throws when homeDir is empty string", () => {
+    expect(() => resolveLegionPaths({}, "")).toThrow("homeDir must be an absolute path, got: ");
+  });
+
+  it("throws when homeDir is relative path", () => {
+    expect(() => resolveLegionPaths({}, "relative/path")).toThrow(
+      "homeDir must be an absolute path, got: relative/path"
+    );
+  });
+
+  it("succeeds when homeDir is valid absolute path", () => {
+    const paths = resolveLegionPaths({}, "/home/test");
+    expect(paths.dataDir).toBe("/home/test/.local/share/legion");
+  });
+
+  it("throws when repoClonePath would escape repos directory", () => {
+    const paths = resolveLegionPaths({}, "/home/test");
+    expect(() => paths.repoClonePath("github.com", "../../..", "etc")).toThrow(
+      "Repo path would escape repos directory"
+    );
+  });
+
+  it("succeeds when repoClonePath is valid", () => {
+    const paths = resolveLegionPaths({}, "/home/test");
+    const result = paths.repoClonePath("github.com", "sjawhar", "42");
+    expect(result).toBe("/home/test/.local/share/legion/repos/github.com/sjawhar/42");
+  });
+
+  it("throws when forLegion would escape legions directory", () => {
+    const paths = resolveLegionPaths({}, "/home/test");
+    expect(() => paths.forLegion("../../../etc")).toThrow(
+      "Project path would escape legions directory"
+    );
+  });
+
+  it("succeeds when forLegion is valid", () => {
+    const paths = resolveLegionPaths({}, "/home/test");
+    const legion = paths.forLegion("sjawhar/42");
+    expect(legion.legionStateDir).toBe("/home/test/.local/state/legion/legions/sjawhar/42");
+  });
+});

--- a/packages/daemon/src/daemon/__tests__/repo-manager.test.ts
+++ b/packages/daemon/src/daemon/__tests__/repo-manager.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "bun:test";
+import { resolveLegionPaths } from "../paths";
+import {
+  cleanupWorkspace,
+  ensureRepoClone,
+  ensureWorkspace,
+  parseIssueRepo,
+  type RepoManagerDeps,
+  resolveWorkspacePath,
+} from "../repo-manager";
+
+describe("parseIssueRepo", () => {
+  it("parses explicit owner/repo", () => {
+    const result = parseIssueRepo("acme/widgets");
+    expect(result).toEqual({ host: "github.com", owner: "acme", repo: "widgets" });
+  });
+
+  it("returns null for invalid repo string", () => {
+    expect(parseIssueRepo("")).toBeNull();
+    expect(parseIssueRepo("noslash")).toBeNull();
+  });
+});
+
+describe("resolveWorkspacePath", () => {
+  it("builds workspace path from paths + projectId + issueId", () => {
+    const paths = resolveLegionPaths({}, "/home/test");
+    const result = resolveWorkspacePath(paths, "sjawhar/42", "acme-widgets-7");
+    expect(result).toBe("/home/test/.local/share/legion/workspaces/sjawhar/42/acme-widgets-7");
+  });
+
+  it("throws when issueId would escape workspaces directory", () => {
+    const paths = resolveLegionPaths({}, "/home/test");
+    expect(() => resolveWorkspacePath(paths, "sjawhar/42", "../../../etc")).toThrow(
+      "Workspace path would escape workspaces directory"
+    );
+  });
+});
+
+describe("ensureRepoClone", () => {
+  it("clones when directory does not exist", async () => {
+    const commands: string[][] = [];
+    const deps: RepoManagerDeps = {
+      runJj: async (args) => {
+        commands.push(args);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      exists: async () => false,
+      rmDir: async () => {},
+    };
+
+    const paths = resolveLegionPaths({}, "/home/test");
+    await ensureRepoClone(paths, { host: "github.com", owner: "acme", repo: "widgets" }, deps);
+
+    expect(commands[0]).toContain("git");
+    expect(commands[0]).toContain("clone");
+    expect(commands[0]).toContain("https://github.com/acme/widgets");
+  });
+
+  it("fetches when directory already exists", async () => {
+    const commands: string[][] = [];
+    const deps: RepoManagerDeps = {
+      runJj: async (args) => {
+        commands.push(args);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      exists: async () => true,
+      rmDir: async () => {},
+    };
+    const paths = resolveLegionPaths({}, "/home/test");
+    await ensureRepoClone(paths, { host: "github.com", owner: "acme", repo: "widgets" }, deps);
+
+    expect(commands[0]).toContain("git");
+    expect(commands[0]).toContain("fetch");
+  });
+
+  describe("characterization: ensureRepoClone", () => {
+    it("returns clone path when directory exists and fetch succeeds", async () => {
+      const commands: string[][] = [];
+      const deps: RepoManagerDeps = {
+        runJj: async (args) => {
+          commands.push(args);
+          return { exitCode: 0, stdout: "", stderr: "" };
+        },
+        exists: async () => true,
+        rmDir: async () => {},
+      };
+      const paths = resolveLegionPaths({}, "/home/test");
+
+      const clonePath = await ensureRepoClone(
+        paths,
+        { host: "github.com", owner: "acme", repo: "widgets" },
+        deps
+      );
+
+      expect(clonePath).toBe("/home/test/.local/share/legion/repos/github.com/acme/widgets");
+      expect(commands).toEqual([
+        ["git", "fetch", "-R", "/home/test/.local/share/legion/repos/github.com/acme/widgets"],
+      ]);
+    });
+
+    it("clones and returns clone path when directory does not exist", async () => {
+      const commands: string[][] = [];
+      const deps: RepoManagerDeps = {
+        runJj: async (args) => {
+          commands.push(args);
+          return { exitCode: 0, stdout: "", stderr: "" };
+        },
+        exists: async () => false,
+        rmDir: async () => {},
+      };
+      const paths = resolveLegionPaths({}, "/home/test");
+
+      const clonePath = await ensureRepoClone(
+        paths,
+        { host: "github.com", owner: "acme", repo: "widgets" },
+        deps
+      );
+
+      expect(clonePath).toBe("/home/test/.local/share/legion/repos/github.com/acme/widgets");
+      expect(commands).toEqual([
+        [
+          "git",
+          "clone",
+          "https://github.com/acme/widgets",
+          "/home/test/.local/share/legion/repos/github.com/acme/widgets",
+        ],
+      ]);
+    });
+  });
+
+  describe("fetch failure propagation", () => {
+    it("throws when jj git fetch fails", async () => {
+      const deps: RepoManagerDeps = {
+        runJj: async () => ({
+          exitCode: 1,
+          stdout: "",
+          stderr: "fatal: could not read from remote",
+        }),
+        exists: async () => true,
+        rmDir: async () => {},
+      };
+      const paths = resolveLegionPaths({}, "/home/test");
+
+      await expect(
+        ensureRepoClone(paths, { host: "github.com", owner: "acme", repo: "widgets" }, deps)
+      ).rejects.toThrow("jj git fetch failed");
+    });
+
+    it("includes stderr in error message", async () => {
+      const deps: RepoManagerDeps = {
+        runJj: async () => ({ exitCode: 128, stdout: "", stderr: "Permission denied (publickey)" }),
+        exists: async () => true,
+        rmDir: async () => {},
+      };
+      const paths = resolveLegionPaths({}, "/home/test");
+
+      await expect(
+        ensureRepoClone(paths, { host: "github.com", owner: "acme", repo: "widgets" }, deps)
+      ).rejects.toThrow("Permission denied (publickey)");
+    });
+  });
+});
+
+describe("ensureWorkspace", () => {
+  it("creates jj workspace when it does not exist", async () => {
+    const commands: string[][] = [];
+    const deps: RepoManagerDeps = {
+      runJj: async (args) => {
+        commands.push(args);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      exists: async (p) => p.includes("repos/"),
+      rmDir: async () => {},
+    };
+    const paths = resolveLegionPaths({}, "/home/test");
+    const repo = { host: "github.com", owner: "acme", repo: "widgets" };
+    const wsPath = await ensureWorkspace(paths, "sjawhar/42", "acme-widgets-7", repo, deps);
+
+    expect(wsPath).toBe("/home/test/.local/share/legion/workspaces/sjawhar/42/acme-widgets-7");
+    const wsCmd = commands.find((c) => c.includes("workspace"));
+    expect(wsCmd).toBeDefined();
+    expect(wsCmd).toContain("add");
+  });
+
+  it("skips workspace creation when it already exists", async () => {
+    const commands: string[][] = [];
+    const deps: RepoManagerDeps = {
+      runJj: async (args) => {
+        commands.push(args);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      exists: async () => true,
+      rmDir: async () => {},
+    };
+    const paths = resolveLegionPaths({}, "/home/test");
+    const repo = { host: "github.com", owner: "acme", repo: "widgets" };
+    await ensureWorkspace(paths, "sjawhar/42", "acme-widgets-7", repo, deps);
+
+    const wsCmd = commands.find((c) => c.includes("workspace"));
+    expect(wsCmd).toBeUndefined();
+  });
+});
+
+describe("cleanupWorkspace", () => {
+  it("forgets jj workspace and removes directory", async () => {
+    const commands: string[][] = [];
+    const removedPaths: string[] = [];
+    const deps: RepoManagerDeps = {
+      runJj: async (args) => {
+        commands.push(args);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      exists: async () => true,
+      rmDir: async (p) => {
+        removedPaths.push(p);
+      },
+    };
+
+    const paths = resolveLegionPaths({}, "/home/test");
+    const repo = { host: "github.com", owner: "acme", repo: "widgets" };
+    await cleanupWorkspace(paths, "sjawhar/42", "acme-widgets-7", repo, deps);
+
+    const forgetCmd = commands.find((c) => c.includes("forget"));
+    expect(forgetCmd).toBeDefined();
+    expect(forgetCmd).toContain("acme-widgets-7");
+    expect(removedPaths).toContain(
+      "/home/test/.local/share/legion/workspaces/sjawhar/42/acme-widgets-7"
+    );
+  });
+});

--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { computeSessionId } from "../../state/types";
+import type { LegionPaths } from "../paths";
+import type { RepoManagerDeps } from "../repo-manager";
 import type { RuntimeAdapter } from "../runtime/types";
 import type { WorkerEntry } from "../serve-manager";
 import { startServer } from "../server";
@@ -19,7 +21,7 @@ describe("daemon server", () => {
     | ((sessionId: string) => Promise<{ data?: unknown; error?: unknown }>)
     | null = null;
   const originalFetch = globalThis.fetch;
-  const teamId = "123e4567-e89b-12d3-a456-426614174000";
+  const legionId = "123e4567-e89b-12d3-a456-426614174000";
 
   function makeAdapter(): RuntimeAdapter {
     return {
@@ -44,6 +46,8 @@ describe("daemon server", () => {
   async function startTestServer(options?: {
     state?: PersistedWorkerState;
     adapterOverrides?: Partial<RuntimeAdapter>;
+    paths?: LegionPaths;
+    repoManagerDeps?: RepoManagerDeps;
     runtime?: string;
     tmuxSession?: string;
   }) {
@@ -60,9 +64,11 @@ describe("daemon server", () => {
     const { server, stop } = startServer({
       port: 0,
       hostname: "127.0.0.1",
-      teamId,
+      legionId,
       legionDir: tempDir,
+      paths: options?.paths,
       adapter,
+      repoManagerDeps: options?.repoManagerDeps,
       stateFilePath,
       runtime: options?.runtime,
       tmuxSession: options?.tmuxSession,
@@ -141,6 +147,20 @@ describe("daemon server", () => {
     expect(response.status).toBe(400);
   });
 
+  it("rejects worker creation when both repo and workspace are missing", async () => {
+    await startTestServer();
+    const response = await requestJson("/workers", {
+      method: "POST",
+      body: JSON.stringify({
+        issueId: "ENG-50",
+        mode: "implement",
+      }),
+    });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("missing repo or workspace");
+  });
+
   it("rejects relative workspace paths", async () => {
     await startTestServer();
     const response = await requestJson("/workers", {
@@ -172,10 +192,10 @@ describe("daemon server", () => {
     const body = (await response.json()) as { id: string; port: number; sessionId: string };
     expect(body.id).toBe("eng-42-implement");
     expect(body.port).toBe(sharedServePort);
-    expect(body.sessionId).toBe(computeSessionId(teamId, "eng-42", "implement"));
+    expect(body.sessionId).toBe(computeSessionId(legionId, "eng-42", "implement"));
 
     expect(createSessionCalls.length).toBe(1);
-    expect(createSessionCalls[0].sessionId).toBe(computeSessionId(teamId, "eng-42", "implement"));
+    expect(createSessionCalls[0].sessionId).toBe(computeSessionId(legionId, "eng-42", "implement"));
     expect(createSessionCalls[0].workspace).toBe("/tmp/work");
 
     const listResponse = await requestJson("/workers");
@@ -186,6 +206,189 @@ describe("daemon server", () => {
     expect(entryResponse.status).toBe(200);
     const entryBody = (await entryResponse.json()) as WorkerEntry;
     expect(entryBody.port).toBe(sharedServePort);
+  });
+
+  it("creates workers from repo by resolving workspace path", async () => {
+    const paths: LegionPaths = {
+      dataDir: "/tmp/legion-data",
+      stateDir: "/tmp/legion-state",
+      reposDir: "/tmp/legion-data/repos",
+      workspacesDir: "/tmp/legion-data/workspaces",
+      legionsFile: "/tmp/legion-state/legions.json",
+      forLegion: (projectId: string) => ({
+        legionStateDir: `/tmp/legion-state/legions/${projectId}`,
+        workersFile: `/tmp/legion-state/legions/${projectId}/workers.json`,
+        logDir: `/tmp/legion-state/legions/${projectId}/logs`,
+        workspacesDir: `/tmp/legion-data/workspaces/${projectId}`,
+      }),
+      repoClonePath: (host: string, owner: string, repo: string) =>
+        `/tmp/legion-data/repos/${host}/${owner}/${repo}`,
+    };
+    const runJjCalls: string[][] = [];
+    const repoManagerDeps: RepoManagerDeps = {
+      runJj: async (args: string[]) => {
+        runJjCalls.push(args);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      exists: async () => false,
+      rmDir: async () => {},
+    };
+    await startTestServer({ paths, repoManagerDeps });
+
+    const response = await requestJson("/workers", {
+      method: "POST",
+      body: JSON.stringify({
+        issueId: "acme-widgets-77",
+        mode: "implement",
+        repo: "acme/widgets",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(createSessionCalls.length).toBe(1);
+    expect(createSessionCalls[0].workspace).toBe(
+      "/tmp/legion-data/workspaces/123e4567-e89b-12d3-a456-426614174000/acme-widgets-77"
+    );
+    expect(runJjCalls).toEqual([
+      [
+        "git",
+        "clone",
+        "https://github.com/acme/widgets",
+        "/tmp/legion-data/repos/github.com/acme/widgets",
+      ],
+      [
+        "workspace",
+        "add",
+        "/tmp/legion-data/workspaces/123e4567-e89b-12d3-a456-426614174000/acme-widgets-77",
+        "--name",
+        "acme-widgets-77",
+        "-R",
+        "/tmp/legion-data/repos/github.com/acme/widgets",
+      ],
+    ]);
+  });
+
+  it("creates workers from legacy workspace payload", async () => {
+    await startTestServer();
+    const response = await requestJson("/workers", {
+      method: "POST",
+      body: JSON.stringify({
+        issueId: "ENG-78",
+        mode: "implement",
+        workspace: "/tmp/legacy-workspace",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(createSessionCalls.length).toBe(1);
+    expect(createSessionCalls[0].workspace).toBe("/tmp/legacy-workspace");
+  });
+
+  describe("characterization: POST /workers routing", () => {
+    it("with only repo resolves workspace and creates worker", async () => {
+      const paths: LegionPaths = {
+        dataDir: "/tmp/legion-data",
+        stateDir: "/tmp/legion-state",
+        reposDir: "/tmp/legion-data/repos",
+        workspacesDir: "/tmp/legion-data/workspaces",
+        legionsFile: "/tmp/legion-state/legions.json",
+        forLegion: (projectId: string) => ({
+          legionStateDir: `/tmp/legion-state/legions/${projectId}`,
+          workersFile: `/tmp/legion-state/legions/${projectId}/workers.json`,
+          logDir: `/tmp/legion-state/legions/${projectId}/logs`,
+          workspacesDir: `/tmp/legion-data/workspaces/${projectId}`,
+        }),
+        repoClonePath: (host: string, owner: string, repo: string) =>
+          `/tmp/legion-data/repos/${host}/${owner}/${repo}`,
+      };
+      const repoManagerDeps: RepoManagerDeps = {
+        runJj: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+        exists: async () => false,
+        rmDir: async () => {},
+      };
+      await startTestServer({ paths, repoManagerDeps });
+
+      const response = await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({
+          issueId: "acme-widgets-80",
+          mode: "implement",
+          repo: "acme/widgets",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(createSessionCalls).toHaveLength(1);
+      expect(createSessionCalls[0].workspace).toBe(
+        "/tmp/legion-data/workspaces/123e4567-e89b-12d3-a456-426614174000/acme-widgets-80"
+      );
+    });
+
+    it("with only workspace uses it directly", async () => {
+      await startTestServer();
+
+      const response = await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({
+          issueId: "ENG-80",
+          mode: "implement",
+          workspace: "/tmp/characterization-workspace",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(createSessionCalls).toHaveLength(1);
+      expect(createSessionCalls[0].workspace).toBe("/tmp/characterization-workspace");
+    });
+
+    it("with neither repo nor workspace returns 400", async () => {
+      await startTestServer();
+
+      const response = await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({ issueId: "ENG-81", mode: "implement" }),
+      });
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error: "missing repo or workspace" });
+    });
+  });
+
+  it("returns 500 when repo fetch fails", async () => {
+    const paths: LegionPaths = {
+      dataDir: "/tmp/legion-data",
+      stateDir: "/tmp/legion-state",
+      reposDir: "/tmp/legion-data/repos",
+      workspacesDir: "/tmp/legion-data/workspaces",
+      legionsFile: "/tmp/legion-state/legions.json",
+      forLegion: (projectId: string) => ({
+        legionStateDir: `/tmp/legion-state/legions/${projectId}`,
+        workersFile: `/tmp/legion-state/legions/${projectId}/workers.json`,
+        logDir: `/tmp/legion-state/legions/${projectId}/logs`,
+        workspacesDir: `/tmp/legion-data/workspaces/${projectId}`,
+      }),
+      repoClonePath: (host: string, owner: string, repo: string) =>
+        `/tmp/legion-data/repos/${host}/${owner}/${repo}`,
+    };
+    const repoManagerDeps: RepoManagerDeps = {
+      runJj: async () => ({ exitCode: 128, stdout: "", stderr: "Permission denied (publickey)" }),
+      exists: async () => true,
+      rmDir: async () => {},
+    };
+    await startTestServer({ paths, repoManagerDeps });
+
+    const response = await requestJson("/workers", {
+      method: "POST",
+      body: JSON.stringify({
+        issueId: "acme-widgets-99",
+        mode: "implement",
+        repo: "acme/widgets",
+      }),
+    });
+
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toContain("Failed to resolve workspace");
   });
 
   it("rejects duplicate worker for same issue+mode", async () => {
@@ -209,7 +412,7 @@ describe("daemon server", () => {
     const existing: WorkerEntry = {
       id: "eng-1-implement",
       port: sharedServePort,
-      sessionId: computeSessionId(teamId, "eng-1", "implement"),
+      sessionId: computeSessionId(legionId, "eng-1", "implement"),
       workspace: "/tmp",
       startedAt: "2026-02-01T00:00:00.000Z",
       status: "running",
@@ -329,6 +532,61 @@ describe("daemon server", () => {
     const listResponse = await requestJson("/workers");
     const listBody = (await listResponse.json()) as WorkerEntry[];
     expect(listBody).toEqual([]);
+  });
+
+  it("cleans worker workspace by repo", async () => {
+    const paths: LegionPaths = {
+      dataDir: "/tmp/legion-data",
+      stateDir: "/tmp/legion-state",
+      reposDir: "/tmp/legion-data/repos",
+      workspacesDir: "/tmp/legion-data/workspaces",
+      legionsFile: "/tmp/legion-state/legions.json",
+      forLegion: (projectId: string) => ({
+        legionStateDir: `/tmp/legion-state/legions/${projectId}`,
+        workersFile: `/tmp/legion-state/legions/${projectId}/workers.json`,
+        logDir: `/tmp/legion-state/legions/${projectId}/logs`,
+        workspacesDir: `/tmp/legion-data/workspaces/${projectId}`,
+      }),
+      repoClonePath: (host: string, owner: string, repo: string) =>
+        `/tmp/legion-data/repos/${host}/${owner}/${repo}`,
+    };
+    const runJjCalls: string[][] = [];
+    const rmDirCalls: string[] = [];
+    const repoManagerDeps: RepoManagerDeps = {
+      runJj: async (args: string[]) => {
+        runJjCalls.push(args);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      exists: async () => true,
+      rmDir: async (workspacePath: string) => {
+        rmDirCalls.push(workspacePath);
+      },
+    };
+    await startTestServer({ paths, repoManagerDeps });
+
+    const createResponse = await requestJson("/workers", {
+      method: "POST",
+      body: JSON.stringify({
+        issueId: "ENG-79",
+        mode: "implement",
+        workspace: "/tmp/worker-79",
+      }),
+    });
+    const created = (await createResponse.json()) as { id: string };
+
+    const cleanupResponse = await requestJson(`/workers/${created.id}/workspace`, {
+      method: "DELETE",
+      body: JSON.stringify({ repo: "acme/widgets" }),
+    });
+
+    expect(cleanupResponse.status).toBe(200);
+    expect(await cleanupResponse.json()).toEqual({ status: "cleaned" });
+    expect(runJjCalls).toEqual([
+      ["workspace", "forget", "eng-79", "-R", "/tmp/legion-data/repos/github.com/acme/widgets"],
+    ]);
+    expect(rmDirCalls).toEqual([
+      "/tmp/legion-data/workspaces/123e4567-e89b-12d3-a456-426614174000/eng-79",
+    ]);
   });
 
   it("returns status from worker", async () => {
@@ -497,7 +755,7 @@ describe("daemon server", () => {
     const baseWorkerEntry: WorkerEntry = {
       id: "leg-42-implement",
       port: sharedServePort,
-      sessionId: computeSessionId(teamId, "leg-42", "implement"),
+      sessionId: computeSessionId(legionId, "leg-42", "implement"),
       workspace: "/tmp/work",
       startedAt: "2026-02-01T00:00:00.000Z",
       status: "running",
@@ -586,7 +844,7 @@ describe("daemon server", () => {
     const { server, stop } = startServer({
       port: 0,
       hostname: "127.0.0.1",
-      teamId,
+      legionId,
       legionDir: tempDir ?? os.tmpdir(),
       adapter: makeAdapter(),
       stateFilePath: path.join(tempDir ?? os.tmpdir(), "workers.json"),
@@ -607,5 +865,120 @@ describe("daemon server", () => {
     await startTestServer();
     const response = await requestJson("/nope");
     expect(response.status).toBe(404);
+  });
+
+  describe("POST /state/fetch-and-collect", () => {
+    it("rejects invalid backend", async () => {
+      await startTestServer();
+      const response = await requestJson("/state/fetch-and-collect", {
+        method: "POST",
+        body: JSON.stringify({ backend: "invalid-backend", legionId: "team-123" }),
+      });
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("invalid_backend");
+    });
+
+    it("rejects linear backend with github-only message", async () => {
+      await startTestServer();
+      const response = await requestJson("/state/fetch-and-collect", {
+        method: "POST",
+        body: JSON.stringify({ backend: "linear", legionId: "team-123" }),
+      });
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("fetch-and-collect only supports github backend currently");
+    });
+
+    it("rejects missing backend field", async () => {
+      await startTestServer();
+      const response = await requestJson("/state/fetch-and-collect", {
+        method: "POST",
+        body: JSON.stringify({ legionId: "owner/123" }),
+      });
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("invalid_backend");
+    });
+
+    it("rejects invalid JSON body", async () => {
+      await startTestServer();
+      const response = await requestJson("/state/fetch-and-collect", {
+        method: "POST",
+        body: "not-json",
+      });
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("invalid_json");
+    });
+
+    it("rejects github backend with invalid legionId format", async () => {
+      await startTestServer();
+      const response = await requestJson("/state/fetch-and-collect", {
+        method: "POST",
+        body: JSON.stringify({ backend: "github", legionId: "no-slash" }),
+      });
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("invalid_team_id: expected owner/project-number");
+    });
+
+    it("rejects github backend with non-numeric project number", async () => {
+      await startTestServer();
+      const response = await requestJson("/state/fetch-and-collect", {
+        method: "POST",
+        body: JSON.stringify({ backend: "github", legionId: "owner/abc" }),
+      });
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("invalid_team_id: project number not a number");
+    });
+
+    it("returns 500 when github fetch fails (no real API)", async () => {
+      await startTestServer();
+      const response = await requestJson("/state/fetch-and-collect", {
+        method: "POST",
+        body: JSON.stringify({ backend: "github", legionId: "owner/123" }),
+      });
+      expect(response.status).toBe(500);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toContain("fetch_and_collect_failed");
+    });
+  });
+
+  describe("persistState serialization", () => {
+    it("concurrent state writes produce valid JSON", async () => {
+      await startTestServer();
+
+      // Register multiple workers concurrently to trigger parallel persistState calls
+      const concurrentRequests = Array.from({ length: 5 }, (_, i) =>
+        requestJson("/workers", {
+          method: "POST",
+          body: JSON.stringify({
+            issueId: `SERIAL-${i}`,
+            mode: "implement",
+            workspace: `/tmp/ws-${i}`,
+          }),
+        })
+      );
+
+      const responses = await Promise.all(concurrentRequests);
+      for (const response of responses) {
+        expect(response.status).toBe(200);
+      }
+
+      // Give a tick for any trailing async writes to complete
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Read the state file directly and verify it's valid JSON
+      const raw = await readFile(path.join(tempDir ?? os.tmpdir(), "workers.json"), "utf-8");
+      const parsed = JSON.parse(raw) as PersistedWorkerState;
+      expect(parsed).toBeDefined();
+      expect(typeof parsed.workers).toBe("object");
+
+      // All 5 workers should be present in the final state
+      const workerIds = Object.keys(parsed.workers);
+      expect(workerIds.length).toBe(5);
+    });
   });
 });

--- a/packages/daemon/src/daemon/__tests__/session-id-contract.test.ts
+++ b/packages/daemon/src/daemon/__tests__/session-id-contract.test.ts
@@ -11,7 +11,7 @@ describe("sessionId contract (daemon vs state)", () => {
   let stopServer: (() => void) | null = null;
 
   const originalFetch = globalThis.fetch;
-  const teamId = "123e4567-e89b-12d3-a456-426614174000";
+  const legionId = "123e4567-e89b-12d3-a456-426614174000";
 
   afterEach(async () => {
     globalThis.fetch = originalFetch;
@@ -46,7 +46,7 @@ describe("sessionId contract (daemon vs state)", () => {
     const { server, stop } = startServer({
       port: 0,
       hostname: "127.0.0.1",
-      teamId,
+      legionId,
       legionDir: tempDir,
       adapter,
       stateFilePath,
@@ -66,7 +66,7 @@ describe("sessionId contract (daemon vs state)", () => {
 
     expect(response.status).toBe(200);
     const body = (await response.json()) as { sessionId: string };
-    expect(body.sessionId).toBe(computeSessionId(teamId, "ENG-42", "implement"));
-    expect(createSessionCalls[0].sessionId).toBe(computeSessionId(teamId, "ENG-42", "implement"));
+    expect(body.sessionId).toBe(computeSessionId(legionId, "ENG-42", "implement"));
+    expect(createSessionCalls[0].sessionId).toBe(computeSessionId(legionId, "ENG-42", "implement"));
   });
 });

--- a/packages/daemon/src/daemon/config.ts
+++ b/packages/daemon/src/daemon/config.ts
@@ -1,10 +1,13 @@
 import os from "node:os";
 import path from "node:path";
+import type { LegionPaths } from "./paths";
+import { resolveLegionPaths } from "./paths";
 
 export interface DaemonConfig {
   daemonPort: number;
-  teamId?: string;
+  legionId?: string;
   legionDir?: string;
+  paths: LegionPaths;
   checkIntervalMs: number;
   baseWorkerPort: number;
   stateFilePath: string;
@@ -15,7 +18,7 @@ export interface DaemonConfig {
   runtime: "opencode" | "claude-code";
 }
 
-const DEFAULT_DAEMON_PORT = 13370;
+const BASE_DAEMON_PORT = 13370;
 const DEFAULT_CHECK_INTERVAL_MS = 60_000;
 const DEFAULT_BASE_WORKER_PORT = 13381;
 
@@ -28,11 +31,6 @@ function parseNumber(value: string | undefined, fallback: number): number {
     return fallback;
   }
   return parsed;
-}
-
-function resolveStateFilePath(legionDir?: string): string {
-  const baseDir = legionDir ?? os.homedir();
-  return path.join(baseDir, ".legion", "daemon", "workers.json");
 }
 
 export function validateControllerPrompt(prompt: string | undefined): void {
@@ -61,8 +59,14 @@ export function validateControllerPrompt(prompt: string | undefined): void {
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): DaemonConfig {
   const legionDir = env.LEGION_DIR;
-  const stateFilePath = resolveStateFilePath(legionDir);
-  const stateDir = path.dirname(stateFilePath);
+  const legionId = env.LEGION_ID;
+  const paths = resolveLegionPaths(env, os.homedir());
+  const stateFilePath = legionId
+    ? paths.forLegion(legionId).workersFile
+    : path.join(paths.stateDir, "daemon", "workers.json");
+  const logDir = legionId
+    ? paths.forLegion(legionId).logDir
+    : path.join(paths.stateDir, "daemon", "logs");
   const controllerSessionId = env.LEGION_CONTROLLER_SESSION_ID || undefined;
   const controllerPrompt = env.LEGION_CONTROLLER_PROMPT || undefined;
 
@@ -86,13 +90,14 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): DaemonConfig {
   }
   const runtime = rawRuntime === "claude-code" ? "claude-code" : "opencode";
   return {
-    daemonPort: parseNumber(env.LEGION_DAEMON_PORT, DEFAULT_DAEMON_PORT),
-    teamId: env.LEGION_TEAM_ID,
+    daemonPort: parseNumber(env.LEGION_DAEMON_PORT, BASE_DAEMON_PORT),
+    legionId,
     legionDir,
+    paths,
     checkIntervalMs: DEFAULT_CHECK_INTERVAL_MS,
     baseWorkerPort: DEFAULT_BASE_WORKER_PORT,
     stateFilePath,
-    logDir: path.join(stateDir, "logs"),
+    logDir,
     controllerSessionId,
     controllerPrompt,
     issueBackend,

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -1,6 +1,13 @@
 import { mkdirSync } from "node:fs";
 import { computeControllerSessionId } from "../state/types";
 import { type DaemonConfig, loadConfig, validateControllerPrompt } from "./config";
+import {
+  allocatePort,
+  readLegionsRegistry,
+  removeLegionEntry,
+  writeLegionEntry,
+} from "./legions-registry";
+import { isPortFree } from "./ports";
 import { createAdapter } from "./runtime";
 import type { RuntimeAdapter } from "./runtime/types";
 import { startServer } from "./server";
@@ -18,6 +25,13 @@ interface DaemonDependencies {
   clearTimeout: typeof clearTimeout;
 }
 
+interface DaemonOverrides extends Partial<DaemonConfig> {
+  readLegionsRegistry?: typeof readLegionsRegistry;
+  allocatePort?: typeof allocatePort;
+  writeLegionEntry?: typeof writeLegionEntry;
+  removeLegionEntry?: typeof removeLegionEntry;
+}
+
 export interface DaemonHandle {
   server: ServerHandle["server"];
   stop: () => Promise<void>;
@@ -30,7 +44,7 @@ function resolveDependencies(
 ): DaemonDependencies {
   const defaultAdapter = createAdapter(config.runtime, {
     port: config.baseWorkerPort,
-    shortId: config.teamId ?? "default",
+    shortId: config.legionId ?? "default",
   });
   return {
     adapter: overrides?.adapter ?? defaultAdapter,
@@ -65,31 +79,65 @@ async function sendPromptWithRetry(
 }
 
 function buildControllerEnv(config: DaemonConfig): Record<string, string> {
-  // config.teamId is guaranteed non-empty by the startDaemon guard at line 107-109.
+  // config.legionId is guaranteed non-empty by the startDaemon guard at line 107-109.
   // The "" fallback is unreachable dead code — kept to satisfy the type checker.
-  const teamId = config.teamId ?? "";
+  const legionId = config.legionId ?? "";
   return {
-    LEGION_TEAM_ID: teamId,
+    LEGION_ID: legionId,
     LEGION_ISSUE_BACKEND: config.issueBackend,
-    LEGION_DIR: config.legionDir ?? "", // legionDir is genuinely optional
-    LEGION_SHORT_ID: teamId.slice(0, 8),
+    LEGION_SHORT_ID: legionId.slice(0, 8),
     LEGION_DAEMON_PORT: String(config.daemonPort),
   };
 }
 
 export async function startDaemon(
-  overrides: Partial<DaemonConfig> = {},
+  overrides: DaemonOverrides = {},
   deps?: Partial<DaemonDependencies>
 ): Promise<DaemonHandle> {
-  const config = { ...loadConfig(), ...overrides };
-  if (!config.teamId) {
-    throw new Error("Missing teamId for daemon");
+  const {
+    readLegionsRegistry: readLegionsRegistryOverride,
+    allocatePort: allocatePortOverride,
+    writeLegionEntry: writeLegionEntryOverride,
+    removeLegionEntry: removeLegionEntryOverride,
+    ...configOverrides
+  } = overrides;
+
+  const readLegionsRegistryFn = readLegionsRegistryOverride ?? readLegionsRegistry;
+  const allocatePortFn = allocatePortOverride ?? allocatePort;
+  const writeLegionEntryFn = writeLegionEntryOverride ?? writeLegionEntry;
+  const removeLegionEntryFn = removeLegionEntryOverride ?? removeLegionEntry;
+
+  let config = { ...loadConfig(), ...configOverrides };
+  const legionId = config.legionId;
+  if (!legionId) {
+    throw new Error("Missing legionId for daemon");
   }
   validateControllerPrompt(config.controllerPrompt);
   mkdirSync(config.logDir, { recursive: true });
+
+  const registry = await readLegionsRegistryFn(config.paths.legionsFile);
+  const { daemonPort, servePort } = allocatePortFn(registry);
+
+  let actualDaemonPort = daemonPort;
+  while (!(await isPortFree(actualDaemonPort))) {
+    actualDaemonPort++;
+  }
+
+  let actualServePort = servePort;
+  while (!(await isPortFree(actualServePort))) {
+    actualServePort++;
+  }
+
+  config = {
+    ...config,
+    daemonPort: actualDaemonPort,
+    baseWorkerPort: actualServePort,
+  };
+
   const resolvedDeps = resolveDependencies(config, deps);
 
   const sharedServePort = config.baseWorkerPort;
+  const controllerWorkspace = config.paths.forLegion(legionId).legionStateDir;
 
   const existingHealthy = await resolvedDeps.adapter.healthy();
   if (existingHealthy) {
@@ -97,7 +145,7 @@ export async function startDaemon(
   } else {
     await resolvedDeps.adapter.start({
       env: buildControllerEnv(config),
-      workspace: config.legionDir ?? "",
+      workspace: controllerWorkspace,
       logDir: config.logDir,
     });
     console.log(`Shared serve started on port ${sharedServePort}`);
@@ -132,6 +180,10 @@ export async function startDaemon(
       healthTickTimeout = null;
     }
 
+    try {
+      await removeLegionEntryFn(config.paths.legionsFile, legionId);
+    } catch {}
+
     await resolvedDeps.adapter.stop();
 
     controllerState = undefined;
@@ -147,25 +199,55 @@ export async function startDaemon(
     }
   };
 
-  const { server, stop } = resolvedDeps.startServer({
-    port: config.daemonPort,
-    hostname: "127.0.0.1",
-    teamId: config.teamId,
-    legionDir: config.legionDir ?? "",
-    adapter: resolvedDeps.adapter,
-    stateFilePath: config.stateFilePath,
-    logDir: config.logDir,
-    runtime: config.runtime,
-    tmuxSession:
-      config.runtime === "claude-code" && config.teamId ? `legion-${config.teamId}` : undefined,
-    getControllerState: () => controllerState,
-    shutdownFn: async () => {
-      resolvedDeps.setTimeout(async () => {
-        await shutdown(true);
-      }, 100);
-    },
-  });
+  let server: ServerHandle["server"];
+  let stop: ServerHandle["stop"];
+  let bindAttempts = 0;
+
+  while (true) {
+    try {
+      const serverHandle = resolvedDeps.startServer({
+        port: config.daemonPort,
+        hostname: "127.0.0.1",
+        legionId,
+        projectId: legionId,
+        legionDir: config.legionDir,
+        paths: config.paths,
+        adapter: resolvedDeps.adapter,
+        stateFilePath: config.stateFilePath,
+        logDir: config.logDir,
+        runtime: config.runtime,
+        tmuxSession:
+          config.runtime === "claude-code" && config.legionId
+            ? `legion-${config.legionId}`
+            : undefined,
+        getControllerState: () => controllerState,
+        shutdownFn: async () => {
+          resolvedDeps.setTimeout(async () => {
+            await shutdown(true);
+          }, 100);
+        },
+      });
+      server = serverHandle.server;
+      stop = serverHandle.stop;
+      break;
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      bindAttempts++;
+      if (err.code !== "EADDRINUSE" || bindAttempts >= 5) {
+        throw error;
+      }
+      config = { ...config, daemonPort: config.daemonPort + 1 };
+    }
+  }
+
   stopServer = stop;
+
+  await writeLegionEntryFn(config.paths.legionsFile, legionId, {
+    port: config.daemonPort,
+    servePort: sharedServePort,
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+  });
 
   const existingController = controllerState;
 
@@ -183,16 +265,12 @@ export async function startDaemon(
     console.log(`External controller: session=${config.controllerSessionId}`);
     controllerState = { sessionId: config.controllerSessionId };
   } else {
-    const teamId = config.teamId;
-    if (!teamId) {
-      throw new Error("LEGION_TEAM_ID is required when no external controller session ID is set");
-    }
-    const requestedSessionId = computeControllerSessionId(teamId);
+    const requestedSessionId = computeControllerSessionId(legionId);
     let actualSessionId: string | undefined;
     try {
       actualSessionId = await resolvedDeps.adapter.createSession(
         requestedSessionId,
-        config.legionDir ?? ""
+        controllerWorkspace
       );
       controllerState = { sessionId: actualSessionId, port: sharedServePort };
     } catch (error) {
@@ -229,7 +307,7 @@ export async function startDaemon(
           try {
             await resolvedDeps.adapter.start({
               env: buildControllerEnv(config),
-              workspace: config.legionDir ?? "",
+              workspace: controllerWorkspace,
               logDir: config.logDir,
             });
             console.log(`Shared serve restarted on port ${sharedServePort}`);
@@ -255,7 +333,7 @@ export async function startDaemon(
               try {
                 const actualControllerSessionId = await resolvedDeps.adapter.createSession(
                   controllerState.sessionId,
-                  config.legionDir ?? ""
+                  controllerWorkspace
                 );
                 if (actualControllerSessionId !== controllerState.sessionId) {
                   console.warn(

--- a/packages/daemon/src/daemon/legions-registry.ts
+++ b/packages/daemon/src/daemon/legions-registry.ts
@@ -1,0 +1,172 @@
+import { closeSync, constants, openSync, readFileSync, writeSync } from "node:fs";
+import { copyFile, mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { LegionsRegistrySchema } from "./schemas";
+
+export interface LegionEntry {
+  port: number;
+  servePort: number;
+  pid: number;
+  startedAt: string;
+}
+
+export type LegionsRegistry = Record<string, LegionEntry>;
+
+const BASE_DAEMON_PORT = 13370;
+const BASE_SERVE_PORT = 13381;
+
+export function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+  } catch {
+    return false;
+  }
+  // On Linux, verify the PID belongs to a Legion/Bun process via /proc/cmdline
+  if (process.platform === "linux") {
+    try {
+      const cmdline = readFileSync(`/proc/${pid}/cmdline`, "utf-8");
+      return cmdline.includes("legion") || cmdline.includes("bun");
+    } catch {
+      // /proc read failed — fall back gracefully (treat as alive)
+    }
+  }
+  return true;
+}
+
+export async function readLegionsRegistry(filePath: string): Promise<LegionsRegistry> {
+  try {
+    const raw = await readFile(filePath, "utf-8");
+    if (!raw.trim()) {
+      return {};
+    }
+
+    const parsed = JSON.parse(raw);
+    const result = LegionsRegistrySchema.safeParse(parsed);
+    if (!result.success) {
+      console.warn(
+        `[legions-registry] Schema validation failed for ${filePath}, backing up and resetting. Error: ${result.error.message}`
+      );
+      try {
+        await copyFile(filePath, `${filePath}.bak.${Date.now()}`);
+      } catch {
+        // backup failure is non-fatal
+      }
+      return {};
+    }
+    return result.data;
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === "ENOENT") {
+      return {};
+    }
+    throw error;
+  }
+}
+
+export async function writeLegionEntry(
+  filePath: string,
+  projectId: string,
+  entry: LegionEntry
+): Promise<void> {
+  await withRegistryLock(filePath, async () => {
+    const registry = await readLegionsRegistry(filePath);
+    registry[projectId] = entry;
+    await writeRegistry(filePath, registry);
+  });
+}
+
+export async function removeLegionEntry(filePath: string, projectId: string): Promise<void> {
+  await withRegistryLock(filePath, async () => {
+    const registry = await readLegionsRegistry(filePath);
+    delete registry[projectId];
+    await writeRegistry(filePath, registry);
+  });
+}
+
+export function allocatePort(registry: LegionsRegistry): { daemonPort: number; servePort: number } {
+  const usedDaemonPorts = new Set<number>();
+  const usedServePorts = new Set<number>();
+
+  for (const entry of Object.values(registry)) {
+    if (isPidAlive(entry.pid)) {
+      usedDaemonPorts.add(entry.port);
+      usedServePorts.add(entry.servePort);
+    }
+  }
+
+  let daemonPort = BASE_DAEMON_PORT;
+  while (usedDaemonPorts.has(daemonPort)) {
+    daemonPort++;
+  }
+
+  let servePort = BASE_SERVE_PORT;
+  while (usedServePorts.has(servePort)) {
+    servePort++;
+  }
+
+  return { daemonPort, servePort };
+}
+
+export async function findLegionByProjectId(
+  filePath: string,
+  projectId: string
+): Promise<LegionEntry | undefined> {
+  const registry = await readLegionsRegistry(filePath);
+  return registry[projectId];
+}
+
+async function writeRegistry(filePath: string, registry: LegionsRegistry): Promise<void> {
+  const dir = path.dirname(filePath);
+  await mkdir(dir, { recursive: true });
+  const tempPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  await writeFile(tempPath, JSON.stringify(registry, null, 2), "utf-8");
+  await rename(tempPath, filePath);
+}
+
+export async function withRegistryLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+  const lockPath = `${filePath}.lock`;
+  const start = Date.now();
+  let delayMs = 50;
+
+  while (Date.now() - start < 3000) {
+    // Atomic lock acquisition via O_CREAT | O_EXCL (fails if file exists)
+    let acquired = false;
+    try {
+      const fd = openSync(lockPath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
+      writeSync(fd, JSON.stringify({ pid: process.pid, timestamp: Date.now() }));
+      closeSync(fd);
+      acquired = true;
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code !== "EEXIST") {
+        throw error;
+      }
+    }
+
+    if (acquired) {
+      try {
+        return await fn();
+      } finally {
+        await unlink(lockPath).catch(() => {});
+      }
+    }
+
+    // Lock exists — check if stale
+    try {
+      const raw = await readFile(lockPath, "utf-8");
+      const parsed = JSON.parse(raw) as { pid?: unknown };
+      if (typeof parsed.pid === "number" && !isPidAlive(parsed.pid)) {
+        await unlink(lockPath).catch(() => {});
+        continue;
+      }
+    } catch {
+      // Lock file unreadable or gone — retry
+      continue;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    delayMs = Math.min(delayMs * 2, 400);
+  }
+
+  throw new Error(`Timed out acquiring registry lock: ${lockPath}`);
+}

--- a/packages/daemon/src/daemon/paths.ts
+++ b/packages/daemon/src/daemon/paths.ts
@@ -1,0 +1,73 @@
+import path from "node:path";
+
+export interface LegionPaths {
+  dataDir: string;
+  stateDir: string;
+  reposDir: string;
+  workspacesDir: string;
+  legionsFile: string;
+  forLegion(projectId: string): LegionInstancePaths;
+  repoClonePath(host: string, owner: string, repo: string): string;
+}
+
+export interface LegionInstancePaths {
+  legionStateDir: string;
+  workersFile: string;
+  logDir: string;
+  workspacesDir: string;
+}
+
+export function resolveLegionPaths(
+  env: Record<string, string | undefined>,
+  homeDir: string
+): LegionPaths {
+  if (!path.isAbsolute(homeDir)) {
+    throw new Error(`homeDir must be an absolute path, got: ${homeDir}`);
+  }
+  function resolveXdgDir(value: string | undefined, fallback: string): string {
+    return value && path.isAbsolute(value) ? value : fallback;
+  }
+
+  const dataHome = resolveXdgDir(env.XDG_DATA_HOME, path.join(homeDir, ".local", "share"));
+  const stateHome = resolveXdgDir(env.XDG_STATE_HOME, path.join(homeDir, ".local", "state"));
+
+  const dataDir = path.join(dataHome, "legion");
+  const stateDir = path.join(stateHome, "legion");
+  const reposDir = path.join(dataDir, "repos");
+  const workspacesDir = path.join(dataDir, "workspaces");
+  const legionsFile = path.join(stateDir, "legions.json");
+
+  return {
+    dataDir,
+    stateDir,
+    reposDir,
+    workspacesDir,
+    legionsFile,
+    forLegion(projectId: string): LegionInstancePaths {
+      const legionStateDir = path.join(stateDir, "legions", projectId);
+      const resolvedStateDir = path.resolve(legionStateDir);
+      const expectedParent = path.resolve(path.join(stateDir, "legions"));
+      if (
+        !resolvedStateDir.startsWith(expectedParent + path.sep) &&
+        resolvedStateDir !== expectedParent
+      ) {
+        throw new Error(`Project path would escape legions directory: ${resolvedStateDir}`);
+      }
+      return {
+        legionStateDir,
+        workersFile: path.join(legionStateDir, "workers.json"),
+        logDir: path.join(legionStateDir, "logs"),
+        workspacesDir: path.join(workspacesDir, projectId),
+      };
+    },
+    repoClonePath(host: string, owner: string, repo: string): string {
+      const clonePath = path.join(reposDir, host, owner, repo);
+      const resolvedPath = path.resolve(clonePath);
+      const expectedParent = path.resolve(reposDir);
+      if (!resolvedPath.startsWith(expectedParent + path.sep) && resolvedPath !== expectedParent) {
+        throw new Error(`Repo path would escape repos directory: ${resolvedPath}`);
+      }
+      return clonePath;
+    },
+  };
+}

--- a/packages/daemon/src/daemon/repo-manager.ts
+++ b/packages/daemon/src/daemon/repo-manager.ts
@@ -1,0 +1,140 @@
+import path from "node:path";
+import type { LegionPaths } from "./paths";
+
+export interface RepoRef {
+  host: string;
+  owner: string;
+  repo: string;
+}
+
+export interface JjResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface RepoManagerDeps {
+  runJj: (args: string[]) => Promise<JjResult>;
+  exists: (path: string) => Promise<boolean>;
+  rmDir: (path: string) => Promise<void>;
+}
+
+const defaultDeps: RepoManagerDeps = {
+  runJj: async (args) => {
+    const result = Bun.spawnSync(["jj", ...args], {
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 120_000,
+    });
+    return {
+      exitCode: result.exitCode,
+      stdout: result.stdout.toString(),
+      stderr: result.stderr.toString(),
+    };
+  },
+  exists: async (p) => {
+    const { existsSync } = await import("node:fs");
+    return existsSync(p);
+  },
+  rmDir: async (p) => {
+    const { rm } = await import("node:fs/promises");
+    await rm(p, { recursive: true, force: true });
+  },
+};
+
+/**
+ * Parse a repository reference string into owner and repo components.
+ *
+ * @param repoStr - Repository string in format "owner/repo" (e.g., "facebook/react")
+ * @returns RepoRef with parsed owner and repo, or null if format is invalid
+ *
+ * @note Currently hardcoded to assume github.com as the host. This is acceptable for
+ * the current scope (GitHub.com only). For GitHub Enterprise (GHE) support, this
+ * function would need to accept an optional host parameter.
+ */
+export function parseIssueRepo(repoStr: string): RepoRef | null {
+  const parts = repoStr.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return null;
+  }
+  return { host: "github.com", owner: parts[0], repo: parts[1] };
+}
+
+export function resolveWorkspacePath(
+  paths: LegionPaths,
+  projectId: string,
+  issueId: string
+): string {
+  const workspacePath = path.join(paths.forLegion(projectId).workspacesDir, issueId);
+  const resolvedPath = path.resolve(workspacePath);
+  const expectedParent = path.resolve(paths.forLegion(projectId).workspacesDir);
+  if (!resolvedPath.startsWith(expectedParent + path.sep) && resolvedPath !== expectedParent) {
+    throw new Error(`Workspace path would escape workspaces directory: ${resolvedPath}`);
+  }
+  return workspacePath;
+}
+
+export async function ensureRepoClone(
+  paths: LegionPaths,
+  repo: RepoRef,
+  deps: RepoManagerDeps = defaultDeps
+): Promise<string> {
+  const clonePath = paths.repoClonePath(repo.host, repo.owner, repo.repo);
+
+  if (await deps.exists(clonePath)) {
+    const result = await deps.runJj(["git", "fetch", "-R", clonePath]);
+    if (result.exitCode !== 0) {
+      throw new Error(`jj git fetch failed for ${clonePath}: ${result.stderr}`);
+    }
+  } else {
+    const url = `https://${repo.host}/${repo.owner}/${repo.repo}`;
+    const result = await deps.runJj(["git", "clone", url, clonePath]);
+    if (result.exitCode !== 0) {
+      throw new Error(`Failed to clone ${url}: ${result.stderr}`);
+    }
+  }
+
+  return clonePath;
+}
+
+export async function ensureWorkspace(
+  paths: LegionPaths,
+  projectId: string,
+  issueId: string,
+  repo: RepoRef,
+  deps: RepoManagerDeps = defaultDeps
+): Promise<string> {
+  const clonePath = await ensureRepoClone(paths, repo, deps);
+  const workspacePath = resolveWorkspacePath(paths, projectId, issueId);
+
+  if (!(await deps.exists(workspacePath))) {
+    const result = await deps.runJj([
+      "workspace",
+      "add",
+      workspacePath,
+      "--name",
+      issueId.toLowerCase(),
+      "-R",
+      clonePath,
+    ]);
+    if (result.exitCode !== 0) {
+      throw new Error(`Failed to create workspace ${workspacePath}: ${result.stderr}`);
+    }
+  }
+
+  return workspacePath;
+}
+
+export async function cleanupWorkspace(
+  paths: LegionPaths,
+  projectId: string,
+  issueId: string,
+  repo: RepoRef,
+  deps: RepoManagerDeps = defaultDeps
+): Promise<void> {
+  const clonePath = paths.repoClonePath(repo.host, repo.owner, repo.repo);
+  const workspacePath = resolveWorkspacePath(paths, projectId, issueId);
+
+  await deps.runJj(["workspace", "forget", issueId.toLowerCase(), "-R", clonePath]);
+
+  await deps.rmDir(workspacePath);
+}

--- a/packages/daemon/src/daemon/runtime/__tests__/claude-code.test.ts
+++ b/packages/daemon/src/daemon/runtime/__tests__/claude-code.test.ts
@@ -53,7 +53,7 @@ describe("ClaudeCodeAdapter", () => {
       const adapter = new ClaudeCodeAdapter("test", spawn);
       await adapter.start({
         workspace: "/tmp/ws",
-        env: { LEGION_TEAM_ID: "abc", LEGION_DIR: "/test" },
+        env: { LEGION_ID: "abc", LEGION_DAEMON_PORT: "13370" },
       });
       const envCalls = calls.filter((c) => c[1] === "set-environment");
       expect(envCalls).toHaveLength(2);
@@ -62,7 +62,7 @@ describe("ClaudeCodeAdapter", () => {
         "set-environment",
         "-t",
         "legion-test",
-        "LEGION_TEAM_ID",
+        "LEGION_ID",
         "abc",
       ]);
       expect(envCalls[1]).toEqual([
@@ -70,8 +70,8 @@ describe("ClaudeCodeAdapter", () => {
         "set-environment",
         "-t",
         "legion-test",
-        "LEGION_DIR",
-        "/test",
+        "LEGION_DAEMON_PORT",
+        "13370",
       ]);
     });
 

--- a/packages/daemon/src/daemon/runtime/opencode.ts
+++ b/packages/daemon/src/daemon/runtime/opencode.ts
@@ -55,6 +55,12 @@ export class OpenCodeAdapter implements RuntimeAdapter {
   async getSessionStatus(sessionId: string): Promise<{ data?: unknown; error?: unknown }> {
     const client = createWorkerClient(this.port, this.workspaces.get(sessionId) ?? "");
     const result = await client.session.status();
-    return result;
+    if (result.error || !result.data) {
+      return result;
+    }
+    // session.status() returns a map of ALL sessions — filter to just the requested one
+    const allStatuses = result.data as Record<string, unknown>;
+    const sessionStatus = allStatuses[sessionId];
+    return { data: sessionStatus ?? { type: "idle" } };
   }
 }

--- a/packages/daemon/src/daemon/schemas.ts
+++ b/packages/daemon/src/daemon/schemas.ts
@@ -71,4 +71,13 @@ export const HealthCheckResponseSchema = z
   })
   .passthrough();
 
+export const LegionEntrySchema = z.object({
+  port: z.number(),
+  servePort: z.number(),
+  pid: z.number(),
+  startedAt: z.string(),
+});
+
+export const LegionsRegistrySchema = z.record(z.string(), LegionEntrySchema);
+
 export type HealthCheckResponse = z.infer<typeof HealthCheckResponseSchema>;

--- a/packages/daemon/src/daemon/serve-manager.ts
+++ b/packages/daemon/src/daemon/serve-manager.ts
@@ -26,6 +26,7 @@ export interface WorkerEntry {
   status: "starting" | "running" | "stopped" | "dead";
   crashCount: number;
   lastCrashAt: string | null;
+  version?: number;
 }
 
 export function createWorkerClient(port: number, workspace: string): OpencodeClient {

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -2,12 +2,20 @@ import { isAbsolute } from "node:path";
 import { getBackend, isBackendName } from "../state/backends/index";
 import { buildCollectedState } from "../state/decision";
 import { enrichParsedIssues } from "../state/fetch";
+import { fetchGitHubProjectItems } from "../state/github-fetch";
 import {
   CollectedState,
   computeSessionId,
   WorkerMode,
   type WorkerModeLiteral,
 } from "../state/types";
+import type { LegionPaths } from "./paths";
+import {
+  cleanupWorkspace,
+  ensureWorkspace,
+  parseIssueRepo,
+  type RepoManagerDeps,
+} from "./repo-manager";
 import type { RuntimeAdapter } from "./runtime/types";
 import type { WorkerEntry } from "./serve-manager";
 import {
@@ -23,9 +31,12 @@ type Server = ReturnType<typeof Bun.serve>;
 export interface ServerOptions {
   port?: number;
   hostname?: string;
-  teamId: string;
-  legionDir: string;
+  legionId: string;
+  projectId?: string;
+  legionDir?: string;
+  paths?: LegionPaths;
   adapter: RuntimeAdapter;
+  repoManagerDeps?: RepoManagerDeps;
   stateFilePath: string;
   logDir?: string;
   shutdownFn?: () => void | Promise<void>;
@@ -78,6 +89,16 @@ async function parseJson(request: Request): Promise<Record<string, unknown>> {
   }
 }
 
+function extractIssueIdFromWorkerId(workerId: string): string | null {
+  for (const mode of Object.values(WorkerMode)) {
+    const suffix = `-${mode}`;
+    if (workerId.endsWith(suffix)) {
+      return workerId.slice(0, -suffix.length);
+    }
+  }
+  return null;
+}
+
 export function startServer(opts: ServerOptions): { server: Server; stop: () => void } {
   const hostname = opts.hostname ?? "127.0.0.1";
   const port = opts.port ?? 13370;
@@ -85,16 +106,23 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
   const workers = new Map<string, WorkerEntry>();
   const crashHistory = new Map<string, CrashHistoryEntry>();
 
+  let pendingWrite: Promise<void> = Promise.resolve();
+
   const persistState = async (): Promise<void> => {
-    const state: PersistedWorkerState = { workers: {}, crashHistory: {} };
-    for (const [id, entry] of workers.entries()) {
-      state.workers[id] = entry;
-    }
-    for (const [id, history] of crashHistory.entries()) {
-      state.crashHistory[id] = history;
-    }
-    state.controller = opts.getControllerState?.();
-    await writeStateFile(opts.stateFilePath, state);
+    const doWrite = async () => {
+      const state: PersistedWorkerState = { workers: {}, crashHistory: {} };
+      for (const [id, entry] of workers.entries()) {
+        state.workers[id] = entry;
+      }
+      for (const [id, history] of crashHistory.entries()) {
+        state.crashHistory[id] = history;
+      }
+      state.controller = opts.getControllerState?.();
+      await writeStateFile(opts.stateFilePath, state);
+    };
+
+    pendingWrite = pendingWrite.then(doWrite, doWrite);
+    await pendingWrite;
   };
 
   const loadState = async (): Promise<void> => {
@@ -145,21 +173,54 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
 
             const issueId = payload.issueId;
             const mode = payload.mode;
+            const repo = payload.repo;
             const workspace = payload.workspace;
+            const version = typeof payload.version === "number" ? payload.version : 0;
 
-            if (
-              typeof issueId !== "string" ||
-              typeof mode !== "string" ||
-              typeof workspace !== "string"
-            ) {
+            if (typeof issueId !== "string" || typeof mode !== "string") {
               return badRequest("missing_fields");
             }
-            if (!isAbsolute(workspace)) {
-              return badRequest("workspace must be an absolute path");
+            if (typeof repo === "string" && typeof workspace === "string") {
+              return badRequest(
+                "repo and workspace are mutually exclusive — provide one or neither"
+              );
+            }
+            if (typeof repo !== "string" && typeof workspace !== "string") {
+              return badRequest("missing repo or workspace");
             }
             const validModes = Object.values(WorkerMode);
             if (!validModes.includes(mode as WorkerModeLiteral)) {
               return badRequest(`invalid_mode: must be one of ${validModes.join(", ")}`);
+            }
+
+            let resolvedWorkspace: string | null = null;
+            if (typeof repo === "string") {
+              if (!opts.paths) {
+                return badRequest("repo_resolution_unavailable");
+              }
+              const repoRef = parseIssueRepo(repo);
+              if (!repoRef) {
+                return badRequest("invalid_repo: expected owner/repo");
+              }
+              try {
+                resolvedWorkspace = await ensureWorkspace(
+                  opts.paths,
+                  opts.legionId,
+                  issueId,
+                  repoRef,
+                  opts.repoManagerDeps
+                );
+              } catch (error) {
+                return serverError(`Failed to resolve workspace: ${(error as Error).message}`);
+              }
+            } else if (typeof workspace === "string") {
+              if (!isAbsolute(workspace)) {
+                return badRequest("workspace must be an absolute path");
+              }
+              resolvedWorkspace = workspace;
+            }
+            if (!resolvedWorkspace) {
+              return badRequest("missing repo or workspace");
             }
 
             const normalizedIssueId = issueId.toLowerCase();
@@ -202,11 +263,16 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
               }
             }
 
-            const sessionId = computeSessionId(opts.teamId, issueId, mode as WorkerModeLiteral);
+            const sessionId = computeSessionId(
+              opts.legionId,
+              issueId,
+              mode as WorkerModeLiteral,
+              version
+            );
 
             let actualSessionId = sessionId;
             try {
-              actualSessionId = await opts.adapter.createSession(sessionId, workspace);
+              actualSessionId = await opts.adapter.createSession(sessionId, resolvedWorkspace);
             } catch (error) {
               return serverError(`Failed to create session: ${(error as Error).message}`);
             }
@@ -215,11 +281,12 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
               id: workerId,
               port: opts.adapter.getPort(),
               sessionId: actualSessionId,
-              workspace,
+              workspace: resolvedWorkspace,
               startedAt: new Date().toISOString(),
               status: "running",
               crashCount: crashHistoryEntry?.crashCount ?? 0,
               lastCrashAt: crashHistoryEntry?.lastCrashAt ?? null,
+              version,
             };
 
             workers.set(entry.id, entry);
@@ -242,6 +309,55 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
           crashHistory.delete(workerId);
           await persistState();
           return jsonResponse({ reset: true, id: workerId });
+        }
+
+        if (segments.length === 3 && segments[0] === "workers" && segments[2] === "workspace") {
+          await stateLoaded;
+          if (method !== "DELETE") {
+            return notFound();
+          }
+          const workerId = segments[1].toLowerCase();
+          const entry = workers.get(workerId);
+          if (!entry) {
+            return notFound();
+          }
+          if (!opts.paths) {
+            return badRequest("workspace_cleanup_unavailable");
+          }
+
+          let payload: Record<string, unknown>;
+          try {
+            payload = await parseJson(request);
+          } catch {
+            return badRequest("invalid_json");
+          }
+
+          const repo = payload.repo;
+          if (typeof repo !== "string") {
+            return badRequest("missing_fields");
+          }
+          const repoRef = parseIssueRepo(repo);
+          if (!repoRef) {
+            return badRequest("invalid_repo: expected owner/repo");
+          }
+          const issueId = extractIssueIdFromWorkerId(entry.id);
+          if (!issueId) {
+            return badRequest("invalid_worker_id");
+          }
+
+          try {
+            await cleanupWorkspace(
+              opts.paths,
+              opts.legionId,
+              issueId,
+              repoRef,
+              opts.repoManagerDeps
+            );
+          } catch (error) {
+            return serverError(`Failed to cleanup workspace: ${(error as Error).message}`);
+          }
+
+          return jsonResponse({ status: "cleaned" });
         }
 
         if (segments.length === 2 && segments[0] === "workers") {
@@ -382,12 +498,56 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
             const parsed = tracker.parseIssues(issues);
             const daemonUrl = `http://127.0.0.1:${server.port}`;
             const issuesData = await enrichParsedIssues(parsed, daemonUrl);
-            const state = buildCollectedState(issuesData, opts.teamId);
+            const state = buildCollectedState(issuesData, opts.legionId);
             return jsonResponse(CollectedState.toDict(state));
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             console.error(`[collect] backend=${backend} error=${message}`);
             return serverError("collect_failed");
+          }
+        }
+
+        if (method === "POST" && url.pathname === "/state/fetch-and-collect") {
+          let payload: Record<string, unknown>;
+          try {
+            payload = await parseJson(request);
+          } catch {
+            return badRequest("invalid_json");
+          }
+
+          const backend = payload.backend;
+          if (!isBackendName(backend)) {
+            return badRequest("invalid_backend");
+          }
+
+          try {
+            let rawIssues: unknown;
+            if (backend === "github") {
+              const legionId = (payload.legionId as string) ?? opts.legionId;
+              const parts = legionId.split("/");
+              if (parts.length !== 2 || !parts[1]) {
+                return badRequest("invalid_team_id: expected owner/project-number");
+              }
+              const [owner, numStr] = parts;
+              const projectNumber = Number(numStr);
+              if (!Number.isFinite(projectNumber)) {
+                return badRequest("invalid_team_id: project number not a number");
+              }
+              rawIssues = await fetchGitHubProjectItems(owner, projectNumber);
+            } else {
+              return badRequest("fetch-and-collect only supports github backend currently");
+            }
+
+            const tracker = getBackend(backend);
+            const parsed = tracker.parseIssues(rawIssues);
+            const daemonUrl = `http://127.0.0.1:${server.port}`;
+            const issuesData = await enrichParsedIssues(parsed, daemonUrl);
+            const state = buildCollectedState(issuesData, opts.legionId);
+            return jsonResponse(CollectedState.toDict(state));
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            console.error(`[fetch-and-collect] backend=${backend} error=${message}`);
+            return serverError(`fetch_and_collect_failed: ${message}`);
           }
         }
 

--- a/packages/daemon/src/state/__tests__/cli.test.ts
+++ b/packages/daemon/src/state/__tests__/cli.test.ts
@@ -22,7 +22,7 @@ describe("parseArgs", () => {
       "--daemon-url",
       "http://localhost:3000",
     ]);
-    expect(args.teamId).toBe("00000000-0000-0000-0000-000000000000");
+    expect(args.legionId).toBe("00000000-0000-0000-0000-000000000000");
     expect(args.daemonUrl).toBe("http://localhost:3000");
   });
 

--- a/packages/daemon/src/state/__tests__/decision.test.ts
+++ b/packages/daemon/src/state/__tests__/decision.test.ts
@@ -326,7 +326,7 @@ describe("buildIssueState", () => {
   });
 
   it("feedback_without_input_needed_follows_normal_flow", () => {
-    const teamId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
+    const legionId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
     const data: FetchedIssueData = {
       issueId: "ENG-21",
       status: "In Progress",
@@ -346,15 +346,15 @@ describe("buildIssueState", () => {
       source: null,
     };
 
-    const state = buildIssueState(data, teamId);
+    const state = buildIssueState(data, legionId);
 
     expect(state.suggestedAction).toBe("transition_to_testing");
-    const expectedSessionId = computeSessionId(teamId, "ENG-21", "test");
+    const expectedSessionId = computeSessionId(legionId, "ENG-21", "test");
     expect(state.sessionId).toBe(expectedSessionId);
   });
 
   it("relay_feedback_computes_correct_session_id", () => {
-    const teamId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
+    const legionId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
     const data: FetchedIssueData = {
       issueId: "ENG-21",
       status: "In Progress",
@@ -374,15 +374,15 @@ describe("buildIssueState", () => {
       source: null,
     };
 
-    const state = buildIssueState(data, teamId);
+    const state = buildIssueState(data, legionId);
 
-    const expectedSessionId = computeSessionId(teamId, "ENG-21", "implement");
+    const expectedSessionId = computeSessionId(legionId, "ENG-21", "implement");
     expect(state.sessionId).toBe(expectedSessionId);
     expect(state.suggestedAction).toBe("relay_user_feedback");
   });
 
   it("relay_feedback_in_different_statuses", () => {
-    const teamId = "00000000-0000-0000-0000-000000000000";
+    const legionId = "00000000-0000-0000-0000-000000000000";
 
     const dataTodo: FetchedIssueData = {
       issueId: "ENG-21",
@@ -402,7 +402,7 @@ describe("buildIssueState", () => {
       hasTestFailed: false,
       source: null,
     };
-    const stateTodo = buildIssueState(dataTodo, teamId);
+    const stateTodo = buildIssueState(dataTodo, legionId);
     expect(stateTodo.suggestedAction).toBe("relay_user_feedback");
 
     const dataReview: FetchedIssueData = {
@@ -423,7 +423,7 @@ describe("buildIssueState", () => {
       hasTestFailed: false,
       source: null,
     };
-    const stateReview = buildIssueState(dataReview, teamId);
+    const stateReview = buildIssueState(dataReview, legionId);
     expect(stateReview.suggestedAction).toBe("relay_user_feedback");
   });
 
@@ -600,7 +600,7 @@ describe("orphan detection", () => {
   });
 
   it("orphan_detected_in_various_statuses", () => {
-    const teamId = "00000000-0000-0000-0000-000000000000";
+    const legionId = "00000000-0000-0000-0000-000000000000";
 
     for (const status of ["Todo", "In Progress", "Backlog", "Needs Review"]) {
       const data: FetchedIssueData = {
@@ -622,7 +622,7 @@ describe("orphan detection", () => {
         source: null,
       };
 
-      const state = buildIssueState(data, teamId);
+      const state = buildIssueState(data, legionId);
       expect(state.suggestedAction).toBe("remove_worker_active_and_redispatch");
     }
   });
@@ -736,7 +736,7 @@ describe("buildCollectedState", () => {
   });
 
   it("relay_feedback_with_multiple_issues", () => {
-    const teamId = "00000000-0000-0000-0000-000000000000";
+    const legionId = "00000000-0000-0000-0000-000000000000";
     const issuesData: FetchedIssueData[] = [
       {
         issueId: "ENG-21",
@@ -794,7 +794,7 @@ describe("buildCollectedState", () => {
       },
     ];
 
-    const state = buildCollectedState(issuesData, teamId);
+    const state = buildCollectedState(issuesData, legionId);
 
     expect(Object.keys(state.issues)).toHaveLength(3);
     expect(state.issues["ENG-21"].suggestedAction).toBe("dispatch_planner");

--- a/packages/daemon/src/state/__tests__/types.test.ts
+++ b/packages/daemon/src/state/__tests__/types.test.ts
@@ -17,70 +17,98 @@ import {
 
 describe("computeSessionId", () => {
   it("returns OpenCode-format session ID", () => {
-    const teamId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
-    const result = computeSessionId(teamId, "ENG-21", "implement");
+    const legionId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
+    const result = computeSessionId(legionId, "ENG-21", "implement");
 
     expect(result).toMatch(/^ses_[0-9a-f]{12}[0-9A-Za-z]{14}$/);
   });
 
   it("same inputs produce same output", () => {
-    const teamId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
-    const result1 = computeSessionId(teamId, "ENG-21", "implement");
-    const result2 = computeSessionId(teamId, "ENG-21", "implement");
+    const legionId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
+    const result1 = computeSessionId(legionId, "ENG-21", "implement");
+    const result2 = computeSessionId(legionId, "ENG-21", "implement");
     expect(result1).toBe(result2);
   });
 
   it("different issue produces different output", () => {
-    const teamId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
-    const result1 = computeSessionId(teamId, "ENG-21", "implement");
-    const result2 = computeSessionId(teamId, "ENG-22", "implement");
+    const legionId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
+    const result1 = computeSessionId(legionId, "ENG-21", "implement");
+    const result2 = computeSessionId(legionId, "ENG-22", "implement");
     expect(result1).not.toBe(result2);
   });
 
   it("different mode produces different output", () => {
-    const teamId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
-    const result1 = computeSessionId(teamId, "ENG-21", "implement");
-    const result2 = computeSessionId(teamId, "ENG-21", "review");
+    const legionId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
+    const result1 = computeSessionId(legionId, "ENG-21", "implement");
+    const result2 = computeSessionId(legionId, "ENG-21", "review");
     expect(result1).not.toBe(result2);
   });
 
-  it("accepts non-UUID team ID without throwing", () => {
+  it("accepts non-UUID legion ID without throwing", () => {
     expect(() => {
       computeSessionId("not-a-valid-uuid", "ENG-21", "implement");
     }).not.toThrow();
+  });
+
+  it("version 0 produces same output as no version", () => {
+    const legionId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
+    const result1 = computeSessionId(legionId, "ENG-21", "implement");
+    const result2 = computeSessionId(legionId, "ENG-21", "implement", 0);
+    expect(result1).toBe(result2);
+  });
+
+  it("version > 0 produces different output", () => {
+    const legionId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
+    const result1 = computeSessionId(legionId, "ENG-21", "implement");
+    const result2 = computeSessionId(legionId, "ENG-21", "implement", 1);
+    expect(result1).not.toBe(result2);
+  });
+
+  it("different versions produce different outputs", () => {
+    const legionId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
+    const result1 = computeSessionId(legionId, "ENG-21", "implement", 1);
+    const result2 = computeSessionId(legionId, "ENG-21", "implement", 2);
+    expect(result1).not.toBe(result2);
+  });
+
+  it("version is deterministic", () => {
+    const legionId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
+    const result1 = computeSessionId(legionId, "ENG-21", "implement", 1);
+    const result2 = computeSessionId(legionId, "ENG-21", "implement", 1);
+    expect(result1).toBe(result2);
   });
 });
 
 describe("computeControllerSessionId", () => {
   it("returns OpenCode-format session ID", () => {
-    const teamId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
-    const result = computeControllerSessionId(teamId);
+    const legionId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
+    const result = computeControllerSessionId(legionId);
 
     expect(result).toMatch(/^ses_[0-9a-f]{12}[0-9A-Za-z]{14}$/);
   });
 
   it("same input produces same output", () => {
-    const teamId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
-    const result1 = computeControllerSessionId(teamId);
-    const result2 = computeControllerSessionId(teamId);
+    const legionId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
+    const result1 = computeControllerSessionId(legionId);
+    const result2 = computeControllerSessionId(legionId);
     expect(result1).toBe(result2);
   });
 
   it("different from worker session id", () => {
-    const teamId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
-    const controllerId = computeControllerSessionId(teamId);
-    const workerId = computeSessionId(teamId, "ENG-21", "implement");
+    const legionId = "7b4f0862-b775-4cb0-9a67-85400c6f44a8";
+    const controllerId = computeControllerSessionId(legionId);
+    const workerId = computeSessionId(legionId, "ENG-21", "implement");
     expect(controllerId).not.toBe(workerId);
   });
 
-  it("accepts non-UUID team ID without throwing", () => {
+  it("accepts non-UUID legion ID without throwing", () => {
     expect(() => {
       computeControllerSessionId("not-a-valid-uuid");
     }).not.toThrow();
   });
 });
 
-describe("computeSessionId with non-UUID team ID", () => {
+describe("computeSessionId with non-UUID legion ID", () => {
   it("accepts a GitHub project ID string", () => {
     const result = computeSessionId("sjawhar/5", "gh-42", "implement");
     expect(result).toMatch(/^ses_[0-9a-f]{12}[0-9A-Za-z]{14}$/);
@@ -97,13 +125,13 @@ describe("computeSessionId with non-UUID team ID", () => {
     expect(result1).toBe(result2);
   });
 
-  it("different non-UUID team IDs produce different output", () => {
+  it("different non-UUID legion IDs produce different output", () => {
     const result1 = computeSessionId("sjawhar/5", "gh-42", "implement");
     const result2 = computeSessionId("sjawhar/6", "gh-42", "implement");
     expect(result1).not.toBe(result2);
   });
 
-  it("non-UUID team ID produces different output from UUID team ID", () => {
+  it("non-UUID legion ID produces different output from UUID legion ID", () => {
     const uuidResult = computeSessionId(
       "7b4f0862-b775-4cb0-9a67-85400c6f44a8",
       "ENG-21",
@@ -114,7 +142,7 @@ describe("computeSessionId with non-UUID team ID", () => {
   });
 });
 
-describe("computeControllerSessionId with non-UUID team ID", () => {
+describe("computeControllerSessionId with non-UUID legion ID", () => {
   it("accepts a GitHub project ID string", () => {
     const result = computeControllerSessionId("sjawhar/5");
     expect(result).toMatch(/^ses_[0-9a-f]{12}[0-9A-Za-z]{14}$/);
@@ -153,8 +181,12 @@ describe("IssueStatus.normalize", () => {
 
   it("returns unknown status unchanged", () => {
     expect(IssueStatus.normalize("Unknown")).toBe("Unknown");
-    expect(IssueStatus.normalize("Today")).toBe("Today");
     expect(IssueStatus.normalize("Scrapped")).toBe("Scrapped");
+  });
+
+  it("normalizes Today to Todo", () => {
+    expect(IssueStatus.normalize("Today")).toBe("Todo");
+    expect(IssueStatus.normalize("today")).toBe("Todo");
   });
 
   it("returns empty string for null", () => {

--- a/packages/daemon/src/state/cli.ts
+++ b/packages/daemon/src/state/cli.ts
@@ -18,7 +18,7 @@ import { CollectedState, type LinearIssueRaw } from "./types";
 // =============================================================================
 
 export interface CliArgs {
-  teamId: string;
+  legionId: string;
   daemonUrl: string;
 }
 
@@ -30,12 +30,12 @@ export interface CliArgs {
  * @throws Error if required arguments are missing
  */
 export function parseArgs(args: string[]): CliArgs {
-  let teamId: string | null = null;
+  let legionId: string | null = null;
   let daemonUrl: string | null = null;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--team-id" && i + 1 < args.length) {
-      teamId = args[i + 1];
+      legionId = args[i + 1];
       i++;
     } else if (args[i] === "--daemon-url" && i + 1 < args.length) {
       daemonUrl = args[i + 1];
@@ -43,14 +43,14 @@ export function parseArgs(args: string[]): CliArgs {
     }
   }
 
-  if (!teamId) {
+  if (!legionId) {
     throw new Error("Missing required argument: --team-id <uuid>");
   }
   if (!daemonUrl) {
     throw new Error("Missing required argument: --daemon-url <url>");
   }
 
-  return { teamId, daemonUrl };
+  return { legionId, daemonUrl };
 }
 
 // =============================================================================
@@ -61,19 +61,19 @@ export function parseArgs(args: string[]): CliArgs {
  * Run the state collection pipeline.
  *
  * @param linearIssues - Raw issues (parsed from stdin JSON)
- * @param teamId - Team/project identifier
+ * @param legionId - Team/project identifier
  * @param daemonUrl - Daemon HTTP API URL
  * @param runner - Optional command runner for testing
  * @returns JSON string of CollectedState
  */
 export async function runPipeline(
   linearIssues: LinearIssueRaw[],
-  teamId: string,
+  legionId: string,
   daemonUrl: string,
   runner?: CommandRunner
 ): Promise<string> {
   const issuesData = await fetchAllIssueData(linearIssues, daemonUrl, runner);
-  const state = buildCollectedState(issuesData, teamId);
+  const state = buildCollectedState(issuesData, legionId);
   return JSON.stringify(CollectedState.toDict(state));
 }
 
@@ -94,7 +94,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const output = await runPipeline(linearIssues, args.teamId, args.daemonUrl);
+  const output = await runPipeline(linearIssues, args.legionId, args.daemonUrl);
   process.stdout.write(`${output}\n`);
 }
 

--- a/packages/daemon/src/state/decision.ts
+++ b/packages/daemon/src/state/decision.ts
@@ -155,7 +155,7 @@ const VALID_WORKER_MODES = new Set<string>([
   WorkerMode.MERGE,
 ]);
 
-export function buildIssueState(data: FetchedIssueData, teamId: string): IssueState {
+export function buildIssueState(data: FetchedIssueData, legionId: string): IssueState {
   let action: ActionType;
 
   if (data.hasUserInputNeeded && data.hasUserFeedback) {
@@ -202,7 +202,7 @@ export function buildIssueState(data: FetchedIssueData, teamId: string): IssueSt
   } else {
     mode = ACTION_TO_MODE[action] ?? WorkerMode.IMPLEMENT;
   }
-  const sessionId = computeSessionId(teamId, data.issueId, mode);
+  const sessionId = computeSessionId(legionId, data.issueId, mode);
 
   return {
     status: data.status,
@@ -222,12 +222,12 @@ export function buildIssueState(data: FetchedIssueData, teamId: string): IssueSt
 
 export function buildCollectedState(
   issuesData: FetchedIssueData[],
-  teamId: string
+  legionId: string
 ): CollectedState {
   const result: CollectedState = { issues: {} };
 
   for (const data of issuesData) {
-    result.issues[data.issueId] = buildIssueState(data, teamId);
+    result.issues[data.issueId] = buildIssueState(data, legionId);
   }
 
   return result;

--- a/packages/daemon/src/state/github-fetch.ts
+++ b/packages/daemon/src/state/github-fetch.ts
@@ -1,0 +1,240 @@
+/**
+ * Fetch all GitHub project items using GraphQL cursor-based pagination.
+ *
+ * Replaces `gh project item-list --format json` which silently drops items
+ * when projects have many entries (see: sjawhar/legion#82).
+ *
+ * Returns items in the same shape as `gh project item-list --format json`
+ * so the existing GitHub backend parser can consume them directly.
+ */
+
+import type { CommandResult, CommandRunner } from "./fetch";
+import { defaultRunner } from "./fetch";
+
+interface GitHubProjectItemNode {
+  id: string;
+  fieldValueByName: {
+    name?: string;
+  } | null;
+  labels: {
+    nodes: Array<{ name: string }>;
+  };
+  content:
+    | {
+        __typename: "Issue" | "PullRequest" | "DraftIssue";
+        number?: number;
+        title?: string;
+        url?: string;
+        repository?: {
+          nameWithOwner: string;
+        };
+        linkedPullRequests?: {
+          nodes: Array<{ url: string }>;
+        } | null;
+      }
+    | Record<string, never>;
+}
+
+interface GitHubProjectItemsPage {
+  data?: {
+    organization?: {
+      projectV2?: {
+        items: {
+          pageInfo: {
+            hasNextPage: boolean;
+            endCursor: string | null;
+          };
+          nodes: GitHubProjectItemNode[];
+        };
+      };
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+const ITEMS_PER_PAGE = 100;
+
+const QUERY = `
+query($owner: String!, $number: Int!, $first: Int!, $after: String) {
+  organization(login: $owner) {
+    projectV2(number: $number) {
+      items(first: $first, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue {
+              name
+            }
+          }
+          labels: fieldValueByName(name: "Labels") {
+            ... on ProjectV2ItemFieldLabelValue {
+              labels(first: 20) {
+                nodes { name }
+              }
+            }
+          }
+          content {
+            __typename
+            ... on Issue {
+              number
+              title
+              url
+              repository { nameWithOwner }
+              linkedPullRequests: closedByPullRequestsReferences(first: 10, includeClosedPrs: true) {
+                nodes { url }
+              }
+            }
+            ... on PullRequest {
+              number
+              title
+              url
+              repository { nameWithOwner }
+            }
+            ... on DraftIssue {
+              title
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+/**
+ * Convert a GraphQL node into the shape expected by `gh project item-list --format json`.
+ */
+function nodeToProjectItem(node: GitHubProjectItemNode): Record<string, unknown> | null {
+  const content = node.content;
+  if (!content || !("__typename" in content)) {
+    return null;
+  }
+
+  const typename = content.__typename;
+
+  // Build content field matching gh CLI format
+  const itemContent: Record<string, unknown> = {};
+  if (typename === "Issue" || typename === "PullRequest") {
+    itemContent.type = typename;
+    itemContent.number = content.number;
+    itemContent.title = content.title;
+    itemContent.url = content.url;
+    itemContent.repository = content.repository?.nameWithOwner;
+  } else if (typename === "DraftIssue") {
+    itemContent.type = "DraftIssue";
+    itemContent.title = content.title;
+  } else {
+    return null;
+  }
+
+  // Extract labels
+  const labelsField = node.labels as unknown;
+  let labels: string[] = [];
+  if (
+    labelsField &&
+    typeof labelsField === "object" &&
+    "labels" in (labelsField as Record<string, unknown>)
+  ) {
+    const labelsObj = (labelsField as { labels?: { nodes?: Array<{ name: string }> } }).labels;
+    labels = labelsObj?.nodes?.map((l) => l.name) ?? [];
+  }
+
+  // Extract linked PRs
+  const linkedPRs: string[] = [];
+  if (typename === "Issue" && content.linkedPullRequests?.nodes) {
+    for (const pr of content.linkedPullRequests.nodes) {
+      if (pr.url) linkedPRs.push(pr.url);
+    }
+  }
+
+  return {
+    id: node.id,
+    content: itemContent,
+    status: node.fieldValueByName?.name ?? null,
+    labels,
+    ...(linkedPRs.length > 0 ? { "linked pull requests": linkedPRs } : {}),
+  };
+}
+
+/**
+ * Fetch all items from a GitHub Project V2 using cursor-based GraphQL pagination.
+ *
+ * @param owner - GitHub organization or user
+ * @param projectNumber - Project number (from the URL)
+ * @param runner - Command runner (for testing)
+ * @returns Items in the same shape as `gh project item-list --format json`
+ */
+export async function fetchGitHubProjectItems(
+  owner: string,
+  projectNumber: number,
+  runner: CommandRunner = defaultRunner
+): Promise<{ items: Record<string, unknown>[] }> {
+  const allItems: Record<string, unknown>[] = [];
+  let cursor: string | null = null;
+  let hasNextPage = true;
+
+  while (hasNextPage) {
+    const variables: Record<string, unknown> = {
+      owner,
+      number: projectNumber,
+      first: ITEMS_PER_PAGE,
+    };
+    if (cursor) {
+      variables.after = cursor;
+    }
+
+    const cmd: string[] = [
+      "gh",
+      "api",
+      "graphql",
+      "-f",
+      `query=${QUERY}`,
+      "-f",
+      `owner=${owner}`,
+      "-F",
+      `number=${projectNumber}`,
+      "-F",
+      `first=${ITEMS_PER_PAGE}`,
+    ];
+    if (cursor) {
+      cmd.push("-f", `after=${cursor}`);
+    }
+
+    const result: CommandResult = await runner(cmd);
+
+    if (result.exitCode !== 0) {
+      throw new Error(`GitHub GraphQL query failed (exit ${result.exitCode}): ${result.stderr}`);
+    }
+
+    let response: GitHubProjectItemsPage;
+    try {
+      response = JSON.parse(result.stdout) as GitHubProjectItemsPage;
+    } catch {
+      throw new Error(`Failed to parse GraphQL response: ${result.stdout.slice(0, 200)}`);
+    }
+
+    if (response.errors?.length) {
+      throw new Error(`GraphQL errors: ${response.errors.map((e) => e.message).join(", ")}`);
+    }
+
+    const items = response.data?.organization?.projectV2?.items;
+    if (!items) {
+      throw new Error("Unexpected GraphQL response structure — missing projectV2.items");
+    }
+
+    for (const node of items.nodes) {
+      const item = nodeToProjectItem(node);
+      if (item) {
+        allItems.push(item);
+      }
+    }
+
+    hasNextPage = items.pageInfo.hasNextPage;
+    cursor = items.pageInfo.endCursor;
+  }
+
+  return { items: allItems };
+}

--- a/packages/daemon/src/state/types.ts
+++ b/packages/daemon/src/state/types.ts
@@ -100,6 +100,7 @@ export const IssueStatus = {
    */
   ALIASES: {
     "In Review": "Needs Review" as IssueStatusLiteral,
+    Today: "Todo" as IssueStatusLiteral,
   } as Record<string, IssueStatusLiteral>,
 
   /**
@@ -446,17 +447,17 @@ export const CollectedState = {
 const BASE62_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
 /**
- * Fixed namespace UUID for deriving team ID namespaces.
- * Used to convert arbitrary team ID strings into deterministic UUID namespaces.
+ * Fixed namespace UUID for deriving legion ID namespaces.
+ * Used to convert arbitrary legion ID strings into deterministic UUID namespaces.
  */
 const LEGION_NAMESPACE = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
 const LEGION_NAMESPACE_UUID = uuidv5(LEGION_NAMESPACE, "6ba7b810-9dad-11d1-80b4-00c04fd430c8");
 
 /**
- * Convert any team ID string into a UUID namespace.
+ * Convert any legion ID string into a UUID namespace.
  */
-function teamIdToNamespace(teamId: string): string {
-  return uuidv5(teamId, LEGION_NAMESPACE_UUID);
+function legionIdToNamespace(legionId: string): string {
+  return uuidv5(legionId, LEGION_NAMESPACE_UUID);
 }
 
 /**
@@ -490,14 +491,22 @@ function uuidToSessionId(uuid: string): string {
  * Session IDs match OpenCode's format: ses_ + 12 hex + 14 Base62.
  * Pattern: ^ses_[0-9a-f]{12}[0-9A-Za-z]{14}$
  *
- * @param teamId - Team identifier (UUID or arbitrary string)
+ * @param legionId - Legion identifier (UUID or arbitrary string)
  * @param issueId - Issue identifier (e.g., "ENG-21")
  * @param mode - Worker mode (e.g., "implement", "review")
  * @returns Session ID string matching OpenCode format
  */
-export function computeSessionId(teamId: string, issueId: string, mode: WorkerModeLiteral): string {
-  const namespace = teamIdToNamespace(teamId);
-  const uuid = uuidv5(`${issueId.toLowerCase()}:${mode}`, namespace);
+export function computeSessionId(
+  legionId: string,
+  issueId: string,
+  mode: WorkerModeLiteral,
+  version: number = 0
+): string {
+  const namespace = legionIdToNamespace(legionId);
+  const uuid = uuidv5(
+    `${issueId.toLowerCase()}:${mode}${version > 0 ? `:v${version}` : ""}`,
+    namespace
+  );
   return uuidToSessionId(uuid);
 }
 
@@ -506,11 +515,11 @@ export function computeSessionId(teamId: string, issueId: string, mode: WorkerMo
  *
  * Session IDs match OpenCode's format: ses_ + 12 hex + 14 Base62.
  *
- * @param teamId - Team identifier (UUID or arbitrary string)
+ * @param legionId - Legion identifier (UUID or arbitrary string)
  * @returns Session ID string matching OpenCode format
  */
-export function computeControllerSessionId(teamId: string): string {
-  const namespace = teamIdToNamespace(teamId);
+export function computeControllerSessionId(legionId: string): string {
+  const namespace = legionIdToNamespace(legionId);
   const uuid = uuidv5("controller", namespace);
   return uuidToSessionId(uuid);
 }


### PR DESCRIPTION
## Summary

Implements XDG-compliant workspace management for the Legion daemon, plus all fixes from the three-model council audit of issue #93.

### Core features
- **XDG path resolution** — `resolveLegionPaths()` derives all Legion directories from `XDG_STATE_HOME` / `XDG_DATA_HOME`
- **Legions registry** — file-based registry tracking live daemon instances with port allocation
- **Repo manager** — clones repos via `jj` and creates isolated worker workspaces
- **`POST /workers` with `--repo`** — server resolves workspace from repo param; CLI passes `--repo` to daemon
- **Port discovery** — CLI reads daemon port from legions registry (XDG path)
- **Controller skill** — updated for multi-repo workspace management

### Audit fixes (17 council findings, all addressed)

**High severity:**
- Fix CLI legacy `~/.legion/` paths — deleted `resolveStateDir`, all commands use `resolveLegionPaths()` XDG paths
- Wire `allocatePort()` into daemon startup with bind-time `EADDRINUSE` retry; record actual bound port in registry
- Add file locking (`withRegistryLock`) around registry read-modify-write to prevent TOCTOU races
- Propagate `jj git fetch` failures (throw instead of `console.warn`), surfacing as HTTP 500

**Medium severity:**
- Path traversal validation on `homeDir`, `repoClonePath`, `resolveWorkspacePath` (validate resolved paths, not raw chars)
- Serialize `persistState` writes via promise chain
- Reject `POST /workers` with 400 when both `repo` and `workspace` provided
- Registry schema failure now logs warning + creates timestamped `.bak` file
- Test coverage for `POST /state/fetch-and-collect` endpoint (7 test cases)
- Full mechanical rename: `teamId`→`legionId`, `LEGION_TEAM_ID`→`LEGION_ID`, `team-resolver.ts`→`legion-resolver.ts`, `teams.json`→`project-cache.json`

**Low severity:**
- Add `--repo` flag to CI failure re-dispatch example in controller skill
- Improve stale PID detection via `/proc/<pid>/cmdline` on Linux
- JSDoc documenting `github.com` host assumption in `parseIssueRepo`

### Test results
- **793 tests pass** (37 new), 0 failures
- `bunx tsc --noEmit` → exit 0
- `bunx biome check` → 0 errors

Closes #93