### PR TITLE
feat: GitHub GraphQL org/user fallback for project fetching

### DIFF
--- a/docs/solutions/github-api/graphql-org-user-fallback.md
+++ b/docs/solutions/github-api/graphql-org-user-fallback.md
@@ -1,0 +1,179 @@
+---
+title: "GitHub GraphQL Organization/User Fallback Pattern"
+category: github-api
+tags: ["graphql", "access-control", "fallback", "testing"]
+date: "2026-03-11"
+status: "active"
+---
+
+# GitHub GraphQL Organization/User Fallback Pattern
+
+## Context
+
+GitHub's GraphQL API bifurcates project data based on owner type: `organization { projectV2 }` for org-owned projects and `user { projectV2 }` for user-owned projects. When an authenticated user is not a member of an organization, queries using `organization(login: $owner)` fail with access errors, requiring fallback to `user(login: $owner)`.
+
+## Core Pattern: Sticky Fallback with Error Classification
+
+```typescript
+let useUserQuery = false;
+
+while (hasNextPage) {
+  if (!useUserQuery) {
+    try {
+      // Try organization query first
+      response = await executeGraphQLQuery(ORG_QUERY, ...);
+      
+      // Check for access-related GraphQL errors
+      if (response.errors?.some(error => 
+        error.message.includes("Could not resolve to an Organization") ||
+        error.message.includes("not a member")
+      )) {
+        useUserQuery = true;
+        response = await executeGraphQLQuery(USER_QUERY, ...);
+      }
+    } catch (error) {
+      // Handle CLI exceptions for access errors
+      if (isAccessError(error)) {
+        useUserQuery = true;
+        response = await executeGraphQLQuery(USER_QUERY, ...);
+      } else {
+        throw error; // Re-throw non-access errors
+      }
+    }
+  } else {
+    // Once fallback triggered, use user query for all subsequent pages
+    response = await executeGraphQLQuery(USER_QUERY, ...);
+  }
+}
+```
+
+## Key Technical Decisions
+
+### 1. Sticky State Optimization
+- **Decision**: Once `useUserQuery` is set to true, skip organization queries for all subsequent pagination calls
+- **Rationale**: If page 1 requires user query, page 2 will too. Avoids doubling API calls for user-owned projects
+- **Impact**: Critical for pagination performance through large user projects
+
+### 2. Dual-Channel Error Handling
+- **Decision**: Handle both GraphQL `errors` array and CLI exceptions separately
+- **Rationale**: GitHub CLI (`gh`) surfaces the same logical access error through different channels depending on response format
+- **Pattern**: Always implement error classification in both contexts
+
+### 3. Error Classification Strategy
+```typescript
+const isAccessError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("Forbidden") ||
+         message.includes("not a member") ||
+         message.includes("Could not resolve to an Organization");
+};
+```
+
+## Reusable Patterns
+
+### 1. GitHub Schema Bifurcation Handler
+This pattern applies to any GitHub GraphQL scenario where data lives under different roots based on owner type:
+- Repository queries (`organization { repositories }` vs `user { repositories }`)
+- Team queries
+- Sponsorship queries
+
+### 2. CommandRunner Injection for Testing
+```typescript
+export async function fetchData(
+  runner: CommandRunner = defaultRunner
+): Promise<Data> {
+  // Implementation uses runner for all CLI calls
+}
+```
+Enables comprehensive testing without mocking `child_process`.
+
+### 3. Query String Templates
+Extract shared GraphQL structure into templates to avoid duplication:
+```typescript
+const buildProjectQuery = (rootType: "organization" | "user") => `
+  query($owner: String!, $number: Int!, $first: Int!, $after: String) {
+    ${rootType}(login: $owner) {
+      projectV2(number: $number) {
+        // ... shared fields
+      }
+    }
+  }
+`;
+```
+
+## Testing Strategies
+
+### 1. Call Sequence Verification
+```typescript
+const mockRunner: CommandRunner = async (cmd: string[]) => {
+  callCount++;
+  const queryArg = cmd.find(arg => arg.startsWith("query="));
+  
+  if (callCount === 1) {
+    expect(queryArg).toContain("organization(login:");
+    // Return access error
+  } else {
+    expect(queryArg).toContain("user(login:");
+    // Return success
+  }
+};
+```
+
+### 2. Pagination-Through-Fallback Testing
+Verify that after fallback on page 1, page 2 goes directly to user query (no re-probing):
+```typescript
+// callCount should be 3 (org fail, user success, user page 2)
+// NOT 4 (org fail, user success, org fail again, user page 2)
+```
+
+### 3. Error Path Coverage
+Test both GraphQL errors and CLI exceptions for each error type:
+- GraphQL errors array: `{ errors: [{ message: "Could not resolve..." }] }`
+- CLI exceptions: `throw new Error("Forbidden")`
+
+## Edge Cases and Gotchas
+
+### 1. Query Duplication Maintenance Risk
+**Issue**: Having separate `ORG_QUERY` and `USER_QUERY` constants creates risk of divergence
+**Mitigation**: Use template functions to generate queries from shared structure
+**Current Risk**: Medium - adding fields to one query but not the other causes silent data loss
+
+### 2. Error String Brittleness
+**Issue**: Access detection relies on exact substring matching of error messages
+**Risk Areas**:
+- `"Forbidden"` is overly broad - could match rate limit errors
+- GitHub could change error messages without notice
+**Mitigation**: Consider more specific error patterns or GraphQL error codes when available
+
+### 3. Mid-Pagination Failure Scenario
+**Issue**: What happens if org query succeeds for page 1 but fails on page 2?
+**Current Behavior**: Attempts user query with org-generated cursor - will fail
+**Recommendation**: Add test coverage for this scenario
+
+### 4. Labels Field Type Complexity
+**Issue**: GraphQL response structure for labels field requires runtime type gymnastics
+**Pattern**: `node.labels as unknown as ExpectedType` reveals schema/type mismatches
+**Solution**: Ensure TypeScript interfaces match actual GraphQL response shapes
+
+## Architecture Insights
+
+### 1. GitHub's Split-Brain Design
+Projects V2 data architecture forces bifurcation handling on all consumers. No polymorphic `owner` root exists - each owner type has its own schema branch.
+
+### 2. CLI vs Direct GraphQL Tradeoffs
+Using `gh` CLI simplifies auth but creates string-based error surfaces instead of typed HTTP responses. This dual-channel error handling pattern will recur in any `gh`-based integration.
+
+### 3. Access Model Asymmetry
+- Org members can query both org and user projects
+- Non-members can only query user projects
+- Always try org first (more common case), then fall back to user
+
+## Future Applications
+
+This pattern is immediately applicable to:
+- Repository listing and management
+- Team membership queries
+- Organization insights and metrics
+- Any GitHub API integration where owner type determines access scope
+
+The error classification and sticky fallback patterns are broadly applicable beyond GitHub to any API with hierarchical access models.

--- a/docs/solutions/index.json
+++ b/docs/solutions/index.json
@@ -7,7 +7,8 @@
       "architecture-patterns/shared-state-file-ownership.md",
       "integration-issues/github-graphql-pr-draft-status.md",
       "integration-issues/external-repo-pr-auto-transition-gap.md",
-      "integration-issues/linear-mcp-label-resolution.md"
+      "integration-issues/linear-mcp-label-resolution.md",
+      "github-api/graphql-org-user-fallback.md"
     ],
     "packages/daemon/src/daemon/serve-manager": [
       "daemon/opencode-serve-lifecycle.md",
@@ -29,9 +30,7 @@
       "architecture-patterns/task-index-retro.md",
       "task-index-patterns.md"
     ],
-    "packages/daemon/src/cli": [
-      "daemon/controller-lifecycle-separation.md"
-    ],
+    "packages/daemon/src/cli": ["daemon/controller-lifecycle-separation.md"],
     "packages/daemon": [
       "architecture-patterns/plugin-migration-assessment.md",
       "architecture-patterns/sync-to-async-modular-refactoring.md",
@@ -47,122 +46,60 @@
       "daemon/controller-lifecycle-separation.md",
       "daemon/controller-observability.md"
     ],
-    ".opencode/skills/linear": [
-      "integration-issues/linear-mcp-label-resolution.md"
-    ],
+    ".opencode/skills/linear": ["integration-issues/linear-mcp-label-resolution.md"],
     ".opencode/skills": [
       "skill-patterns/parallel-subagent-background-execution.md",
       "delegation/delegation-hardening-retro.md",
       "delegation/hardening-patterns.md"
     ],
-    "tests": [
-      "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"
-    ],
-    "tag:SIGTERM": [
-      "daemon/opencode-serve-lifecycle.md"
-    ],
-    "tag:active-index": [
-      "task-index-patterns.md"
-    ],
-    "tag:agent-restrictions": [
-      "delegation/hardening-patterns.md"
-    ],
-    "tag:aiofiles": [
-      "architecture-patterns/sync-to-async-modular-refactoring.md"
-    ],
-    "tag:alru-cache": [
-      "architecture-patterns/sync-to-async-modular-refactoring.md"
-    ],
-    "tag:anyio": [
-      "architecture-patterns/sync-to-async-modular-refactoring.md"
-    ],
+    "tests": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
+    "tag:SIGTERM": ["daemon/opencode-serve-lifecycle.md"],
+    "tag:active-index": ["task-index-patterns.md"],
+    "tag:agent-restrictions": ["delegation/hardening-patterns.md"],
+    "tag:aiofiles": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
+    "tag:alru-cache": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
+    "tag:anyio": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
     "tag:architecture": [
       "daemon/controller-lifecycle-separation.md",
       "daemon/shared-serve-refactor.md"
     ],
-    "tag:askuserquestion": [
-      "integration-patterns/tmux-askuserquestion-navigation.md"
-    ],
-    "tag:async": [
-      "architecture-patterns/sync-to-async-modular-refactoring.md"
-    ],
-    "tag:asyncmock": [
-      "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"
-    ],
-    "tag:atomic-writes": [
-      "delegation/hardening-patterns.md"
-    ],
-    "tag:auto-transition": [
-      "integration-issues/external-repo-pr-auto-transition-gap.md"
-    ],
-    "tag:automation": [
-      "integration-patterns/tmux-askuserquestion-navigation.md"
-    ],
-    "tag:autospec": [
-      "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"
-    ],
-    "tag:background-tasks": [
-      "skill-patterns/parallel-subagent-background-execution.md"
-    ],
-    "tag:batch-queries": [
-      "architecture-patterns/sync-to-async-modular-refactoring.md"
-    ],
-    "tag:batching": [
-      "integration-issues/github-graphql-pr-draft-status.md"
-    ],
-    "tag:bootstrap-bug": [
-      "architecture-patterns/task-index-retro.md"
-    ],
+    "tag:askuserquestion": ["integration-patterns/tmux-askuserquestion-navigation.md"],
+    "tag:async": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
+    "tag:asyncmock": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
+    "tag:atomic-writes": ["delegation/hardening-patterns.md"],
+    "tag:auto-transition": ["integration-issues/external-repo-pr-auto-transition-gap.md"],
+    "tag:automation": ["integration-patterns/tmux-askuserquestion-navigation.md"],
+    "tag:autospec": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
+    "tag:background-tasks": ["skill-patterns/parallel-subagent-background-execution.md"],
+    "tag:batch-queries": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
+    "tag:batching": ["integration-issues/github-graphql-pr-draft-status.md"],
+    "tag:bootstrap-bug": ["architecture-patterns/task-index-retro.md"],
     "tag:caching": [
       "architecture-patterns/sync-to-async-modular-refactoring.md",
       "architecture-patterns/task-index-retro.md",
       "integration-issues/linear-mcp-label-resolution.md",
       "task-index-patterns.md"
     ],
-    "tag:callback-pattern": [
-      "architecture-patterns/shared-state-file-ownership.md"
-    ],
-    "tag:claude-code": [
-      "integration-patterns/tmux-askuserquestion-navigation.md"
-    ],
+    "tag:callback-pattern": ["architecture-patterns/shared-state-file-ownership.md"],
+    "tag:claude-code": ["integration-patterns/tmux-askuserquestion-navigation.md"],
     "tag:cleanup": [
       "daemon/deferred-review-comments-pattern.md",
       "daemon/graceful-worker-shutdown.md"
     ],
-    "tag:cli-interaction": [
-      "integration-patterns/tmux-askuserquestion-navigation.md"
-    ],
-    "tag:code-review": [
-      "daemon/deferred-review-comments-pattern.md"
-    ],
-    "tag:concurrency": [
-      "delegation/delegation-hardening-retro.md"
-    ],
-    "tag:config-schema": [
-      "delegation/hardening-patterns.md"
-    ],
+    "tag:cli-interaction": ["integration-patterns/tmux-askuserquestion-navigation.md"],
+    "tag:code-review": ["daemon/deferred-review-comments-pattern.md"],
+    "tag:concurrency": ["delegation/delegation-hardening-retro.md"],
+    "tag:config-schema": ["delegation/hardening-patterns.md"],
     "tag:controller": [
       "daemon/controller-observability.md",
       "integration-patterns/controller-worker-protocol.md"
     ],
-    "tag:controller-dispatch": [
-      "integration-issues/external-repo-pr-auto-transition-gap.md"
-    ],
-    "tag:crash-recovery": [
-      "daemon/shared-serve-retro.md"
-    ],
-    "tag:daemon": [
-      "architecture-patterns/shared-state-file-ownership.md"
-    ],
-    "tag:debugging": [
-      "daemon/controller-observability.md"
-    ],
-    "tag:defense-in-depth": [
-      "daemon/graceful-worker-shutdown.md"
-    ],
-    "tag:deferred-review-comments": [
-      "daemon/workspace-validation-retro.md"
-    ],
+    "tag:controller-dispatch": ["integration-issues/external-repo-pr-auto-transition-gap.md"],
+    "tag:crash-recovery": ["daemon/shared-serve-retro.md"],
+    "tag:daemon": ["architecture-patterns/shared-state-file-ownership.md"],
+    "tag:debugging": ["daemon/controller-observability.md"],
+    "tag:defense-in-depth": ["daemon/graceful-worker-shutdown.md"],
+    "tag:deferred-review-comments": ["daemon/workspace-validation-retro.md"],
     "tag:delegation": [
       "delegation/delegation-hardening-retro.md",
       "delegation/hardening-patterns.md"
@@ -172,136 +109,64 @@
       "daemon/shared-serve-refactor.md",
       "daemon/shared-serve-retro.md"
     ],
-    "tag:directory-resolution": [
-      "daemon/worker-directory-fix.md"
-    ],
-    "tag:dispatch": [
-      "integration-patterns/controller-worker-protocol.md"
-    ],
-    "tag:dispose": [
-      "daemon/opencode-serve-lifecycle.md"
-    ],
-    "tag:draft-status": [
-      "integration-issues/github-graphql-pr-draft-status.md"
-    ],
-    "tag:error-handling": [
-      "integration-issues/linear-mcp-label-resolution.md"
-    ],
-    "tag:external-repos": [
-      "integration-issues/external-repo-pr-auto-transition-gap.md"
-    ],
-    "tag:failure-modes": [
-      "skill-patterns/worker-skill-failure-modes.md"
-    ],
-    "tag:fallback-pattern": [
-      "task-index-patterns.md"
-    ],
-    "tag:file-based-index": [
-      "architecture-patterns/task-index-retro.md",
-      "task-index-patterns.md"
-    ],
-    "tag:file-based-storage": [
-      "delegation/hardening-patterns.md"
-    ],
-    "tag:finalize-pattern": [
-      "delegation/delegation-hardening-retro.md"
-    ],
+    "tag:directory-resolution": ["daemon/worker-directory-fix.md"],
+    "tag:dispatch": ["integration-patterns/controller-worker-protocol.md"],
+    "tag:dispose": ["daemon/opencode-serve-lifecycle.md"],
+    "tag:draft-status": ["integration-issues/github-graphql-pr-draft-status.md"],
+    "tag:error-handling": ["integration-issues/linear-mcp-label-resolution.md"],
+    "tag:external-repos": ["integration-issues/external-repo-pr-auto-transition-gap.md"],
+    "tag:failure-modes": ["skill-patterns/worker-skill-failure-modes.md"],
+    "tag:fallback-pattern": ["task-index-patterns.md", "github-api/graphql-org-user-fallback.md"],
+    "tag:file-based-index": ["architecture-patterns/task-index-retro.md", "task-index-patterns.md"],
+    "tag:file-based-storage": ["delegation/hardening-patterns.md"],
+    "tag:finalize-pattern": ["delegation/delegation-hardening-retro.md"],
     "tag:github": [
       "integration-issues/external-repo-pr-auto-transition-gap.md",
-      "integration-issues/github-graphql-pr-draft-status.md"
+      "integration-issues/github-graphql-pr-draft-status.md",
+      "github-api/graphql-org-user-fallback.md"
     ],
     "tag:graphql": [
       "architecture-patterns/sync-to-async-modular-refactoring.md",
       "integration-issues/github-graphql-pr-draft-status.md",
-      "integration-issues/linear-mcp-label-resolution.md"
+      "integration-issues/linear-mcp-label-resolution.md",
+      "github-api/graphql-org-user-fallback.md"
     ],
-    "tag:implement": [
-      "skill-patterns/worker-skill-failure-modes.md"
-    ],
+    "tag:implement": ["skill-patterns/worker-skill-failure-modes.md"],
     "tag:jj-workspaces": [
       "daemon/worker-directory-fix.md",
       "daemon/worker-directory-resolution.md"
     ],
-    "tag:keyboard-navigation": [
-      "integration-patterns/tmux-askuserquestion-navigation.md"
-    ],
-    "tag:labels": [
-      "integration-issues/linear-mcp-label-resolution.md"
-    ],
-    "tag:lifecycle": [
-      "daemon/controller-lifecycle-separation.md"
-    ],
-    "tag:lifecycle-separation": [
-      "architecture-patterns/shared-state-file-ownership.md"
-    ],
+    "tag:keyboard-navigation": ["integration-patterns/tmux-askuserquestion-navigation.md"],
+    "tag:labels": ["integration-issues/linear-mcp-label-resolution.md"],
+    "tag:lifecycle": ["daemon/controller-lifecycle-separation.md"],
+    "tag:lifecycle-separation": ["architecture-patterns/shared-state-file-ownership.md"],
     "tag:linear": [
       "integration-issues/external-repo-pr-auto-transition-gap.md",
       "integration-issues/linear-mcp-label-resolution.md"
     ],
-    "tag:mcp": [
-      "integration-issues/linear-mcp-label-resolution.md"
-    ],
-    "tag:merge": [
-      "skill-patterns/worker-skill-failure-modes.md"
-    ],
-    "tag:migration": [
-      "architecture-patterns/plugin-migration-assessment.md"
-    ],
-    "tag:mocking": [
-      "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"
-    ],
-    "tag:modular-architecture": [
-      "architecture-patterns/sync-to-async-modular-refactoring.md"
-    ],
-    "tag:n-plus-one": [
-      "architecture-patterns/sync-to-async-modular-refactoring.md"
-    ],
-    "tag:name-resolution": [
-      "integration-issues/linear-mcp-label-resolution.md"
-    ],
-    "tag:observability": [
-      "daemon/controller-observability.md"
-    ],
-    "tag:oh-my-opencode": [
-      "architecture-patterns/plugin-migration-assessment.md"
-    ],
+    "tag:mcp": ["integration-issues/linear-mcp-label-resolution.md"],
+    "tag:merge": ["skill-patterns/worker-skill-failure-modes.md"],
+    "tag:migration": ["architecture-patterns/plugin-migration-assessment.md"],
+    "tag:mocking": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
+    "tag:modular-architecture": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
+    "tag:n-plus-one": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
+    "tag:name-resolution": ["integration-issues/linear-mcp-label-resolution.md"],
+    "tag:observability": ["daemon/controller-observability.md"],
+    "tag:oh-my-opencode": ["architecture-patterns/plugin-migration-assessment.md"],
     "tag:opencode": [
       "daemon/opencode-serve-lifecycle.md",
       "skill-patterns/parallel-subagent-background-execution.md"
     ],
-    "tag:opencode-legion": [
-      "architecture-patterns/plugin-migration-assessment.md"
-    ],
-    "tag:opencode-sdk": [
-      "daemon/worker-directory-fix.md",
-      "daemon/worker-directory-resolution.md"
-    ],
-    "tag:opencode-serve": [
-      "daemon/shared-serve-refactor.md",
-      "daemon/shared-serve-retro.md"
-    ],
-    "tag:parallel-execution": [
-      "skill-patterns/parallel-subagent-background-execution.md"
-    ],
-    "tag:parallel-subagents": [
-      "architecture-patterns/task-index-retro.md"
-    ],
-    "tag:performance": [
-      "architecture-patterns/task-index-retro.md",
-      "task-index-patterns.md"
-    ],
-    "tag:persistence": [
-      "architecture-patterns/shared-state-file-ownership.md"
-    ],
-    "tag:plugin": [
-      "architecture-patterns/plugin-migration-assessment.md"
-    ],
-    "tag:pr-review": [
-      "integration-issues/github-graphql-pr-draft-status.md"
-    ],
-    "tag:pr-workflow": [
-      "daemon/workspace-validation-retro.md"
-    ],
+    "tag:opencode-legion": ["architecture-patterns/plugin-migration-assessment.md"],
+    "tag:opencode-sdk": ["daemon/worker-directory-fix.md", "daemon/worker-directory-resolution.md"],
+    "tag:opencode-serve": ["daemon/shared-serve-refactor.md", "daemon/shared-serve-retro.md"],
+    "tag:parallel-execution": ["skill-patterns/parallel-subagent-background-execution.md"],
+    "tag:parallel-subagents": ["architecture-patterns/task-index-retro.md"],
+    "tag:performance": ["architecture-patterns/task-index-retro.md", "task-index-patterns.md"],
+    "tag:persistence": ["architecture-patterns/shared-state-file-ownership.md"],
+    "tag:plugin": ["architecture-patterns/plugin-migration-assessment.md"],
+    "tag:pr-review": ["integration-issues/github-graphql-pr-draft-status.md"],
+    "tag:pr-workflow": ["daemon/workspace-validation-retro.md"],
     "tag:process-management": [
       "daemon/graceful-worker-shutdown.md",
       "daemon/opencode-serve-lifecycle.md",
@@ -315,116 +180,49 @@
       "integration-issues/external-repo-pr-auto-transition-gap.md",
       "integration-issues/github-graphql-pr-draft-status.md"
     ],
-    "tag:pytest-mock": [
-      "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"
-    ],
-    "tag:python": [
-      "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"
-    ],
-    "tag:race-condition": [
-      "architecture-patterns/shared-state-file-ownership.md"
-    ],
-    "tag:refactoring": [
-      "architecture-patterns/sync-to-async-modular-refactoring.md"
-    ],
-    "tag:remote-control": [
-      "integration-patterns/tmux-askuserquestion-navigation.md"
-    ],
-    "tag:resource-accounting": [
-      "delegation/delegation-hardening-retro.md"
-    ],
-    "tag:resume": [
-      "integration-patterns/controller-worker-protocol.md"
-    ],
-    "tag:retro": [
-      "skill-patterns/worker-skill-failure-modes.md"
-    ],
-    "tag:review": [
-      "skill-patterns/worker-skill-failure-modes.md"
-    ],
-    "tag:serve": [
-      "daemon/opencode-serve-lifecycle.md"
-    ],
-    "tag:session-management": [
-      "daemon/worker-directory-resolution.md"
-    ],
-    "tag:sessions": [
-      "daemon/shared-serve-refactor.md",
-      "daemon/shared-serve-retro.md"
-    ],
-    "tag:shared-serve": [
-      "daemon/shared-serve-refactor.md",
-      "daemon/shared-serve-retro.md"
-    ],
-    "tag:skill-authoring": [
-      "skill-patterns/parallel-subagent-background-execution.md"
-    ],
-    "tag:skills": [
-      "skill-patterns/worker-skill-failure-modes.md"
-    ],
-    "tag:stale-detection": [
-      "delegation/delegation-hardening-retro.md"
-    ],
-    "tag:state-file": [
-      "architecture-patterns/shared-state-file-ownership.md"
-    ],
+    "tag:pytest-mock": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
+    "tag:python": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
+    "tag:race-condition": ["architecture-patterns/shared-state-file-ownership.md"],
+    "tag:refactoring": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
+    "tag:remote-control": ["integration-patterns/tmux-askuserquestion-navigation.md"],
+    "tag:resource-accounting": ["delegation/delegation-hardening-retro.md"],
+    "tag:resume": ["integration-patterns/controller-worker-protocol.md"],
+    "tag:retro": ["skill-patterns/worker-skill-failure-modes.md"],
+    "tag:review": ["skill-patterns/worker-skill-failure-modes.md"],
+    "tag:serve": ["daemon/opencode-serve-lifecycle.md"],
+    "tag:session-management": ["daemon/worker-directory-resolution.md"],
+    "tag:sessions": ["daemon/shared-serve-refactor.md", "daemon/shared-serve-retro.md"],
+    "tag:shared-serve": ["daemon/shared-serve-refactor.md", "daemon/shared-serve-retro.md"],
+    "tag:skill-authoring": ["skill-patterns/parallel-subagent-background-execution.md"],
+    "tag:skills": ["skill-patterns/worker-skill-failure-modes.md"],
+    "tag:stale-detection": ["delegation/delegation-hardening-retro.md"],
+    "tag:state-file": ["architecture-patterns/shared-state-file-ownership.md"],
     "tag:state-machine": [
       "daemon/controller-observability.md",
       "integration-issues/github-graphql-pr-draft-status.md"
     ],
-    "tag:state-management": [
-      "daemon/controller-lifecycle-separation.md"
-    ],
-    "tag:subagents": [
-      "skill-patterns/parallel-subagent-background-execution.md"
-    ],
-    "tag:task-index": [
-      "architecture-patterns/task-index-retro.md"
-    ],
+    "tag:state-management": ["daemon/controller-lifecycle-separation.md"],
+    "tag:subagents": ["skill-patterns/parallel-subagent-background-execution.md"],
+    "tag:task-index": ["architecture-patterns/task-index-retro.md"],
     "tag:task-persistence": [
       "delegation/delegation-hardening-retro.md",
       "delegation/hardening-patterns.md",
       "task-index-patterns.md"
     ],
-    "tag:testability": [
-      "architecture-patterns/sync-to-async-modular-refactoring.md"
-    ],
+    "tag:testability": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
     "tag:testing": [
       "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md",
-      "daemon/controller-lifecycle-separation.md",
-      "daemon/graceful-worker-shutdown.md",
-      "daemon/shared-serve-retro.md",
-      "delegation/delegation-hardening-retro.md"
+      "github-api/graphql-org-user-fallback.md"
     ],
-    "tag:tmux": [
-      "integration-patterns/tmux-askuserquestion-navigation.md"
-    ],
-    "tag:validation": [
-      "daemon/workspace-validation-retro.md"
-    ],
-    "tag:worker": [
-      "integration-patterns/controller-worker-protocol.md"
-    ],
-    "tag:worker-isolation": [
-      "daemon/worker-directory-resolution.md"
-    ],
-    "tag:worker-lifecycle": [
-      "integration-issues/external-repo-pr-auto-transition-gap.md"
-    ],
-    "tag:worker-spawning": [
-      "daemon/worker-directory-fix.md"
-    ],
-    "tag:workers": [
-      "skill-patterns/worker-skill-failure-modes.md"
-    ],
-    "tag:workflow-design": [
-      "skill-patterns/parallel-subagent-background-execution.md"
-    ],
-    "tag:workflow-pattern": [
-      "daemon/deferred-review-comments-pattern.md"
-    ],
-    "tag:workspace-validation": [
-      "daemon/workspace-validation-retro.md"
-    ]
+    "tag:tmux": ["integration-patterns/tmux-askuserquestion-navigation.md"],
+    "tag:validation": ["daemon/workspace-validation-retro.md"],
+    "tag:worker": ["integration-patterns/controller-worker-protocol.md"],
+    "tag:worker-isolation": ["daemon/worker-directory-resolution.md"],
+    "tag:worker-lifecycle": ["integration-issues/external-repo-pr-auto-transition-gap.md"],
+    "tag:worker-spawning": ["daemon/worker-directory-fix.md"],
+    "tag:workers": ["skill-patterns/worker-skill-failure-modes.md"],
+    "tag:workflow-design": ["skill-patterns/parallel-subagent-background-execution.md"],
+    "tag:workflow-pattern": ["daemon/deferred-review-comments-pattern.md"],
+    "tag:workspace-validation": ["daemon/workspace-validation-retro.md"]
   }
 }

--- a/packages/daemon/src/state/__tests__/github-fetch.test.ts
+++ b/packages/daemon/src/state/__tests__/github-fetch.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Tests for GitHub GraphQL project fetching with organization/user fallback.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { CommandRunner } from "../fetch";
+import { fetchGitHubProjectItems } from "../github-fetch";
+
+describe("fetchGitHubProjectItems", () => {
+  it("successfully fetches from organization", async () => {
+    const mockRunner: CommandRunner = async (cmd: string[]) => {
+      expect(cmd).toContain("graphql");
+      const queryArg = cmd.find((arg) => arg.startsWith("query="));
+      expect(queryArg).toContain("organization(login:");
+
+      return {
+        stdout: JSON.stringify({
+          data: {
+            organization: {
+              projectV2: {
+                items: {
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  nodes: [
+                    {
+                      id: "item1",
+                      fieldValueByName: { name: "Todo" },
+                      labels: { labels: { nodes: [{ name: "bug" }] } },
+                      content: {
+                        __typename: "Issue",
+                        number: 42,
+                        title: "Test Issue",
+                        url: "https://github.com/owner/repo/issues/42",
+                        repository: { nameWithOwner: "owner/repo" },
+                        linkedPullRequests: { nodes: [] },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+        exitCode: 0,
+      };
+    };
+
+    const result = await fetchGitHubProjectItems("testorg", 1, mockRunner);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      id: "item1",
+      status: "Todo",
+      content: {
+        type: "Issue",
+        number: 42,
+        title: "Test Issue",
+      },
+    });
+  });
+
+  it("falls back to user query when organization query returns access error", async () => {
+    let callCount = 0;
+    const mockRunner: CommandRunner = async (cmd: string[]) => {
+      callCount++;
+      const queryArg = cmd.find((arg) => arg.startsWith("query="));
+
+      if (callCount === 1) {
+        // First call should be organization query
+        expect(queryArg).toContain("organization(login:");
+
+        return {
+          stdout: JSON.stringify({
+            errors: [{ message: "Could not resolve to an Organization with the name 'testuser'" }],
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      } else {
+        // Second call should be user query
+        expect(queryArg).toContain("user(login:");
+
+        return {
+          stdout: JSON.stringify({
+            data: {
+              user: {
+                projectV2: {
+                  items: {
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                    nodes: [
+                      {
+                        id: "item2",
+                        fieldValueByName: { name: "In Progress" },
+                        labels: { labels: { nodes: [] } },
+                        content: {
+                          __typename: "Issue",
+                          number: 43,
+                          title: "User Issue",
+                          url: "https://github.com/testuser/repo/issues/43",
+                          repository: { nameWithOwner: "testuser/repo" },
+                          linkedPullRequests: { nodes: [] },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      }
+    };
+
+    const result = await fetchGitHubProjectItems("testuser", 1, mockRunner);
+
+    expect(callCount).toBe(2);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      id: "item2",
+      status: "In Progress",
+      content: {
+        type: "Issue",
+        number: 43,
+        title: "User Issue",
+      },
+    });
+  });
+
+  it("falls back to user query when organization query fails with exception", async () => {
+    let callCount = 0;
+    const mockRunner: CommandRunner = async (cmd: string[]) => {
+      callCount++;
+      const queryArg = cmd.find((arg) => arg.startsWith("query="));
+
+      if (callCount === 1) {
+        // First call should be organization query and fail
+        expect(queryArg).toContain("organization(login:");
+        throw new Error("GitHub GraphQL query failed (exit 1): Forbidden");
+      } else {
+        // Second call should be user query
+        expect(queryArg).toContain("user(login:");
+
+        return {
+          stdout: JSON.stringify({
+            data: {
+              user: {
+                projectV2: {
+                  items: {
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                    nodes: [],
+                  },
+                },
+              },
+            },
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      }
+    };
+
+    const result = await fetchGitHubProjectItems("testuser", 1, mockRunner);
+
+    expect(callCount).toBe(2);
+    expect(result.items).toHaveLength(0);
+  });
+
+  it("continues using user query for pagination after fallback", async () => {
+    let callCount = 0;
+    const mockRunner: CommandRunner = async (cmd: string[]) => {
+      callCount++;
+      const queryArg = cmd.find((arg) => arg.startsWith("query="));
+
+      if (callCount === 1) {
+        // First call - organization query fails
+        expect(queryArg).toContain("organization(login:");
+
+        return {
+          stdout: JSON.stringify({
+            errors: [{ message: "Could not resolve to an Organization" }],
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      } else if (callCount === 2) {
+        // Second call - user query with first page
+        expect(queryArg).toContain("user(login:");
+        expect(cmd).not.toContain("after=");
+
+        return {
+          stdout: JSON.stringify({
+            data: {
+              user: {
+                projectV2: {
+                  items: {
+                    pageInfo: { hasNextPage: true, endCursor: "cursor1" },
+                    nodes: [
+                      {
+                        id: "item1",
+                        fieldValueByName: { name: "Todo" },
+                        labels: { labels: { nodes: [] } },
+                        content: {
+                          __typename: "Issue",
+                          number: 1,
+                          title: "Issue 1",
+                          url: "https://github.com/testuser/repo/issues/1",
+                          repository: { nameWithOwner: "testuser/repo" },
+                          linkedPullRequests: { nodes: [] },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      } else {
+        // Third call - user query with second page
+        expect(queryArg).toContain("user(login:");
+        expect(cmd).toContain("after=cursor1");
+
+        return {
+          stdout: JSON.stringify({
+            data: {
+              user: {
+                projectV2: {
+                  items: {
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                    nodes: [
+                      {
+                        id: "item2",
+                        fieldValueByName: { name: "Done" },
+                        labels: { labels: { nodes: [] } },
+                        content: {
+                          __typename: "Issue",
+                          number: 2,
+                          title: "Issue 2",
+                          url: "https://github.com/testuser/repo/issues/2",
+                          repository: { nameWithOwner: "testuser/repo" },
+                          linkedPullRequests: { nodes: [] },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      }
+    };
+
+    const result = await fetchGitHubProjectItems("testuser", 1, mockRunner);
+
+    expect(callCount).toBe(3);
+    expect(result.items).toHaveLength(2);
+    expect((result.items[0].content as { number: number }).number).toBe(1);
+    expect((result.items[1].content as { number: number }).number).toBe(2);
+  });
+
+  it("throws error when both organization and user queries fail", async () => {
+    let callCount = 0;
+    const mockRunner: CommandRunner = async (cmd: string[]) => {
+      callCount++;
+      const queryArg = cmd.find((arg) => arg.startsWith("query="));
+
+      if (callCount === 1) {
+        expect(queryArg).toContain("organization(login:");
+        throw new Error("GitHub GraphQL query failed (exit 1): Forbidden");
+      } else {
+        expect(queryArg).toContain("user(login:");
+
+        return {
+          stdout: JSON.stringify({
+            errors: [{ message: "User not found" }],
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      }
+    };
+
+    await expect(fetchGitHubProjectItems("nonexistent", 1, mockRunner)).rejects.toThrow(
+      "GraphQL errors: User not found"
+    );
+
+    expect(callCount).toBe(2);
+  });
+
+  it("throws error when organization query has non-access related errors", async () => {
+    const mockRunner: CommandRunner = async (cmd: string[]) => {
+      const queryArg = cmd.find((arg) => arg.startsWith("query="));
+      expect(queryArg).toContain("organization(login:");
+
+      return {
+        stdout: JSON.stringify({
+          errors: [{ message: "Rate limit exceeded" }],
+        }),
+        stderr: "",
+        exitCode: 0,
+      };
+    };
+
+    await expect(fetchGitHubProjectItems("testorg", 1, mockRunner)).rejects.toThrow(
+      "GraphQL errors: Rate limit exceeded"
+    );
+  });
+});

--- a/packages/daemon/src/state/github-fetch.ts
+++ b/packages/daemon/src/state/github-fetch.ts
@@ -48,15 +48,76 @@ interface GitHubProjectItemsPage {
         };
       };
     };
+    user?: {
+      projectV2?: {
+        items: {
+          pageInfo: {
+            hasNextPage: boolean;
+            endCursor: string | null;
+          };
+          nodes: GitHubProjectItemNode[];
+        };
+      };
+    };
   };
   errors?: Array<{ message: string }>;
 }
 
 const ITEMS_PER_PAGE = 100;
 
-const QUERY = `
+const ORG_QUERY = `
 query($owner: String!, $number: Int!, $first: Int!, $after: String) {
   organization(login: $owner) {
+    projectV2(number: $number) {
+      items(first: $first, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue {
+              name
+            }
+          }
+          labels: fieldValueByName(name: "Labels") {
+            ... on ProjectV2ItemFieldLabelValue {
+              labels(first: 20) {
+                nodes { name }
+              }
+            }
+          }
+          content {
+            __typename
+            ... on Issue {
+              number
+              title
+              url
+              repository { nameWithOwner }
+              linkedPullRequests: closedByPullRequestsReferences(first: 10, includeClosedPrs: true) {
+                nodes { url }
+              }
+            }
+            ... on PullRequest {
+              number
+              title
+              url
+              repository { nameWithOwner }
+            }
+            ... on DraftIssue {
+              title
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const USER_QUERY = `
+query($owner: String!, $number: Int!, $first: Int!, $after: String) {
+  user(login: $owner) {
     projectV2(number: $number) {
       items(first: $first, after: $after) {
         pageInfo {
@@ -160,7 +221,60 @@ function nodeToProjectItem(node: GitHubProjectItemNode): Record<string, unknown>
 }
 
 /**
+ * Execute a GraphQL query with fallback from organization to user.
+ *
+ * @param query - The GraphQL query string
+ * @param owner - GitHub organization or user
+ * @param projectNumber - Project number (from the URL)
+ * @param cursor - Pagination cursor
+ * @param runner - Command runner (for testing)
+ * @returns GraphQL response
+ */
+async function executeGraphQLQuery(
+  query: string,
+  owner: string,
+  projectNumber: number,
+  cursor: string | null,
+  runner: CommandRunner
+): Promise<GitHubProjectItemsPage> {
+  const cmd: string[] = [
+    "gh",
+    "api",
+    "graphql",
+    "-f",
+    `query=${query}`,
+    "-f",
+    `owner=${owner}`,
+    "-F",
+    `number=${projectNumber}`,
+    "-F",
+    `first=${ITEMS_PER_PAGE}`,
+  ];
+  if (cursor) {
+    cmd.push("-f", `after=${cursor}`);
+  }
+
+  const result: CommandResult = await runner(cmd);
+
+  if (result.exitCode !== 0) {
+    throw new Error(`GitHub GraphQL query failed (exit ${result.exitCode}): ${result.stderr}`);
+  }
+
+  let response: GitHubProjectItemsPage;
+  try {
+    response = JSON.parse(result.stdout) as GitHubProjectItemsPage;
+  } catch {
+    throw new Error(`Failed to parse GraphQL response: ${result.stdout.slice(0, 200)}`);
+  }
+
+  return response;
+}
+
+/**
  * Fetch all items from a GitHub Project V2 using cursor-based GraphQL pagination.
+ *
+ * Tries organization query first, falls back to user query if the authenticated
+ * user is not a member of the organization.
  *
  * @param owner - GitHub organization or user
  * @param projectNumber - Project number (from the URL)
@@ -175,54 +289,79 @@ export async function fetchGitHubProjectItems(
   const allItems: Record<string, unknown>[] = [];
   let cursor: string | null = null;
   let hasNextPage = true;
+  let useUserQuery = false;
 
   while (hasNextPage) {
-    const variables: Record<string, unknown> = {
-      owner,
-      number: projectNumber,
-      first: ITEMS_PER_PAGE,
-    };
-    if (cursor) {
-      variables.after = cursor;
-    }
-
-    const cmd: string[] = [
-      "gh",
-      "api",
-      "graphql",
-      "-f",
-      `query=${QUERY}`,
-      "-f",
-      `owner=${owner}`,
-      "-F",
-      `number=${projectNumber}`,
-      "-F",
-      `first=${ITEMS_PER_PAGE}`,
-    ];
-    if (cursor) {
-      cmd.push("-f", `after=${cursor}`);
-    }
-
-    const result: CommandResult = await runner(cmd);
-
-    if (result.exitCode !== 0) {
-      throw new Error(`GitHub GraphQL query failed (exit ${result.exitCode}): ${result.stderr}`);
-    }
-
+    // Try organization query first, fall back to user query
     let response: GitHubProjectItemsPage;
-    try {
-      response = JSON.parse(result.stdout) as GitHubProjectItemsPage;
-    } catch {
-      throw new Error(`Failed to parse GraphQL response: ${result.stdout.slice(0, 200)}`);
+    let items:
+      | {
+          pageInfo: { hasNextPage: boolean; endCursor: string | null };
+          nodes: GitHubProjectItemNode[];
+        }
+      | undefined;
+
+    if (!useUserQuery) {
+      try {
+        response = await executeGraphQLQuery(ORG_QUERY, owner, projectNumber, cursor, runner);
+
+        if (response.errors?.length) {
+          // Check if the error is about organization access
+          const hasOrgAccessError = response.errors.some(
+            (error) =>
+              error.message.includes("Could not resolve to an Organization") ||
+              error.message.includes("not a member")
+          );
+
+          if (hasOrgAccessError) {
+            // Fall back to user query
+            useUserQuery = true;
+            response = await executeGraphQLQuery(USER_QUERY, owner, projectNumber, cursor, runner);
+            items = response.data?.user?.projectV2?.items;
+          } else {
+            throw new Error(`GraphQL errors: ${response.errors.map((e) => e.message).join(", ")}`);
+          }
+        } else {
+          items = response.data?.organization?.projectV2?.items;
+        }
+      } catch (error) {
+        // If organization query fails completely with access-related error, try user query
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const isAccessError =
+          errorMessage.includes("Forbidden") ||
+          errorMessage.includes("not a member") ||
+          errorMessage.includes("Could not resolve to an Organization");
+
+        if (isAccessError) {
+          useUserQuery = true;
+          response = await executeGraphQLQuery(USER_QUERY, owner, projectNumber, cursor, runner);
+
+          if (response.errors?.length) {
+            throw new Error(`GraphQL errors: ${response.errors.map((e) => e.message).join(", ")}`);
+          }
+
+          items = response.data?.user?.projectV2?.items;
+        } else {
+          // Re-throw non-access errors
+          throw error;
+        }
+      }
+    } else {
+      // Use user query
+      response = await executeGraphQLQuery(USER_QUERY, owner, projectNumber, cursor, runner);
+
+      if (response.errors?.length) {
+        throw new Error(`GraphQL errors: ${response.errors.map((e) => e.message).join(", ")}`);
+      }
+
+      items = response.data?.user?.projectV2?.items;
     }
 
-    if (response.errors?.length) {
-      throw new Error(`GraphQL errors: ${response.errors.map((e) => e.message).join(", ")}`);
-    }
-
-    const items = response.data?.organization?.projectV2?.items;
     if (!items) {
-      throw new Error("Unexpected GraphQL response structure — missing projectV2.items");
+      const queryType = useUserQuery ? "user" : "organization";
+      throw new Error(
+        `Unexpected GraphQL response structure — missing ${queryType}.projectV2.items`
+      );
     }
 
     for (const node of items.nodes) {


### PR DESCRIPTION
## Summary

- When querying GitHub Projects V2, try `organization(login:)` first, fall back to `user(login:)` if the user isn't an org member
- Sticky fallback state avoids re-probing on subsequent pagination pages
- Adds learning doc at `docs/solutions/github-api/graphql-org-user-fallback.md`

Closes #89