### PR TITLE
docs: add retro learnings, opencode-api skill, and controller plans

### DIFF
--- a/.opencode/skills/opencode-api/SKILL.md
+++ b/.opencode/skills/opencode-api/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: opencode-api
+description: OpenCode serve HTTP API reference. Use when interacting with sessions, reading messages/todos, aborting workers, managing workspaces, or any direct OpenCode serve API call. The shared serve runs on port 13381 and handles all worker and controller sessions.
+---
+
+# OpenCode Serve API
+
+HTTP API for the shared OpenCode serve process. All worker and controller sessions run on a
+single `opencode serve` instance (default port **13381**).
+
+**When to use this skill:**
+- Reading session messages or todos (diagnostics)
+- Aborting a stuck session
+- Checking session status directly
+- Creating/managing sessions outside the daemon
+- Workspace or worktree operations
+- Any endpoint the daemon API doesn't expose
+
+**When to use the daemon API instead:**
+- `POST /workers` — dispatch a new worker (daemon handles session creation + workspace)
+- `GET /workers` — list workers
+- `POST /state/collect` — state machine decisions
+- `GET /health` — daemon health
+
+## Architecture
+
+```
+Controller ──► Daemon API (port $LEGION_DAEMON_PORT, default 13370)
+                  │
+                  ├── POST /workers        → creates session on shared serve
+                  ├── POST /workers/:id/prompt → proxies to session.promptAsync()
+                  ├── GET /workers/:id/status  → proxies to session.status()
+                  └── POST /state/collect  → state machine
+                  │
+                  ▼
+              Shared Serve (port 13381)
+                  │
+                  ├── Session 1 (controller)
+                  ├── Session 2 (worker: eng-42-implement)
+                  ├── Session 3 (worker: eng-42-review)
+                  └── ...
+```
+
+## Port Discovery
+
+The shared serve port is **13381** by default. To discover it programmatically:
+
+```bash
+# From any worker entry returned by the daemon
+SERVE_PORT=$(curl -s http://127.0.0.1:$LEGION_DAEMON_PORT/workers | jq '.[0].port')
+```
+
+## Request Scoping
+
+Every request must be scoped to a project directory. Use **either**:
+
+```bash
+# Option 1: Query parameter (recommended for curl)
+curl -s "http://127.0.0.1:13381/session?directory=/path/to/workspace"
+
+# Option 2: Header
+curl -s http://127.0.0.1:13381/session \
+  -H "x-opencode-directory: /path/to/workspace"
+```
+
+The workspace path comes from the worker entry:
+```bash
+WORKSPACE=$(curl -s http://127.0.0.1:$LEGION_DAEMON_PORT/workers/$WORKER_ID | jq -r '.workspace')
+```
+
+## Key Patterns
+
+### Create a Session
+
+```bash
+curl -s -X POST "http://127.0.0.1:13381/session?directory=$WORKSPACE" \
+  -H 'Content-Type: application/json' \
+  -d '{"id": "ses_deterministic_id"}'
+```
+
+- Returns `{"id": "ses_...", "title": "", ...}` on success
+- Returns **409** `DuplicateIDError` if session exists (idempotent — reuse it)
+- Session IDs are deterministic UUIDs from `computeSessionId(legionId, issueId, mode)`
+
+### Send a Prompt (Async)
+
+```bash
+curl -s -X POST "http://127.0.0.1:13381/session/$SESSION_ID/prompt_async?directory=$WORKSPACE" \
+  -H 'Content-Type: application/json' \
+  -d '{"parts": [{"type": "text", "text": "Your prompt here"}]}'
+```
+
+- Returns **204** immediately (fire-and-forget)
+- The session processes the prompt when its current turn completes
+- Use for: resuming workers, relaying feedback, triggering retro
+
+### Check Session Status
+
+```bash
+# All sessions
+curl -s "http://127.0.0.1:13381/session/status?directory=$WORKSPACE"
+
+# Returns map: { "ses_abc": {"type": "busy"}, "ses_def": {"type": "idle"} }
+```
+
+Status types:
+- `{"type": "idle"}` — session is waiting for input
+- `{"type": "busy"}` — session is processing
+- `{"type": "retry", "attempt": N, "message": "...", "next": timestamp}` — retrying after error
+
+### Read Session Messages
+
+```bash
+# All messages
+curl -s "http://127.0.0.1:13381/session/$SESSION_ID/message?directory=$WORKSPACE"
+
+# Last N messages
+curl -s "http://127.0.0.1:13381/session/$SESSION_ID/message?directory=$WORKSPACE&limit=5"
+
+# Message count
+curl -s "http://127.0.0.1:13381/session/$SESSION_ID/message/count?directory=$WORKSPACE"
+```
+
+Response is an array of `{info, parts}` objects. Each message has:
+- `info.role` — `"user"` or `"assistant"`
+- `info.time.created` — timestamp
+- `parts[]` — array of text, tool calls, files, etc.
+
+### Read Session Todos
+
+```bash
+curl -s "http://127.0.0.1:13381/session/$SESSION_ID/todo?directory=$WORKSPACE"
+```
+
+Returns array of `{content, status, priority}` objects. Status: `pending`, `in_progress`, `completed`, `cancelled`.
+
+### Abort a Session
+
+```bash
+curl -s -X POST "http://127.0.0.1:13381/session/$SESSION_ID/abort?directory=$WORKSPACE"
+```
+
+Stops any ongoing AI processing. Returns `true` on success.
+
+### Get Session Details
+
+```bash
+curl -s "http://127.0.0.1:13381/session/$SESSION_ID?directory=$WORKSPACE"
+```
+
+Returns full session object including title, timestamps, workspace, summary (file changes).
+
+### List All Sessions
+
+```bash
+curl -s "http://127.0.0.1:13381/session?directory=$WORKSPACE"
+
+# Filter: only root sessions (no children)
+curl -s "http://127.0.0.1:13381/session?directory=$WORKSPACE&roots=true"
+
+# Filter: sessions updated after timestamp
+curl -s "http://127.0.0.1:13381/session?directory=$WORKSPACE&start=1710000000000"
+```
+
+### Get File Changes (Diff)
+
+```bash
+curl -s "http://127.0.0.1:13381/session/$SESSION_ID/diff?directory=$WORKSPACE"
+```
+
+Returns array of `{file, before, after, additions, deletions, status}`.
+
+### Compact/Summarize a Session
+
+```bash
+curl -s -X POST "http://127.0.0.1:13381/session/$SESSION_ID/summarize?directory=$WORKSPACE" \
+  -H 'Content-Type: application/json' \
+  -d '{"providerID": "anthropic", "modelID": "claude-sonnet-4-20250514", "auto": true}'
+```
+
+Use when a session is running out of context window.
+
+### Health Check
+
+```bash
+curl -s http://127.0.0.1:13381/global/health
+# {"healthy": true, "version": "..."}
+```
+
+### Graceful Shutdown
+
+```bash
+curl -s -X POST http://127.0.0.1:13381/global/dispose
+```
+
+Disposes all sessions and cleans up resources. Best-effort (3s timeout).
+
+## Workspace & Worktree Management
+
+### Create a Worktree
+
+```bash
+curl -s -X POST "http://127.0.0.1:13381/experimental/worktree?directory=$WORKSPACE" \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "feature-branch"}'
+```
+
+### List Worktrees
+
+```bash
+curl -s "http://127.0.0.1:13381/experimental/worktree?directory=$WORKSPACE"
+```
+
+### Remove a Worktree
+
+```bash
+curl -s -X DELETE "http://127.0.0.1:13381/experimental/worktree?directory=$WORKSPACE" \
+  -H 'Content-Type: application/json' \
+  -d '{"directory": "/path/to/worktree"}'
+```
+
+## Events (SSE)
+
+Subscribe to real-time events:
+
+```bash
+curl -s -N "http://127.0.0.1:13381/event?directory=$WORKSPACE"
+```
+
+Key event types:
+- `session.status` — session busy/idle transitions
+- `session.idle` — session finished processing
+- `message.updated` — new message created
+- `message.part.updated` — tool call completed, text streamed
+- `todo.updated` — todo list changed
+- `permission.asked` — permission request pending
+- `question.asked` — question pending
+
+## Error Handling
+
+| Status | Meaning |
+|--------|---------|
+| 200 | Success |
+| 204 | Accepted (prompt_async) |
+| 400 | Bad request (invalid JSON, missing fields) |
+| 404 | Session/resource not found |
+| 409 | Duplicate ID (session already exists — safe to reuse) |
+
+## For Complete Endpoint Reference
+
+See [reference.md](reference.md) for all endpoints with full request/response schemas.

--- a/.opencode/skills/opencode-api/reference.md
+++ b/.opencode/skills/opencode-api/reference.md
@@ -1,0 +1,590 @@
+# OpenCode Serve API — Complete Endpoint Reference
+
+Base URL: `http://127.0.0.1:13381`
+
+All per-project endpoints accept `?directory=/path` query param or `x-opencode-directory` header.
+
+---
+
+## Global
+
+### GET /global/health
+
+Health check. No directory scoping needed.
+
+```
+Response 200:
+{
+  "healthy": true,
+  "version": "0.0.3"
+}
+```
+
+### GET /global/event
+
+SSE stream of global events (all projects). Each event has `{directory, payload}`.
+
+### GET /global/config
+
+Get global configuration.
+
+### PATCH /global/config
+
+Update global configuration. Body: partial `Config` object.
+
+### POST /global/dispose
+
+Dispose all instances. Releases all resources. Returns `true`.
+
+---
+
+## Sessions
+
+### GET /session
+
+List sessions. Sorted by most recently updated.
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `roots` | boolean | Only root sessions (no parentID) |
+| `start` | number | Sessions updated on/after this timestamp (ms epoch) |
+| `search` | string | Filter by title (case-insensitive) |
+| `limit` | number | Max sessions to return |
+
+```
+Response 200: Session[]
+```
+
+### POST /session
+
+Create a new session.
+
+```json
+Body:
+{
+  "id": "ses_optional_custom_id",
+  "parentID": "ses_parent_if_fork",
+  "title": "Optional title",
+  "workspaceID": "wrk_optional"
+}
+```
+
+All fields optional. `id` must match `^ses.*` pattern.
+
+```
+Response 200: Session
+Response 409: DuplicateIDError (safe to reuse existing session)
+```
+
+### GET /session/status
+
+Get status of ALL sessions.
+
+```
+Response 200:
+{
+  "ses_abc123": {"type": "idle"},
+  "ses_def456": {"type": "busy"},
+  "ses_ghi789": {"type": "retry", "attempt": 2, "message": "rate limited", "next": 1710000000}
+}
+```
+
+### GET /session/{sessionID}
+
+Get single session details.
+
+```
+Response 200: Session
+Response 404: NotFoundError
+```
+
+Session object:
+```json
+{
+  "id": "ses_...",
+  "slug": "...",
+  "projectID": "...",
+  "directory": "/path/to/workspace",
+  "title": "Session title",
+  "version": "...",
+  "time": {
+    "created": 1710000000,
+    "updated": 1710000100
+  },
+  "summary": {
+    "additions": 42,
+    "deletions": 10,
+    "files": 3,
+    "diffs": [...]
+  }
+}
+```
+
+### PATCH /session/{sessionID}
+
+Update session properties.
+
+```json
+Body:
+{
+  "title": "New title",
+  "time": {"archived": 1710000000}
+}
+```
+
+### DELETE /session/{sessionID}
+
+Delete session and all messages permanently.
+
+### POST /session/{sessionID}/abort
+
+Abort active processing. Returns `true`.
+
+### POST /session/{sessionID}/fork
+
+Fork session at a specific message.
+
+```json
+Body:
+{
+  "messageID": "msg_optional_fork_point"
+}
+```
+
+Returns new `Session`.
+
+### POST /session/{sessionID}/summarize
+
+Compact session to preserve key information.
+
+```json
+Body:
+{
+  "providerID": "anthropic",
+  "modelID": "claude-sonnet-4-20250514",
+  "auto": true
+}
+```
+
+### GET /session/{sessionID}/children
+
+Get child sessions forked from this session.
+
+### GET /session/{sessionID}/diff
+
+Get file changes for the session (or specific message).
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `messageID` | string | Filter to specific message's changes |
+
+```
+Response 200: FileDiff[]
+{
+  "file": "src/index.ts",
+  "before": "...",
+  "after": "...",
+  "additions": 5,
+  "deletions": 2,
+  "status": "modified"  // added | deleted | modified
+}
+```
+
+---
+
+## Messages
+
+### GET /session/{sessionID}/message
+
+Get session messages.
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `limit` | integer | Max messages to return |
+| `before` | string | Cursor for pagination |
+
+```
+Response 200: Array of {info: Message, parts: Part[]}
+```
+
+Message types:
+- **UserMessage**: `{role: "user", agent, model, ...}`
+- **AssistantMessage**: `{role: "assistant", modelID, providerID, cost, tokens, ...}`
+
+Part types:
+- **TextPart**: `{type: "text", text: "..."}`
+- **ToolPart**: `{type: "tool", tool: "bash", state: {status: "completed", input: {...}, output: "..."}}`
+- **FilePart**: `{type: "file", mime: "...", url: "..."}`
+- **SubtaskPart**: `{type: "subtask", prompt: "...", agent: "..."}`
+- **ReasoningPart**: `{type: "reasoning", text: "..."}`
+- **StepStartPart / StepFinishPart**: Agentic step boundaries with token counts
+
+### GET /session/{sessionID}/message/count
+
+```
+Response 200: {"count": 42}
+```
+
+### GET /session/{sessionID}/message/{messageID}
+
+Get specific message with parts.
+
+### DELETE /session/{sessionID}/message/{messageID}
+
+Delete a message. Does NOT revert file changes.
+
+---
+
+## Prompting
+
+### POST /session/{sessionID}/message
+
+Send a message synchronously (waits for full response).
+
+```json
+Body:
+{
+  "parts": [
+    {"type": "text", "text": "Your prompt"},
+    {"type": "file", "mime": "image/png", "url": "data:image/png;base64,..."}
+  ],
+  "model": {
+    "providerID": "anthropic",
+    "modelID": "claude-sonnet-4-20250514"
+  },
+  "agent": "build"
+}
+```
+
+### POST /session/{sessionID}/prompt_async
+
+Send a message asynchronously (returns immediately).
+
+Same body as `/message`. Returns **204** on acceptance.
+
+Use this for fire-and-forget prompts (worker dispatch, feedback relay).
+
+### POST /session/{sessionID}/command
+
+Execute a slash command.
+
+```json
+Body:
+{
+  "command": "legion-worker",
+  "arguments": "implement mode for eng-42"
+}
+```
+
+### POST /session/{sessionID}/shell
+
+Run a shell command in session context.
+
+```json
+Body:
+{
+  "command": "bun test",
+  "agent": "build"
+}
+```
+
+---
+
+## Todos
+
+### GET /session/{sessionID}/todo
+
+Get session todo list.
+
+```
+Response 200:
+[
+  {"content": "Implement feature X", "status": "completed", "priority": "high"},
+  {"content": "Write tests", "status": "in_progress", "priority": "high"},
+  {"content": "Push changes", "status": "pending", "priority": "medium"}
+]
+```
+
+Status: `pending`, `in_progress`, `completed`, `cancelled`
+Priority: `high`, `medium`, `low`
+
+---
+
+## Permissions & Questions
+
+### GET /permission
+
+List pending permission requests across all sessions.
+
+### POST /permission/{requestID}/reply
+
+Respond to a permission request.
+
+```json
+Body:
+{
+  "reply": "once"  // once | always | reject
+}
+```
+
+### GET /question
+
+List pending questions across all sessions.
+
+### POST /question/{requestID}/reply
+
+Answer a question.
+
+```json
+Body:
+{
+  "answers": [["Selected option label"]]
+}
+```
+
+### POST /question/{requestID}/reject
+
+Reject a question.
+
+---
+
+## Workspaces
+
+### GET /experimental/workspace
+
+List all workspaces.
+
+### POST /experimental/workspace
+
+Create a workspace.
+
+```json
+Body:
+{
+  "type": "worktree",
+  "branch": "feature-branch",
+  "extra": null
+}
+```
+
+### DELETE /experimental/workspace/{id}
+
+Remove a workspace. ID must match `^wrk.*`.
+
+---
+
+## Worktrees
+
+### POST /experimental/worktree
+
+Create a git worktree.
+
+```json
+Body:
+{
+  "name": "feature-branch",
+  "startCommand": "bun install"
+}
+```
+
+Returns `{name, branch, directory}`.
+
+### GET /experimental/worktree
+
+List all worktree directories. Returns `string[]`.
+
+### DELETE /experimental/worktree
+
+Remove a worktree and delete its branch.
+
+```json
+Body:
+{
+  "directory": "/path/to/worktree"
+}
+```
+
+### POST /experimental/worktree/reset
+
+Reset a worktree branch to primary default branch.
+
+```json
+Body:
+{
+  "directory": "/path/to/worktree"
+}
+```
+
+---
+
+## Events (SSE)
+
+### GET /event
+
+Subscribe to project-scoped events via Server-Sent Events.
+
+Key event types for controller use:
+
+| Event | Properties | Use |
+|-------|-----------|-----|
+| `session.status` | `{sessionID, status}` | Monitor busy/idle |
+| `session.idle` | `{sessionID}` | Detect worker completion |
+| `message.updated` | `{info: Message}` | New message posted |
+| `message.part.updated` | `{part: Part}` | Tool call completed |
+| `todo.updated` | `{sessionID, todos[]}` | Worker progress |
+| `permission.asked` | `{id, sessionID, permission, patterns}` | Permission needed |
+| `question.asked` | `{id, sessionID, questions[]}` | Question pending |
+| `session.error` | `{sessionID, error}` | Session error |
+
+---
+
+## Files & Search
+
+### GET /file?path=...
+
+List files and directories at a path.
+
+### GET /file/content?path=...
+
+Read file content.
+
+### GET /file/status
+
+Get git status of all files. Returns `{path, added, removed, status}[]`.
+
+### GET /find?pattern=...
+
+Search file contents (uses ripgrep).
+
+### GET /find/file?query=...
+
+Search for files by name/pattern.
+
+### GET /find/symbol?query=...
+
+Search for workspace symbols (functions, classes) via LSP.
+
+---
+
+## Configuration
+
+### GET /config
+
+Get current configuration.
+
+### PATCH /config
+
+Update configuration.
+
+### GET /config/providers
+
+List configured AI providers and default models.
+
+---
+
+## Providers
+
+### GET /provider
+
+List all available AI providers with connection status.
+
+### GET /provider/auth
+
+Get authentication methods for all providers.
+
+---
+
+## MCP Servers
+
+### GET /mcp
+
+Get status of all MCP servers.
+
+### POST /mcp
+
+Add a new MCP server dynamically.
+
+```json
+Body:
+{
+  "name": "my-server",
+  "config": {
+    "type": "local",
+    "command": ["node", "server.js"]
+  }
+}
+```
+
+### POST /mcp/{name}/connect
+
+Connect an MCP server.
+
+### POST /mcp/{name}/disconnect
+
+Disconnect an MCP server.
+
+---
+
+## PTY (Terminal Sessions)
+
+### GET /pty
+
+List active PTY sessions.
+
+### POST /pty
+
+Create a PTY session.
+
+```json
+Body:
+{
+  "command": "bash",
+  "args": [],
+  "cwd": "/path",
+  "title": "My terminal"
+}
+```
+
+### GET /pty/{ptyID}/connect
+
+WebSocket connection to interact with PTY in real-time.
+
+---
+
+## Agents & Skills
+
+### GET /agent
+
+List available AI agents. Returns `Agent[]` with name, mode, model, permissions.
+
+### GET /skill
+
+List available skills with content. Returns `{name, description, location, content}[]`.
+
+### GET /command
+
+List available slash commands.
+
+---
+
+## Paths & VCS
+
+### GET /path
+
+Get working directory paths: `{home, state, config, worktree, directory}`.
+
+### GET /vcs
+
+Get version control info: `{branch: "main"}`.
+
+---
+
+## LSP & Formatter
+
+### GET /lsp
+
+Get LSP server status.
+
+### GET /formatter
+
+Get formatter status.

--- a/bun.lock
+++ b/bun.lock
@@ -45,35 +45,35 @@
     },
   },
   "packages": {
-    "@biomejs/biome": ["@biomejs/biome@2.3.14", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.14", "@biomejs/cli-darwin-x64": "2.3.14", "@biomejs/cli-linux-arm64": "2.3.14", "@biomejs/cli-linux-arm64-musl": "2.3.14", "@biomejs/cli-linux-x64": "2.3.14", "@biomejs/cli-linux-x64-musl": "2.3.14", "@biomejs/cli-win32-arm64": "2.3.14", "@biomejs/cli-win32-x64": "2.3.14" }, "bin": { "biome": "bin/biome" } }, "sha512-QMT6QviX0WqXJCaiqVMiBUCr5WRQ1iFSjvOLoTk6auKukJMvnMzWucXpwZB0e8F00/1/BsS9DzcKgWH+CLqVuA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.8", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.8", "@biomejs/cli-darwin-x64": "2.4.8", "@biomejs/cli-linux-arm64": "2.4.8", "@biomejs/cli-linux-arm64-musl": "2.4.8", "@biomejs/cli-linux-x64": "2.4.8", "@biomejs/cli-linux-x64-musl": "2.4.8", "@biomejs/cli-win32-arm64": "2.4.8", "@biomejs/cli-win32-x64": "2.4.8" }, "bin": { "biome": "bin/biome" } }, "sha512-ponn0oKOky1oRXBV+rlSaUlixUxf1aZvWC19Z41zBfUOUesthrQqL3OtiAlSB1EjFjyWpn98Q64DHelhA6jNlA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UJGPpvWJMkLxSRtpCAKfKh41Q4JJXisvxZL8ChN1eNW3m/WlPFJ6EFDCE7YfUb4XS8ZFi3C1dFpxUJ0Ety5n+A=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ARx0tECE8I7S2C2yjnWYLNbBdDoPdq3oyNLhMglmuctThwUsuzFWRKrHmIGwIRWKz0Mat9DuzLEDp52hGnrxGQ=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-PNkLNQG6RLo8lG7QoWe/hhnMxJIt1tEimoXpGQjwS/dkdNiKBLPv4RpeQl8o3s1OKI3ZOR5XPiYtmbGGHAOnLA=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-Jg9/PsB9vDCJlANE8uhG7qDhb5w0Ix69D7XIIc8IfZPUoiPrbLm33k2Ig3NOJ/7nb3UbesFz3D1aDKm9DvzjhQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-KT67FKfzIw6DNnUNdYlBg+eU24Go3n75GWK6NwU4+yJmDYFe9i/MjiI+U/iEzKvo0g7G7MZqoyrhIYuND2w8QQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-5CdrsJct76XG2hpKFwXnEtlT1p+4g4yV+XvvwBpzKsTNLO9c6iLlAxwcae2BJ7ekPGWjNGw9j09T5KGPKKxQig=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-LInRbXhYujtL3sH2TMCH/UBwJZsoGwfQjBrMfl84CD4hL/41C/EU5mldqf1yoFpsI0iPWuU83U+nB2TUUypWeg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-Zo9OhBQDJ3IBGPlqHiTISloo5H0+FBIpemqIJdW/0edJ+gEcLR+MZeZozcUyz3o1nXkVA7++DdRKQT0599j9jA=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-ZsZzQsl9U+wxFrGGS4f6UxREUlgHwmEfu1IrXlgNFrNnd5Th6lIJr8KmSzu/+meSa9f4rzFrbEW9LBBA6ScoMA=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.8", "", { "os": "linux", "cpu": "x64" }, "sha512-PdKXspVEaMCQLjtZCn6vfSck/li4KX9KGwSDbZdgIqlrizJ2MnMcE3TvHa2tVfXNmbjMikzcfJpuPWH695yJrw=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-KQU7EkbBBuHPW3/rAcoiVmhlPtDSGOGRPv9js7qJVpYTzjQmVR+C9Rfcz+ti8YCH+zT1J52tuBybtP4IodjxZQ=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.8", "", { "os": "linux", "cpu": "x64" }, "sha512-Gi8quv8MEuDdKaPFtS2XjEnMqODPsRg6POT6KhoP+VrkNb+T2ywunVB+TvOU0LX1jAZzfBr+3V1mIbBhzAMKvw=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-+IKYkj/pUBbnRf1G1+RlyA3LWiDgra1xpS7H2g4BuOzzRbRB+hmlw0yFsLprHhbbt7jUzbzAbAjK/Pn0FDnh1A=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-LoFatS0tnHv6KkCVpIy3qZCih+MxUMvdYiPWLHRri7mhi2vyOOs8OrbZBcLTUEWCS+ktO72nZMy4F96oMhkOHQ=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-oizCjdyQ3WJEswpb3Chdngeat56rIdSYK12JI3iI11Mt5T5EXcZ7WLuowzEaFPNJ3zmOQFliMN8QY1Pi+qsfdQ=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.8", "", { "os": "win32", "cpu": "x64" }, "sha512-vAn7iXDoUbqFXqVocuq1sMYAd33p8+mmurqJkWl6CtIhobd/O6moe4rY5AJvzbunn/qZCdiDVcveqtkFh1e7Hg=="],
 
-    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.1.53", "", { "dependencies": { "@opencode-ai/sdk": "1.1.53", "zod": "4.1.8" } }, "sha512-9ye7Wz2kESgt02AUDaMea4hXxj6XhWwKAG8NwFhrw09Ux54bGaMJFt1eIS8QQGIMaD+Lp11X4QdyEg96etEBJw=="],
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.2.27", "", { "dependencies": { "@opencode-ai/sdk": "1.2.27", "zod": "4.1.8" } }, "sha512-h+8Bw9v9nghMg7T+SUCTzxlIhOrsTqXW7U0HVLGQST5DjbN7uyCUM51roZWZ8LRjGxzbzFhvPnY1bj8i+ioZyw=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@https://github.com/sjawhar/opencode/releases/download/v1.2.4-post.2/opencode-ai-sdk-1.2.4-post.1.tgz", {}],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@https://github.com/sjawhar/opencode/releases/download/v1.2.4-post.2/opencode-ai-sdk-1.2.4-post.1.tgz", {}, "sha512-ZRTvyD3GnUpUJ8kMLdeBH9rbtb3oC3hVvMSMdxW8B4ohLfTgUh/5vdDd6nG4vaUG+KqtN56KDltu6s6/TpN3yQ=="],
 
-    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
 
-    "@types/node": ["@types/node@25.2.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ=="],
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
-    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
-    "citty": ["citty@0.2.0", "", {}, "sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA=="],
+    "citty": ["citty@0.2.1", "", {}, "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg=="],
 
     "legion": ["legion@workspace:packages/daemon"],
 
@@ -81,7 +81,7 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
@@ -93,18 +93,14 @@
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@opencode-ai/plugin/@opencode-ai/sdk": ["@opencode-ai/sdk@1.1.53", "", {}, "sha512-RUIVnPOP1CyyU32FrOOYuE7Ge51lOBuhaFp2NSX98ncApT7ffoNetmwzqrhOiJQgZB1KrbCHLYOCK6AZfacxag=="],
+    "@opencode-ai/plugin/@opencode-ai/sdk": ["@opencode-ai/sdk@1.2.27", "", {}, "sha512-Wk0o/I+Fo+wE3zgvlJDs8Fb67KlKqX0PrV8dK5adSDkANq6r4Z25zXJg2iOir+a8ntg3rAcpel1OY4FV/TwRUA=="],
 
     "@opencode-ai/plugin/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
 
-    "opencode-legion/@opencode-ai/sdk": ["@opencode-ai/sdk@1.1.53", "", {}, "sha512-RUIVnPOP1CyyU32FrOOYuE7Ge51lOBuhaFp2NSX98ncApT7ffoNetmwzqrhOiJQgZB1KrbCHLYOCK6AZfacxag=="],
-
-    "opencode-legion/@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
+    "opencode-legion/@opencode-ai/sdk": ["@opencode-ai/sdk@1.2.27", "", {}, "sha512-Wk0o/I+Fo+wE3zgvlJDs8Fb67KlKqX0PrV8dK5adSDkANq6r4Z25zXJg2iOir+a8ntg3rAcpel1OY4FV/TwRUA=="],
 
     "opencode-legion/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "vscode-languageserver-protocol/vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
-
-    "opencode-legion/@types/bun/bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
   }
 }

--- a/docs/plans/slack-push-to-controller.md
+++ b/docs/plans/slack-push-to-controller.md
@@ -1,0 +1,291 @@
+# Slack Push to Legion Controller Session
+
+**Date:** 2026-03-15
+**Status:** Draft
+
+## Problem
+
+The controller currently polls Slack every 30-60 seconds for `#engineering` updates and `@sami`
+mentions. Polling adds latency, wastes tokens, and burns controller cycles even when no relevant
+messages exist.
+
+We need a push architecture where Slack events are delivered to the controller session in near
+real time, while keeping the deployment private on EC2 (no public inbound endpoint required).
+
+## Constraints and Existing System
+
+- Legion daemon runs on `127.0.0.1:13370` (`packages/daemon/src/daemon/server.ts`).
+- Shared OpenCode serve runs on `127.0.0.1:13381` and hosts worker + controller sessions.
+- Controller session is long-lived (`ses_30ea49044ffepa7XoYJBuzJ9CX`).
+- Daemon currently exposes worker prompting via `POST /workers/:id/prompt` and calls
+  `client.session.promptAsync(...)` through `OpenCodeAdapter.sendPrompt()`.
+- Daemon session creation uses `POST /session` on OpenCode serve with `x-opencode-directory`
+  (see `packages/daemon/src/daemon/serve-manager.ts`).
+- EC2 is private (no public domain/IP for Slack webhooks), so Socket Mode is preferred.
+
+## Delivery Modes Considered
+
+### Option A (Recommended): Slack Socket Mode
+
+Use Slack Socket Mode (WebSocket) with an internal bridge process.
+
+Why this fits:
+- No public inbound HTTP endpoint required.
+- Works behind NAT/firewall on private EC2.
+- Lower latency than polling.
+- Bidirectional channel available for event acks and response workflows.
+
+Tradeoffs:
+- Stateful long-lived connection; must handle reconnects and lifecycle.
+- Slightly harder horizontal scaling (not a blocker here; single EC2 host).
+- Slack limits concurrent Socket Mode connections (up to 10 per app).
+
+### Option B (Alternative): Events API over HTTP
+
+Expose a public HTTPS endpoint and receive Slack webhook events.
+
+Pros:
+- Slack-recommended production model for broadly distributed apps.
+- Stateless request handling.
+
+Cons for this deployment:
+- Requires public ingress, TLS, DNS, and signature verification endpoint.
+- Conflicts with private-EC2/no-public-endpoint constraint.
+
+## Recommended Architecture
+
+### Components
+
+1. **Slack Bridge Service** (new, local process)
+   - Runs on same EC2 host as daemon/controller.
+   - Maintains Socket Mode connection to Slack.
+   - Filters and normalizes incoming events.
+   - Forwards approved events to controller session via local API.
+
+2. **Legion Daemon Control Ingress** (recommended addition)
+   - New localhost endpoints on daemon (`:13370`) for controller session delivery:
+     - `POST /controller/message` (maps to OpenCode serve `POST /session/{id}/message`)
+     - `POST /controller/prompt` (maps to OpenCode serve `POST /session/{id}/prompt_async`)
+   - Daemon resolves controller session ID from existing controller state and performs forwarding.
+
+3. **OpenCode Serve Session API** (existing)
+   - Session-targeted delivery into the controller session:
+     - `POST /session/{sessionID}/message`
+     - `POST /session/{sessionID}/prompt_async`
+
+4. **Slack Web API Outbound Client** (bridge-owned)
+   - Sends controller responses back to Slack (`chat.postMessage`, `chat.update`, thread replies).
+
+### Why route through daemon instead of directly to serve
+
+- Centralizes session identity and future auth/rate limit controls in one place.
+- Keeps bridge blind to internals of worker/session topology.
+- Matches existing architecture where daemon is the control plane for session interactions.
+
+Direct-to-serve can exist as a fallback path if daemon endpointing is temporarily unavailable.
+
+## Message Flows
+
+### A) Slack -> Controller (notification ingestion)
+
+1. Slack emits event to Socket Mode connection.
+2. Bridge validates envelope freshness/idempotency and immediately acks envelope.
+3. Bridge applies filters (channel/user/event type/mention target/thread policy).
+4. Bridge normalizes payload into a compact internal event shape.
+5. Bridge forwards to daemon:
+   - informational context: `POST /controller/message`
+   - actionable instruction: `POST /controller/prompt`
+6. Daemon forwards to controller session on OpenCode serve (`/session/{id}/message` or
+   `/session/{id}/prompt_async`).
+7. Controller session processes event and decides whether to act.
+
+### B) Controller -> Slack (responses)
+
+1. Controller emits structured response intent (for example, JSON block in its output stream or
+   explicit command message contract).
+2. Bridge parses intent from controller session output stream or receives callback payload from
+   daemon-side hook.
+3. Bridge posts to Slack via Web API using bot token:
+   - thread reply for existing thread context
+   - channel message for new notifications
+   - DM when event policy requires direct escalation
+4. Bridge records Slack API result (`channel`, `ts`) for dedupe/retry correlation.
+
+## Event Subscriptions and Filtering Policy
+
+### Subscribe to
+
+- `app_mention` (primary trigger in channels)
+- `message.channels` (for `#engineering` scoped monitoring)
+- `message.groups` (if private engineering channels are needed)
+- `message.im` (DMs to bot)
+- `message.mpim` (optional, if group DMs matter)
+- `message_replied` (thread follow-ups)
+- `app_rate_limited` (operational telemetry)
+
+### Filter rules (default deny, explicit allow)
+
+- **Workspace allowlist:** only `trajectorylabs` workspace/team ID.
+- **Channel allowlist:** explicit list including `#engineering` channel ID(s).
+- **User allowlist/priority:** `@sami` and optional trusted operators.
+- **Bot/self suppression:** drop events from bot users including self.
+- **Subtype exclusions:** ignore edits/deletes/join messages unless explicitly needed.
+- **Thread binding:** only accept thread replies for threads created by bridge/controller, unless
+  user is in allowlist.
+
+## Security Model
+
+### Secrets and tokens
+
+- Store tokens in EC2 secret storage (SSM Parameter Store or Secrets Manager), never in repo:
+  - `SLACK_BOT_TOKEN` (`xoxb-...`)
+  - `SLACK_APP_TOKEN` (`xapp-...`) for Socket Mode
+  - `SLACK_SIGNING_SECRET` only required for HTTP Events fallback
+- Inject as environment variables at process start.
+- Rotate tokens on a schedule and on incident.
+- Restrict token scopes to minimum required (`app_mentions:read`, `channels:history`,
+  `chat:write`, `im:history`, etc. only as needed).
+
+### Validation and trust boundaries
+
+- **Socket Mode path:** trust is anchored by authenticated WebSocket session; still validate
+  `team_id`, `api_app_id`, and envelope shape.
+- **HTTP fallback path:** validate Slack signature (`X-Slack-Signature`) + timestamp skew check
+  (<= 5 min) using HMAC SHA-256 signing secret.
+- Enforce localhost-only ingress from bridge to daemon (`127.0.0.1`), not public network.
+- Add shared local auth token between bridge and daemon control endpoints to prevent accidental
+  local injection from unrelated processes.
+- Sanitize inbound text before prompt injection (strip control chars, cap length, prefix with
+  provenance metadata).
+
+### Prompt-injection mitigation
+
+- Wrap Slack content in a strict envelope:
+  - source metadata (`user`, `channel`, `ts`, `event_type`)
+  - quoted message body (not merged into raw instructions)
+  - explicit system prefix: "external untrusted user input"
+- Apply max size and truncation policy with link back to full Slack context.
+
+## Reliability, Rate Limiting, and Backpressure
+
+### Slack-side constraints
+
+- Events API requires quick ack behavior (3-second rule for HTTP; Socket Mode requires per-envelope
+  ack).
+- `app_rate_limited` events signal workspace-level event pressure.
+
+### Bridge controls
+
+- In-memory + durable queue (disk-backed) for transient daemon/controller outages.
+- Idempotency key from `event_id` + `event_ts` to dedupe retries/reconnect duplicates.
+- Token bucket rate limiting per channel/user to avoid flooding controller session.
+- Circuit breaker when controller ingress fails repeatedly.
+- Dead-letter queue for poisoned/unparseable events with operator alerting.
+
+### Controller ingress controls
+
+- Per-session prompt concurrency cap (serialize or small bounded parallelism).
+- Coalescing policy for bursty events (e.g., merge thread reply bursts within 2-5 seconds).
+- Distinguish `message` (context) vs `prompt_async` (action) to reduce unnecessary wakeups.
+
+## Failure Modes and Handling
+
+1. **Socket disconnect / refresh requested**
+   - Auto-reconnect with exponential backoff + jitter.
+   - Optionally keep secondary warm connection for seamless rollover.
+
+2. **Daemon unavailable (`:13370` down)**
+   - Queue events locally with TTL.
+   - Health-check daemon and replay on recovery.
+
+3. **OpenCode serve unavailable (`:13381` down)**
+   - Daemon should return retriable failure; bridge retries through queue.
+
+4. **Controller session missing/stale**
+   - Daemon resolves current controller session from state file/runtime and rejects unknown session.
+   - Bridge pauses actionable forwarding, emits ops alert.
+
+5. **Slack API post failures (outbound)**
+   - Retry with backoff for 429/5xx.
+   - Respect `Retry-After` headers.
+   - Dead-letter and alert after retry budget exhaustion.
+
+6. **Duplicate deliveries**
+   - Deduplicate by Slack `event_id` and normalized routing key.
+
+7. **Injection/abuse attempt in Slack content**
+   - Treat as untrusted data; never interpolate raw text as system instructions.
+
+## Deployment on Existing EC2 Infrastructure
+
+### Process placement
+
+- Keep daemon (`13370`) and shared serve (`13381`) unchanged.
+- Add `slack-bridge` process managed similarly to daemon (systemd/supervisor/tmux-managed service).
+- Bridge binds no public port in Socket Mode.
+
+### Local networking
+
+- Bridge -> daemon over `127.0.0.1:13370` only.
+- Daemon -> shared serve over `127.0.0.1:13381` only.
+- Security group inbound can remain closed for Slack integration path.
+
+### Observability
+
+- Structured logs with correlation IDs (`event_id`, `session_id`, `slack_ts`).
+- Metrics: events received, filtered, forwarded, dropped, retry count, queue depth, ack latency,
+  post-to-Slack latency.
+- Alerts: reconnect storm, queue growth, repeated daemon forward failures, token expiry.
+
+## Suggested Contract Between Bridge and Daemon
+
+### `POST /controller/message`
+
+Body:
+
+```json
+{
+  "source": "slack",
+  "eventId": "Ev123",
+  "teamId": "T123",
+  "channelId": "C123",
+  "threadTs": "1712345678.000100",
+  "userId": "U123",
+  "text": "raw message text",
+  "metadata": {
+    "type": "app_mention"
+  }
+}
+```
+
+Semantics: Add contextual message to controller session using OpenCode serve
+`POST /session/{sessionID}/message`.
+
+### `POST /controller/prompt`
+
+Body:
+
+```json
+{
+  "source": "slack",
+  "eventId": "Ev123",
+  "prompt": "You received a mention in #engineering. Evaluate and respond if needed. Context: ..."
+}
+```
+
+Semantics: Trigger controller reasoning using OpenCode serve
+`POST /session/{sessionID}/prompt_async`.
+
+## Rollout Plan (Architecture-Level)
+
+1. Build and run bridge in shadow mode (receive + filter + log, no forwarding).
+2. Enable forwarding to `/controller/message` only (context ingestion, no prompting).
+3. Enable controlled `prompt_async` for allowlisted events (`app_mention`, DM, `@sami` only).
+4. Enable outbound controller-to-Slack responses in limited channels.
+5. Decommission polling loops after equivalent coverage is verified.
+
+## Decision
+
+Adopt **Socket Mode bridge -> daemon controller ingress -> OpenCode session endpoints** as the
+primary architecture. Keep Events API over HTTP as a documented fallback for future environments
+with public ingress.

--- a/docs/solutions/controller/controller-session-anti-patterns.md
+++ b/docs/solutions/controller/controller-session-anti-patterns.md
@@ -1,0 +1,146 @@
+---
+title: "Controller session anti-patterns: polling waste, version increments, and merge cascades"
+category: controller
+tags:
+  - controller
+  - polling
+  - session-management
+  - merge-ordering
+date: 2026-03-19
+status: active
+module: daemon
+related_issues:
+  - "4817"
+---
+
+# Controller Session Anti-Patterns: Polling Waste, Version Increments, and Merge Cascades
+
+Source session: `ses_2fe5a7e21ffeZicAZhxr9NXQxu` (2026-03-18 15:55 UTC – 2026-03-19 16:29 UTC), controller for `trajectory-labs-pbc/2` operating on `trajectory-labs-pbc/agent-c`. 821 messages over ~20 hours; 15 bug-fix PRs merged across 5 agar environments plus infra blockers.
+
+## Anti-Pattern 1: Polling Waste
+
+### Problem
+
+The controller burned enormous amounts of context window on `sleep 60 && check status` loops. Hundreds of polls, 90%+ returning identical state. The controller acknowledged this explicitly:
+
+> "I burned enormous amounts of context window on `sleep 60 && check status` loops. Hundreds of polls, 90%+ returning identical state."
+
+Polling appeared continuously throughout the session — at 16:29, 16:35, 16:41, 17:46, 18:00, 18:23, 18:29, 18:33, 18:34 UTC and onward through the next day. The user had to intervene directly:
+
+> "You're not polling" — user at 17:50 UTC
+
+Even after acknowledging the waste, the controller fell back into the same pattern: "Let me keep polling" repeated across dozens of messages.
+
+### Impact
+
+- Token/time burn with zero state change per poll
+- Slower reaction to real blockers because noisy polling crowded operator attention
+- Controller context window consumed by repetitive status checks instead of decision-making
+
+### Fix
+
+Event-driven notifications instead of polling. The daemon should push state changes to the controller (worker completion, CI status change, PR merge) rather than the controller pulling every 30–60 seconds. If polling is unavoidable, use exponential backoff: 30s → 60s → 120s → 5min when no state changes are detected.
+
+## Anti-Pattern 2: Version Increment Abuse
+
+### Problem
+
+When dispatch timed out during session creation, the controller incremented `--version` to create fresh workers, destroying all accumulated context. The user's dispatch instructions were explicit:
+
+> "The `--version` flag on `legion dispatch` exists **only as an escape hatch** for unrecoverable sessions. **Do NOT increment versions during normal pipeline operation.**"
+
+Yet the controller used `--version` increments multiple times:
+
+> "I used `--version` increments multiple times because session creation timed out."
+
+The later self-retro called this out:
+
+> "It was wrong to use `--version` increments when dispatches timed out. Those timeouts were transient — the session was created successfully, I just didn't wait long enough."
+
+> "When session creation timed out, I incremented `--version` multiple times, creating fresh context-less workers."
+
+### Impact
+
+- Context-less workers that don't understand branch topology, prior changes, or conventions
+- Elevated risk of wrong-branch pushes and destructive actions
+- Duplicate or partially overlapping work streams
+
+### Fix
+
+Strict timeout recovery ladder:
+1. Retry dispatch once (same session)
+2. Verify session existence via daemon API (`GET /workers`)
+3. Re-prompt existing session
+4. Only allow version increment with explicit "session unrecoverable" evidence (serve crash, corrupted session, deleted workspace)
+
+## Anti-Pattern 3: Merge Cascade
+
+### Problem
+
+Merging 2 PRs into `main` made all other open PRs stale, triggering a cascade of rebases, CI re-runs, and failures. The session shows this pattern playing out repeatedly:
+
+> "#4529 merged. #4550 has a merge conflict — needs rebase" — 04:08 UTC
+
+> "Both need rebasing. Let me rebase the ones that passed tests and are ready" — 04:21 UTC
+
+> "3 builds failing after rebase" — 05:13 UTC
+
+The controller then set auto-merge on rebased PRs, but auto-merge was blocked by the Docker build ENOSPC issue, creating a double cascade:
+
+> "The auto-merge PRs are all still open — they're blocked by the Docker build space issue" — 07:15 UTC
+
+> "CI checks need to pass after rebase. Let me set auto-merge and keep polling" — 04:26 UTC
+
+The pattern repeated: merge → rebase remaining → CI re-runs → some fail → fix → rebase again. With 10+ open PRs touching overlapping files (agar environments), each merge invalidated all others.
+
+### Impact
+
+- Quadratic CI cost: N PRs × N merges = N² CI runs
+- Hours of rebase/CI churn that produced no new value
+- Auto-merge toggles on structurally blocked PRs wasted GitHub API calls
+
+### Fix
+
+Merge queue that rebases and merges sequentially. After each merge, the queue rebases the next PR, waits for CI, then merges — rather than rebasing all PRs simultaneously. GitHub's native merge queue or a controller-managed serial merge loop would eliminate the cascade. For batches of related PRs (like agar environments), consider consolidating into fewer, larger PRs to reduce the N in the N² problem.
+
+## Anti-Pattern 4: Stuck Workers Without Health Checks
+
+### Problem
+
+The Bitwarden tester ran for 14+ hours without producing any durable output. The controller noticed it was stuck but had no mechanism to automatically intervene:
+
+> "Worker has been running for 7+ hours. It's likely stuck in a loop — possibly trying to build the Docker image" — 09:52 UTC
+
+> "The Bitwarden test already had 'PASS — 3/3 acceptance criteria verified' from the first testing round, but..." — 09:52 UTC
+
+> "Running for 14 hours and is still showing 'busy' — almost certainly stuck in a loop hitting ENOSPC trying to build the Docker image" — 11:57 UTC
+
+> "Stuck Bitwarden tester — still 'busy' after 14 hours, eating a serve slot" — 13:14 UTC
+
+The controller had to manually kill the stuck tester at 12:01 UTC after it had consumed a serve slot for over 12 hours:
+
+> "Let me also kill the stuck Bitwarden tester that's been running for 12+ hours" — 12:01 UTC
+
+### Impact
+
+- 14 hours of a serve slot consumed by a dead worker
+- Reduced parallelism for the entire session (one fewer worker available)
+- Manual intervention required — the controller had to notice and act
+
+### Fix
+
+Dead-worker heuristic in the daemon:
+- If a worker remains "busy" for T hours (e.g., 2h) without new PR comment, check update, or git activity, mark as `suspected-stuck`
+- Expose `lastMessageAt`, `lastToolCallAt`, `lastGitActivityAt` in the worker status API
+- Controller policy: suspected-stuck workers get one "are you alive?" prompt. No response within 10 minutes → kill and re-dispatch
+- Add first-class `stuck`/`degraded` worker statuses computed from liveness + progress deltas, not just process health
+
+## Cross-Cutting: Infrastructure Blocker Mode
+
+The ENOSPC issue (`#4817`) blocked Docker builds across all PRs. The controller continued dispatching testers and setting auto-merges on PRs that were structurally blocked:
+
+> "`ENOSPC: no space left on device` — it's a Docker build space issue, not a code issue. The `vault.bitwarden.com` node_modules exhausts disk" — 05:14 UTC
+
+> "The auto-merge PRs will keep failing until this is fixed at the infrastructure level" — 05:14 UTC
+
+**Fix:** When N PRs fail on the same infrastructure signature, the controller should pause non-blocker dispatches, file and prioritize the infra issue, dispatch a dedicated fix, and resume the queue only after verification. The session eventually did this (`#4817` filed, `PR #4872` fix merged), but hours of queue churn happened before the controller shifted to blocker-first mode.

--- a/docs/solutions/daemon/controller-retro-20h-bug-pipeline-optimization.md
+++ b/docs/solutions/daemon/controller-retro-20h-bug-pipeline-optimization.md
@@ -1,0 +1,187 @@
+---
+title: "Controller Retro: 20h Bug Pipeline Optimization"
+category: daemon
+tags:
+  - controller
+  - throughput
+  - session-management
+  - testing
+  - workflow-design
+date: 2026-03-19
+status: active
+module: daemon
+related_issues:
+  - "4817"
+symptoms:
+  - "dispatch timed out while creating worker sessions"
+  - "workers stayed busy for hours with no new PR evidence"
+  - "test-passed labels appeared without reproducible smoke evidence"
+  - "stale workers accumulated across controller restarts"
+---
+
+# Controller Retro: 20h Bug Pipeline Optimization
+
+## Context and Scope
+
+This retro analyzes controller session `ses_2fe5a7e21ffeZicAZhxr9NXQxu` (2026-03-18 15:55 UTC to 2026-03-19 16:29 UTC) for `trajectory-labs-pbc/2` with focus on bug triage and fix flow in `trajectory-labs-pbc/agent-c`.
+
+Observed outputs and board state during/after the session:
+
+- Session scale: 821 messages over ~24h.
+- Repository merge throughput in-session: 46 merged PRs in the same time window (mixed bugfix + unrelated work).
+- User-stated target subset: 15 bug PRs across 5 agar environments plus 3 infra blockers.
+- Board anchor issues at end of analysis: `#4450` Done, `#4524` Done, `#4522/#4523` still In progress.
+- Open `agar-environment-issue` backlog remains substantial (18 open issues).
+
+## What Went Well
+
+- The controller kept a high issue movement rate despite infrastructure friction.
+- Blocking infra issue `#4817` was eventually isolated, fixed (`PR #4872`), and unblocked multiple waiting PRs.
+- Multi-environment workstreams (LinkedIn, Bitwarden, Email, Greenhouse, Google) were advanced in parallel rather than serially.
+- The pipeline generally respected stage semantics (architect/plan/implement/test/review), even when manual nudging was required.
+
+## Waste and Failure Patterns
+
+### 1) Polling-heavy control loop burned context without adding state
+
+Symptoms:
+
+- Repeated "keep polling" cycles with low information gain.
+- User had to explicitly prompt "You're not polling" after idle windows.
+- Long stretches where workers were "busy" but produced no new durable artifact.
+
+Impact:
+
+- High token/time burn in the controller session.
+- Slower reaction to true blockers because noisy polling crowded operator attention.
+
+### 2) Session creation timeouts triggered unsafe recovery behavior
+
+Symptoms:
+
+- Multiple dispatch/session creation timeouts.
+- Timeout handling sometimes escalated to `--version` increments, spawning fresh contextless sessions.
+- Later self-retro explicitly called this out as harmful.
+
+Impact:
+
+- Lost worker continuity.
+- Duplicate or partially overlapping work.
+- Elevated risk of wrong-branch pushes and repeated onboarding prompts.
+
+### 3) Worker liveness and work completion were inferred from weak signals
+
+Symptoms:
+
+- "busy" status treated as progress.
+- Testers sometimes completed with no comment/label evidence, or labels were used without strong reproducibility proof.
+- A Bitwarden tester remained effectively stuck for 12+ hours.
+
+Impact:
+
+- False confidence in test quality.
+- Slow detection of deadlocked workers.
+- Rework when missing evidence had to be reconstructed.
+
+### 4) Infrastructure blocker triage came later than optimal
+
+Symptoms:
+
+- ENOSPC (`#4817`) blocked merges while environment PRs kept cycling through rebase/CI loops.
+- Auto-merge was toggled repeatedly on PRs that were structurally blocked by infra state.
+
+Impact:
+
+- Queue churn and repeated CI runs.
+- Longer cycle times for otherwise-ready fixes.
+
+## Quality Findings
+
+The main quality gap was not whether tests existed, but whether they produced auditable, environment-level acceptance evidence.
+
+Observed failure mode:
+
+- "test-passed" was sometimes treated as sufficient even when tester comments lacked hard evidence (exact command, endpoint, expected/actual outcome).
+
+Required standard for this pipeline:
+
+- A tester pass must include reproducible proof on the PR (or linked issue comment):
+  - exact smoke command(s),
+  - environment and scenario target,
+  - observed result payload/status,
+  - explicit pass/fail against acceptance criteria.
+
+Without this artifact, the controller should treat the phase as unresolved.
+
+## Prioritization Assessment
+
+The controller correctly recognized infra blockers as important, but execution order lagged:
+
+- Early parallelization increased throughput initially.
+- Once ENOSPC became the dominant merge bottleneck, priority should have collapsed to "fix infra first, then resume queue".
+
+Net: prioritization intent was good, but policy needed a stronger automatic "global blocker" mode.
+
+## Session Management Assessment
+
+Good:
+
+- Sessions were often reused as designed.
+
+Gaps:
+
+- Timeout paths were not deterministic enough; retries vs reattach vs recreate were handled ad hoc.
+- Stale worker accumulation (5 then 33 stale workers observed in-session) added noise and made status interpretation harder.
+- No automatic stale-worker quarantine/escalation policy prevented very long-running stuck sessions.
+
+## Concrete Changes to Go 2x Faster with Half the Waste
+
+### Controller skill changes (`.opencode/skills/legion-controller/SKILL.md`)
+
+1. Add a strict timeout recovery ladder:
+   - retry dispatch once,
+   - verify session existence,
+   - re-prompt existing session,
+   - only allow version increment with explicit "session unrecoverable" evidence.
+
+2. Add evidence-gated tester completion:
+   - do not advance on `test-passed` label alone,
+   - require proof template in latest tester comment.
+
+3. Add blocker mode policy:
+   - when N PRs fail on same infra signature (e.g., ENOSPC), pause non-blocker dispatches,
+   - dispatch dedicated infra implementer/tester pair,
+   - resume queued PR flow only after blocker verification.
+
+4. Add dead-worker heuristic:
+   - if worker remains busy for T without new PR comment/check/run change, mark suspected-stuck and escalate.
+
+### Daemon/state-machine enhancements (`packages/daemon/src/*`)
+
+1. Expose richer progress signals per worker:
+   - `lastMessageAt`, `lastToolCallAt`, `lastGitActivityAt`, `workspaceExists`.
+
+2. Add first-class `stuck`/`degraded` worker statuses:
+   - computed from liveness + progress deltas, not just process health.
+
+3. Add dispatch idempotency key and timeout-safe return path:
+   - if dispatch times out after creation, return existing worker/session metadata instead of inviting duplicate retries.
+
+4. Add global blocker detector:
+   - aggregate failing check signatures across active PRs and emit controller hint (`prioritize_blocker_issue`).
+
+### Worker workflow changes (`.opencode/skills/legion-worker/workflows/*`)
+
+1. Tester workflow must publish structured evidence block (machine-parseable section).
+2. Implementer workflow should detect infra-class CI failures and annotate "blocked by global infra issue" once, then stop retry loops.
+3. Retro workflow should auto-capture stuck-session incidents and timeout recovery paths for continual policy tuning.
+
+## Suggested Metrics to Track Next Session
+
+- Median issue cycle time per mode transition (architect->plan->implement->test->review->merge).
+- Time in "busy with no artifact" per worker.
+- Dispatch timeout count and successful reattach rate.
+- Percentage of tester passes with full evidence template.
+- Merge queue delay attributable to shared blocker signatures.
+
+If these changes are implemented, the largest expected gains are from reducing blind polling, eliminating timeout-driven context resets, and enforcing evidence-based test transitions.

--- a/docs/solutions/index.json
+++ b/docs/solutions/index.json
@@ -8,8 +8,10 @@
       "integration-issues/github-graphql-pr-draft-status.md",
       "integration-issues/external-repo-pr-auto-transition-gap.md",
       "integration-issues/linear-mcp-label-resolution.md",
-      "deterministic-session-ids.md"
-      "github-api/graphql-org-user-fallback.md"
+      "deterministic-session-ids.md",
+      "github-api/graphql-org-user-fallback.md",
+      "daemon/controller-retro-20h-bug-pipeline-optimization.md",
+      "controller/controller-session-anti-patterns.md"
     ],
     "packages/daemon/src/daemon/serve-manager": [
       "daemon/opencode-serve-lifecycle.md",
@@ -30,7 +32,9 @@
       "integration-patterns/controller-worker-protocol.md",
       "architecture-patterns/task-index-retro.md",
       "task-index-patterns.md",
-      "deterministic-session-ids.md"
+      "deterministic-session-ids.md",
+      "daemon/controller-retro-20h-bug-pipeline-optimization.md",
+      "controller/controller-session-anti-patterns.md"
     ],
     "packages/daemon/src/cli": [
       "daemon/controller-lifecycle-separation.md",
@@ -44,67 +48,135 @@
     ".opencode/skills/legion-worker": [
       "skill-patterns/worker-skill-failure-modes.md",
       "daemon/deferred-review-comments-pattern.md",
-      "integration-patterns/controller-worker-protocol.md"
+      "integration-patterns/controller-worker-protocol.md",
+      "daemon/controller-retro-20h-bug-pipeline-optimization.md",
+      "testing/worker-smoke-testing-requirements.md"
     ],
     ".opencode/skills/legion-controller": [
       "integration-patterns/controller-worker-protocol.md",
       "daemon/controller-lifecycle-separation.md",
-      "daemon/controller-observability.md"
+      "daemon/controller-observability.md",
+      "daemon/controller-retro-20h-bug-pipeline-optimization.md",
+      "controller/controller-session-anti-patterns.md",
+      "testing/worker-smoke-testing-requirements.md"
     ],
-    ".opencode/skills/linear": ["integration-issues/linear-mcp-label-resolution.md"],
+    ".opencode/skills/linear": [
+      "integration-issues/linear-mcp-label-resolution.md"
+    ],
     ".opencode/skills": [
       "skill-patterns/parallel-subagent-background-execution.md",
       "delegation/delegation-hardening-retro.md",
       "delegation/hardening-patterns.md"
     ],
-    "tests": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
-    "tag:SIGTERM": ["daemon/opencode-serve-lifecycle.md"],
-    "tag:active-index": ["task-index-patterns.md"],
-    "tag:agent-restrictions": ["delegation/hardening-patterns.md"],
-    "tag:aiofiles": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
-    "tag:alru-cache": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
-    "tag:anyio": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
+    "tests": [
+      "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"
+    ],
+    "tag:SIGTERM": [
+      "daemon/opencode-serve-lifecycle.md"
+    ],
+    "tag:active-index": [
+      "task-index-patterns.md"
+    ],
+    "tag:agent-restrictions": [
+      "delegation/hardening-patterns.md"
+    ],
+    "tag:aiofiles": [
+      "architecture-patterns/sync-to-async-modular-refactoring.md"
+    ],
+    "tag:alru-cache": [
+      "architecture-patterns/sync-to-async-modular-refactoring.md"
+    ],
+    "tag:anyio": [
+      "architecture-patterns/sync-to-async-modular-refactoring.md"
+    ],
     "tag:architecture": [
       "daemon/controller-lifecycle-separation.md",
       "daemon/shared-serve-refactor.md"
     ],
-    "tag:askuserquestion": ["integration-patterns/tmux-askuserquestion-navigation.md"],
-    "tag:async": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
-    "tag:asyncmock": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
-    "tag:atomic-writes": ["delegation/hardening-patterns.md"],
-    "tag:auto-transition": ["integration-issues/external-repo-pr-auto-transition-gap.md"],
-    "tag:automation": ["integration-patterns/tmux-askuserquestion-navigation.md"],
-    "tag:autospec": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
-    "tag:background-tasks": ["skill-patterns/parallel-subagent-background-execution.md"],
-    "tag:batch-queries": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
-    "tag:batching": ["integration-issues/github-graphql-pr-draft-status.md"],
-    "tag:bootstrap-bug": ["architecture-patterns/task-index-retro.md"],
+    "tag:askuserquestion": [
+      "integration-patterns/tmux-askuserquestion-navigation.md"
+    ],
+    "tag:async": [
+      "architecture-patterns/sync-to-async-modular-refactoring.md"
+    ],
+    "tag:asyncmock": [
+      "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"
+    ],
+    "tag:atomic-writes": [
+      "delegation/hardening-patterns.md"
+    ],
+    "tag:auto-transition": [
+      "integration-issues/external-repo-pr-auto-transition-gap.md"
+    ],
+    "tag:automation": [
+      "integration-patterns/tmux-askuserquestion-navigation.md"
+    ],
+    "tag:autospec": [
+      "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"
+    ],
+    "tag:background-tasks": [
+      "skill-patterns/parallel-subagent-background-execution.md"
+    ],
+    "tag:batch-queries": [
+      "architecture-patterns/sync-to-async-modular-refactoring.md"
+    ],
+    "tag:batching": [
+      "integration-issues/github-graphql-pr-draft-status.md"
+    ],
+    "tag:bootstrap-bug": [
+      "architecture-patterns/task-index-retro.md"
+    ],
     "tag:caching": [
       "architecture-patterns/sync-to-async-modular-refactoring.md",
       "architecture-patterns/task-index-retro.md",
       "integration-issues/linear-mcp-label-resolution.md",
       "task-index-patterns.md"
     ],
-    "tag:callback-pattern": ["architecture-patterns/shared-state-file-ownership.md"],
-    "tag:claude-code": ["integration-patterns/tmux-askuserquestion-navigation.md"],
+    "tag:callback-pattern": [
+      "architecture-patterns/shared-state-file-ownership.md"
+    ],
+    "tag:claude-code": [
+      "integration-patterns/tmux-askuserquestion-navigation.md"
+    ],
     "tag:cleanup": [
       "daemon/deferred-review-comments-pattern.md",
       "daemon/graceful-worker-shutdown.md"
     ],
-    "tag:cli-interaction": ["integration-patterns/tmux-askuserquestion-navigation.md"],
-    "tag:code-review": ["daemon/deferred-review-comments-pattern.md"],
-    "tag:concurrency": ["delegation/delegation-hardening-retro.md"],
-    "tag:config-schema": ["delegation/hardening-patterns.md"],
+    "tag:cli-interaction": [
+      "integration-patterns/tmux-askuserquestion-navigation.md"
+    ],
+    "tag:code-review": [
+      "daemon/deferred-review-comments-pattern.md"
+    ],
+    "tag:concurrency": [
+      "delegation/delegation-hardening-retro.md"
+    ],
+    "tag:config-schema": [
+      "delegation/hardening-patterns.md"
+    ],
     "tag:controller": [
       "daemon/controller-observability.md",
-      "integration-patterns/controller-worker-protocol.md"
+      "integration-patterns/controller-worker-protocol.md",
+      "controller/controller-session-anti-patterns.md"
     ],
-    "tag:controller-dispatch": ["integration-issues/external-repo-pr-auto-transition-gap.md"],
-    "tag:crash-recovery": ["daemon/shared-serve-retro.md"],
-    "tag:daemon": ["architecture-patterns/shared-state-file-ownership.md"],
-    "tag:debugging": ["daemon/controller-observability.md"],
-    "tag:defense-in-depth": ["daemon/graceful-worker-shutdown.md"],
-    "tag:deferred-review-comments": ["daemon/workspace-validation-retro.md"],
+    "tag:controller-dispatch": [
+      "integration-issues/external-repo-pr-auto-transition-gap.md"
+    ],
+    "tag:crash-recovery": [
+      "daemon/shared-serve-retro.md"
+    ],
+    "tag:daemon": [
+      "architecture-patterns/shared-state-file-ownership.md"
+    ],
+    "tag:debugging": [
+      "daemon/controller-observability.md"
+    ],
+    "tag:defense-in-depth": [
+      "daemon/graceful-worker-shutdown.md"
+    ],
+    "tag:deferred-review-comments": [
+      "daemon/workspace-validation-retro.md"
+    ],
     "tag:delegation": [
       "delegation/delegation-hardening-retro.md",
       "delegation/hardening-patterns.md"
@@ -114,17 +186,41 @@
       "daemon/shared-serve-refactor.md",
       "daemon/shared-serve-retro.md"
     ],
-    "tag:directory-resolution": ["daemon/worker-directory-fix.md"],
-    "tag:dispatch": ["integration-patterns/controller-worker-protocol.md"],
-    "tag:dispose": ["daemon/opencode-serve-lifecycle.md"],
-    "tag:draft-status": ["integration-issues/github-graphql-pr-draft-status.md"],
-    "tag:error-handling": ["integration-issues/linear-mcp-label-resolution.md"],
-    "tag:external-repos": ["integration-issues/external-repo-pr-auto-transition-gap.md"],
-    "tag:failure-modes": ["skill-patterns/worker-skill-failure-modes.md"],
-    "tag:fallback-pattern": ["task-index-patterns.md", "github-api/graphql-org-user-fallback.md"],
-    "tag:file-based-index": ["architecture-patterns/task-index-retro.md", "task-index-patterns.md"],
-    "tag:file-based-storage": ["delegation/hardening-patterns.md"],
-    "tag:finalize-pattern": ["delegation/delegation-hardening-retro.md"],
+    "tag:directory-resolution": [
+      "daemon/worker-directory-fix.md"
+    ],
+    "tag:dispatch": [
+      "integration-patterns/controller-worker-protocol.md"
+    ],
+    "tag:dispose": [
+      "daemon/opencode-serve-lifecycle.md"
+    ],
+    "tag:draft-status": [
+      "integration-issues/github-graphql-pr-draft-status.md"
+    ],
+    "tag:error-handling": [
+      "integration-issues/linear-mcp-label-resolution.md"
+    ],
+    "tag:external-repos": [
+      "integration-issues/external-repo-pr-auto-transition-gap.md"
+    ],
+    "tag:failure-modes": [
+      "skill-patterns/worker-skill-failure-modes.md"
+    ],
+    "tag:fallback-pattern": [
+      "task-index-patterns.md",
+      "github-api/graphql-org-user-fallback.md"
+    ],
+    "tag:file-based-index": [
+      "architecture-patterns/task-index-retro.md",
+      "task-index-patterns.md"
+    ],
+    "tag:file-based-storage": [
+      "delegation/hardening-patterns.md"
+    ],
+    "tag:finalize-pattern": [
+      "delegation/delegation-hardening-retro.md"
+    ],
     "tag:github": [
       "integration-issues/external-repo-pr-auto-transition-gap.md",
       "integration-issues/github-graphql-pr-draft-status.md",
@@ -136,42 +232,93 @@
       "integration-issues/linear-mcp-label-resolution.md",
       "github-api/graphql-org-user-fallback.md"
     ],
-    "tag:implement": ["skill-patterns/worker-skill-failure-modes.md"],
+    "tag:implement": [
+      "skill-patterns/worker-skill-failure-modes.md"
+    ],
     "tag:jj-workspaces": [
       "daemon/worker-directory-fix.md",
       "daemon/worker-directory-resolution.md"
     ],
-    "tag:keyboard-navigation": ["integration-patterns/tmux-askuserquestion-navigation.md"],
-    "tag:labels": ["integration-issues/linear-mcp-label-resolution.md"],
-    "tag:lifecycle": ["daemon/controller-lifecycle-separation.md"],
-    "tag:lifecycle-separation": ["architecture-patterns/shared-state-file-ownership.md"],
+    "tag:keyboard-navigation": [
+      "integration-patterns/tmux-askuserquestion-navigation.md"
+    ],
+    "tag:labels": [
+      "integration-issues/linear-mcp-label-resolution.md"
+    ],
+    "tag:lifecycle": [
+      "daemon/controller-lifecycle-separation.md"
+    ],
+    "tag:lifecycle-separation": [
+      "architecture-patterns/shared-state-file-ownership.md"
+    ],
     "tag:linear": [
       "integration-issues/external-repo-pr-auto-transition-gap.md",
       "integration-issues/linear-mcp-label-resolution.md"
     ],
-    "tag:mcp": ["integration-issues/linear-mcp-label-resolution.md"],
-    "tag:merge": ["skill-patterns/worker-skill-failure-modes.md"],
-    "tag:migration": ["architecture-patterns/plugin-migration-assessment.md"],
-    "tag:mocking": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
-    "tag:modular-architecture": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
-    "tag:n-plus-one": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
-    "tag:name-resolution": ["integration-issues/linear-mcp-label-resolution.md"],
-    "tag:observability": ["daemon/controller-observability.md"],
-    "tag:oh-my-opencode": ["architecture-patterns/plugin-migration-assessment.md"],
+    "tag:mcp": [
+      "integration-issues/linear-mcp-label-resolution.md"
+    ],
+    "tag:merge": [
+      "skill-patterns/worker-skill-failure-modes.md"
+    ],
+    "tag:migration": [
+      "architecture-patterns/plugin-migration-assessment.md"
+    ],
+    "tag:mocking": [
+      "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"
+    ],
+    "tag:modular-architecture": [
+      "architecture-patterns/sync-to-async-modular-refactoring.md"
+    ],
+    "tag:n-plus-one": [
+      "architecture-patterns/sync-to-async-modular-refactoring.md"
+    ],
+    "tag:name-resolution": [
+      "integration-issues/linear-mcp-label-resolution.md"
+    ],
+    "tag:observability": [
+      "daemon/controller-observability.md"
+    ],
+    "tag:oh-my-opencode": [
+      "architecture-patterns/plugin-migration-assessment.md"
+    ],
     "tag:opencode": [
       "daemon/opencode-serve-lifecycle.md",
       "skill-patterns/parallel-subagent-background-execution.md"
     ],
-    "tag:opencode-legion": ["architecture-patterns/plugin-migration-assessment.md"],
-    "tag:opencode-sdk": ["daemon/worker-directory-fix.md", "daemon/worker-directory-resolution.md"],
-    "tag:opencode-serve": ["daemon/shared-serve-refactor.md", "daemon/shared-serve-retro.md"],
-    "tag:parallel-execution": ["skill-patterns/parallel-subagent-background-execution.md"],
-    "tag:parallel-subagents": ["architecture-patterns/task-index-retro.md"],
-    "tag:performance": ["architecture-patterns/task-index-retro.md", "task-index-patterns.md"],
-    "tag:persistence": ["architecture-patterns/shared-state-file-ownership.md"],
-    "tag:plugin": ["architecture-patterns/plugin-migration-assessment.md"],
-    "tag:pr-review": ["integration-issues/github-graphql-pr-draft-status.md"],
-    "tag:pr-workflow": ["daemon/workspace-validation-retro.md"],
+    "tag:opencode-legion": [
+      "architecture-patterns/plugin-migration-assessment.md"
+    ],
+    "tag:opencode-sdk": [
+      "daemon/worker-directory-fix.md",
+      "daemon/worker-directory-resolution.md"
+    ],
+    "tag:opencode-serve": [
+      "daemon/shared-serve-refactor.md",
+      "daemon/shared-serve-retro.md"
+    ],
+    "tag:parallel-execution": [
+      "skill-patterns/parallel-subagent-background-execution.md"
+    ],
+    "tag:parallel-subagents": [
+      "architecture-patterns/task-index-retro.md"
+    ],
+    "tag:performance": [
+      "architecture-patterns/task-index-retro.md",
+      "task-index-patterns.md"
+    ],
+    "tag:persistence": [
+      "architecture-patterns/shared-state-file-ownership.md"
+    ],
+    "tag:plugin": [
+      "architecture-patterns/plugin-migration-assessment.md"
+    ],
+    "tag:pr-review": [
+      "integration-issues/github-graphql-pr-draft-status.md"
+    ],
+    "tag:pr-workflow": [
+      "daemon/workspace-validation-retro.md"
+    ],
     "tag:process-management": [
       "daemon/graceful-worker-shutdown.md",
       "daemon/opencode-serve-lifecycle.md",
@@ -185,49 +332,128 @@
       "integration-issues/external-repo-pr-auto-transition-gap.md",
       "integration-issues/github-graphql-pr-draft-status.md"
     ],
-    "tag:pytest-mock": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
-    "tag:python": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
-    "tag:race-condition": ["architecture-patterns/shared-state-file-ownership.md"],
-    "tag:refactoring": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
-    "tag:remote-control": ["integration-patterns/tmux-askuserquestion-navigation.md"],
-    "tag:resource-accounting": ["delegation/delegation-hardening-retro.md"],
-    "tag:resume": ["integration-patterns/controller-worker-protocol.md"],
-    "tag:retro": ["skill-patterns/worker-skill-failure-modes.md"],
-    "tag:review": ["skill-patterns/worker-skill-failure-modes.md"],
-    "tag:serve": ["daemon/opencode-serve-lifecycle.md"],
-    "tag:session-management": ["daemon/worker-directory-resolution.md"],
-    "tag:sessions": ["daemon/shared-serve-refactor.md", "daemon/shared-serve-retro.md"],
-    "tag:shared-serve": ["daemon/shared-serve-refactor.md", "daemon/shared-serve-retro.md"],
-    "tag:skill-authoring": ["skill-patterns/parallel-subagent-background-execution.md"],
-    "tag:skills": ["skill-patterns/worker-skill-failure-modes.md"],
-    "tag:stale-detection": ["delegation/delegation-hardening-retro.md"],
-    "tag:state-file": ["architecture-patterns/shared-state-file-ownership.md"],
+    "tag:pytest-mock": [
+      "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"
+    ],
+    "tag:python": [
+      "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"
+    ],
+    "tag:race-condition": [
+      "architecture-patterns/shared-state-file-ownership.md"
+    ],
+    "tag:refactoring": [
+      "architecture-patterns/sync-to-async-modular-refactoring.md"
+    ],
+    "tag:remote-control": [
+      "integration-patterns/tmux-askuserquestion-navigation.md"
+    ],
+    "tag:resource-accounting": [
+      "delegation/delegation-hardening-retro.md"
+    ],
+    "tag:resume": [
+      "integration-patterns/controller-worker-protocol.md"
+    ],
+    "tag:retro": [
+      "skill-patterns/worker-skill-failure-modes.md"
+    ],
+    "tag:review": [
+      "skill-patterns/worker-skill-failure-modes.md"
+    ],
+    "tag:serve": [
+      "daemon/opencode-serve-lifecycle.md"
+    ],
+    "tag:session-management": [
+      "daemon/worker-directory-resolution.md",
+      "controller/controller-session-anti-patterns.md"
+    ],
+    "tag:sessions": [
+      "daemon/shared-serve-refactor.md",
+      "daemon/shared-serve-retro.md"
+    ],
+    "tag:shared-serve": [
+      "daemon/shared-serve-refactor.md",
+      "daemon/shared-serve-retro.md"
+    ],
+    "tag:skill-authoring": [
+      "skill-patterns/parallel-subagent-background-execution.md"
+    ],
+    "tag:skills": [
+      "skill-patterns/worker-skill-failure-modes.md"
+    ],
+    "tag:stale-detection": [
+      "delegation/delegation-hardening-retro.md"
+    ],
+    "tag:state-file": [
+      "architecture-patterns/shared-state-file-ownership.md"
+    ],
     "tag:state-machine": [
       "daemon/controller-observability.md",
       "integration-issues/github-graphql-pr-draft-status.md"
     ],
-    "tag:state-management": ["daemon/controller-lifecycle-separation.md"],
-    "tag:subagents": ["skill-patterns/parallel-subagent-background-execution.md"],
-    "tag:task-index": ["architecture-patterns/task-index-retro.md"],
+    "tag:state-management": [
+      "daemon/controller-lifecycle-separation.md"
+    ],
+    "tag:subagents": [
+      "skill-patterns/parallel-subagent-background-execution.md"
+    ],
+    "tag:task-index": [
+      "architecture-patterns/task-index-retro.md"
+    ],
     "tag:task-persistence": [
       "delegation/delegation-hardening-retro.md",
       "delegation/hardening-patterns.md",
       "task-index-patterns.md"
     ],
-    "tag:testability": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
+    "tag:testability": [
+      "architecture-patterns/sync-to-async-modular-refactoring.md"
+    ],
     "tag:testing": [
       "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md",
-      "github-api/graphql-org-user-fallback.md"
+      "github-api/graphql-org-user-fallback.md",
+      "testing/worker-smoke-testing-requirements.md"
     ],
-    "tag:tmux": ["integration-patterns/tmux-askuserquestion-navigation.md"],
-    "tag:validation": ["daemon/workspace-validation-retro.md"],
-    "tag:worker": ["integration-patterns/controller-worker-protocol.md"],
-    "tag:worker-isolation": ["daemon/worker-directory-resolution.md"],
-    "tag:worker-lifecycle": ["integration-issues/external-repo-pr-auto-transition-gap.md"],
-    "tag:worker-spawning": ["daemon/worker-directory-fix.md"],
-    "tag:workers": ["skill-patterns/worker-skill-failure-modes.md"],
-    "tag:workflow-design": ["skill-patterns/parallel-subagent-background-execution.md"],
-    "tag:workflow-pattern": ["daemon/deferred-review-comments-pattern.md"],
-    "tag:workspace-validation": ["daemon/workspace-validation-retro.md"]
+    "tag:tmux": [
+      "integration-patterns/tmux-askuserquestion-navigation.md"
+    ],
+    "tag:validation": [
+      "daemon/workspace-validation-retro.md"
+    ],
+    "tag:worker": [
+      "integration-patterns/controller-worker-protocol.md"
+    ],
+    "tag:worker-isolation": [
+      "daemon/worker-directory-resolution.md"
+    ],
+    "tag:worker-lifecycle": [
+      "integration-issues/external-repo-pr-auto-transition-gap.md",
+      "testing/worker-smoke-testing-requirements.md"
+    ],
+    "tag:worker-spawning": [
+      "daemon/worker-directory-fix.md"
+    ],
+    "tag:workers": [
+      "skill-patterns/worker-skill-failure-modes.md"
+    ],
+    "tag:workflow-design": [
+      "skill-patterns/parallel-subagent-background-execution.md"
+    ],
+    "tag:workflow-pattern": [
+      "daemon/deferred-review-comments-pattern.md"
+    ],
+    "tag:workspace-validation": [
+      "daemon/workspace-validation-retro.md"
+    ],
+    "tag:polling": [
+      "controller/controller-session-anti-patterns.md"
+    ],
+    "tag:merge-ordering": [
+      "controller/controller-session-anti-patterns.md"
+    ],
+    "tag:smoke-testing": [
+      "testing/worker-smoke-testing-requirements.md"
+    ],
+    "tag:quality-gates": [
+      "testing/worker-smoke-testing-requirements.md"
+    ]
   }
 }

--- a/docs/solutions/testing/worker-smoke-testing-requirements.md
+++ b/docs/solutions/testing/worker-smoke-testing-requirements.md
@@ -1,0 +1,128 @@
+---
+title: "Worker smoke testing must use real builds and runtime verification, not code review"
+category: testing
+tags:
+  - testing
+  - smoke-testing
+  - quality-gates
+  - worker-lifecycle
+date: 2026-03-19
+status: active
+related_issues:
+  - "3515"
+  - "3983"
+  - "3506"
+---
+
+# Worker Smoke Testing Must Use Real Builds and Runtime Verification, Not Code Review
+
+Source session: `ses_2fe5a7e21ffeZicAZhxr9NXQxu` (2026-03-18 15:55 UTC – 2026-03-19 16:29 UTC). 10 testers dispatched across multiple environments.
+
+## Problem: False Passes from Code Review
+
+All 10 testers initially passed by doing code review — reading the code and reasoning about correctness — rather than actually building and running the environments. The controller caught this only because it re-inspected the results:
+
+> "Let me resume all 10 with explicit instructions to do real testing" — 04:08 UTC
+
+The testers produced `test-passed` labels without any build evidence, endpoint verification, or runtime output. The controller had to explicitly reprompt:
+
+> "Code review is NOT testing." — 03:55 UTC
+
+This is the core failure: **testers treated code review as a substitute for runtime verification**, and the testing framework did not prevent this.
+
+### Evidence Pattern
+
+The first round of testers completed with variations of "code looks correct, PASS" without:
+- Building the application
+- Starting the environment
+- Making HTTP requests to verify endpoints
+- Checking that the actual bug (e.g., 500 error, missing field) was resolved
+
+One tester that actually ran the environment found real evidence:
+
+> "Solid evidence — HTTP 200, build passes, job submitted, no 500s. This passes." — 04:15 UTC
+
+This was the exception, not the norm. Most testers never reached the build step.
+
+## Problem: No Acceptance Criteria in Issues or Plans
+
+Issues and plans did not define what "tested" means. Testers had no runbook, no acceptance criteria checklist, and no defined smoke test procedure:
+
+> "Each issue (or the plan) should declare acceptance criteria that are machine-executable. 'Profile page returns 200' not 'profile page works'." — 15:20 UTC
+
+One tester illustrates the gap: it reported "PASS — 3/3 acceptance criteria verified" but was then found stuck for 14 hours trying to build:
+
+> "The test already had 'PASS — 3/3 acceptance criteria verified' from the first testing round, but..."
+
+The "acceptance criteria" were self-invented by the tester (code review based), not defined by the issue or plan.
+
+## Problem: No Standardized Smoke Test Infrastructure
+
+Each tester had to improvise the build and verification process from scratch. There was no standardized command to build an environment and run smoke tests.
+
+Without a standard tool, testers encountered environment-specific build issues:
+- `npm install` failures from ENOSPC
+- Build space exhaustion across environments
+- Missing environment variables and configuration
+
+A standardized smoke test command would have failed fast with a clear error instead of letting workers loop for hours.
+
+## Problem: Too Many Small PRs Create Testing/Merge Burden
+
+Each environment got its own issue and PR, resulting in 10+ PRs that each needed independent testing, review, rebasing, and merging. After each merge, remaining PRs went stale:
+
+> "#4529 merged. #4550 has a merge conflict — needs rebase" — 04:08 UTC
+
+The testers consumed 5 serve slots simultaneously, and the merge cascade consumed hours of CI.
+
+### Consolidation Principle
+
+For batch fixes (same root cause across multiple targets), fewer larger PRs reduce the testing/rebase/merge burden. One PR touching 5 targets needs one test cycle and one merge, versus 5 PRs needing 5 test cycles and a 5-step merge cascade.
+
+## Required Changes
+
+### 1. Tester Workflow: Mandatory Runtime Evidence
+
+The tester workflow must require structured evidence in the PR comment:
+
+```markdown
+## Smoke Test Evidence
+- **Environment:** [name]
+- **Build:** [pass/fail + build time]
+- **Health check:** [endpoint → HTTP status]
+- **Bug verification:** [original bug scenario → observed result]
+- **Acceptance criteria:** [each criterion → pass/fail with evidence]
+```
+
+The controller should not advance on `test-passed` alone — it must verify the evidence block exists in the latest tester comment.
+
+### 2. Issue Templates: Machine-Executable Acceptance Criteria
+
+Each issue must include acceptance criteria that a tester can mechanically verify:
+
+```markdown
+## Acceptance Criteria
+- [ ] Build succeeds
+- [ ] Health check endpoint returns 200
+- [ ] Target endpoint returns expected payload (no 500)
+- [ ] Original bug scenario produces correct behavior
+```
+
+### 3. Infrastructure: Standardized Smoke Test Command
+
+Build a standardized smoke test command that:
+- Builds the application
+- Starts the environment
+- Runs health checks and verifies endpoints
+- Exits with 0/1 and structured output
+
+This eliminates tester improvisation and provides a fail-fast path for infrastructure issues.
+
+### 4. Consolidation Policy
+
+For batch fixes with the same root cause:
+- Group into 1–2 PRs maximum
+- Run a single combined test pass
+- Merge once, avoid the N² rebase cascade
+
+This is a controller-level policy decision during triage: when the architect identifies the same fix pattern across N targets, instruct the planner to consolidate.

--- a/packages/daemon/src/cli/index.ts
+++ b/packages/daemon/src/cli/index.ts
@@ -161,8 +161,7 @@ async function cmdStop(team: string, _stateDir?: string, backend?: string): Prom
 
   const stateFilePath = instancePaths.workersFile;
   if (!fs.existsSync(stateFilePath)) {
-    console.log("No state file found. Daemon may not be running.");
-    return;
+    console.log("No state file found — attempting HTTP shutdown anyway.");
   }
 
   const daemonPort = await getDaemonPort(legionId);


### PR DESCRIPTION
## Summary

- Add controller session anti-patterns and pipeline optimization retro docs
- Add generalized worker smoke testing requirements (from agar retro, de-scoped to be project-agnostic)
- Add opencode-api skill with reference docs
- Add slack push-to-controller design plan
- Fix CLI stop command to not bail early when state file missing
- Fix index.json syntax errors (missing commas, premature brace close) and update references
- Bump biome (2.3→2.4) and opencode-ai plugin/SDK dependencies
- Remove stale files that belonged to agent-c (download.txt, jpmorgan postman collection, npm lockfile, projects-v2 investigation plan)
- Remove duplicate session adoption design doc (already captured in #98)