### PR TITLE
sjawhar-legion-107: GitHub App token management for worker roles

### DIFF
--- a/.opencode/skills/legion-controller/SKILL.md
+++ b/.opencode/skills/legion-controller/SKILL.md
@@ -280,6 +280,56 @@ from the issue identifier:
   identifier (format: `owner-repo-number`, e.g. `acme-widgets-42` → `acme/widgets`)
 - **Linear:** `(linear backend)`
 
+### GitHub App Credentials (Worker Identity)
+
+When GitHub App credentials are configured on the daemon, each worker mode maps to a
+specific role identity. The daemon manages token generation and caching — the controller
+just fetches the right credential before dispatch.
+
+**Mode-to-role mapping:**
+
+| Mode | Role | App Name |
+|------|------|----------|
+| `implement`, `merge` | `impl` | `legion-impl` |
+| `review` | `review` | `legion-review` |
+| `test`, `architect`, `plan` | `ops` | `legion-ops` |
+
+**Before dispatching a worker (GitHub backend only):**
+
+```bash
+# Map mode to role
+case "$MODE" in
+  implement|merge) ROLE="impl" ;;
+  review) ROLE="review" ;;
+  test|architect|plan) ROLE="ops" ;;
+esac
+
+# Fetch credential from daemon (returns JSON with token + gitIdentity, or 404 if not configured)
+CRED=$(curl -sf http://127.0.0.1:$LEGION_DAEMON_PORT/credentials/$ROLE 2>/dev/null)
+if [ -n "$CRED" ]; then
+  GH_TOKEN=$(echo "$CRED" | jq -r '.token')
+  # Git identity from the response
+  GIT_AUTHOR_NAME=$(echo "$CRED" | jq -r '.gitIdentity.name')
+  GIT_AUTHOR_EMAIL=$(echo "$CRED" | jq -r '.gitIdentity.email')
+  GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+  GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+fi
+```
+
+**Credential env vars for workers:**
+- `GH_TOKEN` — GitHub App installation token (short-lived, ~1 hour)
+- `GIT_AUTHOR_NAME` / `GIT_COMMITTER_NAME` — `<app-name>[bot]` (e.g., `legion-impl[bot]`)
+- `GIT_AUTHOR_EMAIL` / `GIT_COMMITTER_EMAIL` — `<app-id>+<app-name>[bot]@users.noreply.github.com`
+
+**Important constraints:**
+- Never call `gh auth login`, `git config --global`, or write to `~/.config/gh/` or `~/.gitconfig`
+- All identity is set via environment variables only
+- If credentials are not configured for a role, fall back to ambient credentials (the
+  user's personal token) — the daemon's `/credentials/{role}` endpoint returns 404 for
+  unconfigured roles
+- Tokens expire after ~1 hour; the daemon refreshes automatically when within 5 minutes
+  of expiry, so always fetch fresh before dispatch
+
 ### Dispatch (New Worker)
 
 **Always use skill invocation (`/skill-name`), not file paths.** Workers load skills via the

--- a/docs/setup/github-apps.md
+++ b/docs/setup/github-apps.md
@@ -1,0 +1,128 @@
+# GitHub App Setup for Worker Identity
+
+Legion uses GitHub Apps to give each worker role a distinct identity. This enables proper PR review flows where the implementer and reviewer are different actors — GitHub blocks same-actor PR approvals.
+
+## Why GitHub Apps?
+
+- **PR compliance**: Implementer and reviewer must be different identities
+- **Least privilege**: Each role gets only the permissions it needs
+- **Free**: GitHub Apps don't consume org seats
+- **Audit trail**: Commits and PR actions are attributed to specific roles
+
+## Architecture
+
+Three GitHub Apps, one per role group:
+
+| App Name | Used By | Permissions |
+|----------|---------|-------------|
+| `legion-impl` | Implementer, Merger | Contents: write, Pull requests: write, Issues: write |
+| `legion-review` | Reviewer | Pull requests: write, Issues: write |
+| `legion-ops` | Tester, Architect, Planner, Controller | Contents: read, Pull requests: read, Issues: write |
+
+## Step 1: Create the GitHub Apps
+
+For each of the three apps (`legion-impl`, `legion-review`, `legion-ops`):
+
+1. Go to **GitHub Settings → Developer settings → GitHub Apps → New GitHub App**
+2. Set **GitHub App name** to the app name (e.g., `legion-impl`)
+3. Set **Homepage URL** to your repository URL
+4. Uncheck **Webhook → Active** (not needed)
+5. Under **Permissions**, set the permissions from the table above:
+   - For `legion-impl`: Repository → Contents: Read & Write, Pull requests: Read & Write, Issues: Read & Write
+   - For `legion-review`: Repository → Pull requests: Read & Write, Issues: Read & Write
+   - For `legion-ops`: Repository → Contents: Read-only, Pull requests: Read-only, Issues: Read & Write
+6. Under **Where can this GitHub App be installed?**, select "Only on this account"
+7. Click **Create GitHub App**
+8. **Note the App ID** from the app's settings page (shown near the top)
+
+## Step 2: Generate Private Keys
+
+For each app:
+
+1. On the app's settings page, scroll to **Private keys**
+2. Click **Generate a private key**
+3. A `.pem` file downloads automatically
+4. Store it securely (e.g., `/etc/legion/keys/legion-impl.pem`)
+5. Set permissions: `chmod 600 /etc/legion/keys/*.pem`
+
+## Step 3: Install Apps on Repository
+
+For each app:
+
+1. On the app's settings page, click **Install App** in the sidebar
+2. Select your organization/account
+3. Choose **Only select repositories** and pick the target repo
+4. Click **Install**
+5. **Note the Installation ID** from the URL: `https://github.com/settings/installations/<INSTALLATION_ID>`
+
+## Step 4: Configure Daemon Environment
+
+Set these environment variables before starting the daemon. A role is configured only when all three variables are set for that role:
+
+```bash
+# Implementer + Merger identity
+export LEGION_GITHUB_APP_IMPL_ID="<app-id-from-step-1>"
+export LEGION_GITHUB_APP_IMPL_PRIVATE_KEY_PATH="/etc/legion/keys/legion-impl.pem"
+export LEGION_GITHUB_APP_IMPL_INSTALLATION_ID="<installation-id-from-step-3>"
+
+# Reviewer identity
+export LEGION_GITHUB_APP_REVIEW_ID="<app-id>"
+export LEGION_GITHUB_APP_REVIEW_PRIVATE_KEY_PATH="/etc/legion/keys/legion-review.pem"
+export LEGION_GITHUB_APP_REVIEW_INSTALLATION_ID="<installation-id>"
+
+# Ops identity (tester, architect, planner)
+export LEGION_GITHUB_APP_OPS_ID="<app-id>"
+export LEGION_GITHUB_APP_OPS_PRIVATE_KEY_PATH="/etc/legion/keys/legion-ops.pem"
+export LEGION_GITHUB_APP_OPS_INSTALLATION_ID="<installation-id>"
+```
+
+## Step 5: Verify
+
+After starting the daemon, test each role's credentials endpoint:
+
+```bash
+DAEMON_PORT=13370  # or your configured port
+
+# Test impl credentials
+curl -s http://127.0.0.1:$DAEMON_PORT/credentials/impl | jq .
+# Expected: {"token":"ghs_...","expiresAt":"...","gitIdentity":{"name":"legion-impl[bot]","email":"..."}}
+
+# Test review credentials
+curl -s http://127.0.0.1:$DAEMON_PORT/credentials/review | jq .
+
+# Test ops credentials
+curl -s http://127.0.0.1:$DAEMON_PORT/credentials/ops | jq .
+```
+
+A 404 response means that role's credentials are not configured — the daemon will fall back to ambient credentials (the user's personal token) for that role.
+
+## Partial Configuration
+
+Any subset of roles works. If you only need separate identities for implementation and review:
+
+```bash
+# Only configure impl and review — ops workers use ambient credentials
+export LEGION_GITHUB_APP_IMPL_ID="..."
+export LEGION_GITHUB_APP_IMPL_PRIVATE_KEY_PATH="..."
+export LEGION_GITHUB_APP_IMPL_INSTALLATION_ID="..."
+
+export LEGION_GITHUB_APP_REVIEW_ID="..."
+export LEGION_GITHUB_APP_REVIEW_PRIVATE_KEY_PATH="..."
+export LEGION_GITHUB_APP_REVIEW_INSTALLATION_ID="..."
+```
+
+## Token Lifecycle
+
+- Installation tokens expire after **1 hour**
+- The daemon caches tokens and refreshes automatically when within **5 minutes** of expiry
+- The controller fetches fresh credentials before each worker dispatch
+- No background refresh — tokens are generated lazily on demand
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| 400 `github_apps_not_configured` | No App credentials in env | Set the `LEGION_GITHUB_APP_*` env vars |
+| 404 `role_not_configured` | Specific role not configured | Set all 3 env vars for that role |
+| 500 `token_generation_failed` | Key file unreadable or API error | Check key path permissions, verify installation ID |
+| JWT errors in daemon logs | Key format issue | Ensure `.pem` file is PKCS#1 or PKCS#8 format |

--- a/packages/daemon/src/daemon/__tests__/config.test.ts
+++ b/packages/daemon/src/daemon/__tests__/config.test.ts
@@ -113,4 +113,67 @@ describe("daemon config", () => {
       expect(() => loadConfig({ LEGION_ID: "test", LEGION_RUNTIME: "invalid" })).toThrow();
     });
   });
+
+  describe("githubApps", () => {
+    it("is undefined when no github app env vars are set", () => {
+      const config = loadConfig({});
+      expect(config.githubApps).toBeUndefined();
+    });
+
+    it("loads a single configured role when all role vars are present", () => {
+      const config = loadConfig({
+        LEGION_GITHUB_APP_IMPL_ID: "12345",
+        LEGION_GITHUB_APP_IMPL_PRIVATE_KEY_PATH: "/tmp/impl.pem",
+        LEGION_GITHUB_APP_IMPL_INSTALLATION_ID: "777",
+      });
+
+      expect(config.githubApps).toEqual({
+        impl: {
+          appId: "12345",
+          privateKeyPath: "/tmp/impl.pem",
+          installationId: "777",
+        },
+      });
+    });
+
+    it("loads all configured roles simultaneously", () => {
+      const config = loadConfig({
+        LEGION_GITHUB_APP_IMPL_ID: "111",
+        LEGION_GITHUB_APP_IMPL_PRIVATE_KEY_PATH: "/tmp/impl.pem",
+        LEGION_GITHUB_APP_IMPL_INSTALLATION_ID: "222",
+        LEGION_GITHUB_APP_REVIEW_ID: "333",
+        LEGION_GITHUB_APP_REVIEW_PRIVATE_KEY_PATH: "/tmp/review.pem",
+        LEGION_GITHUB_APP_REVIEW_INSTALLATION_ID: "444",
+        LEGION_GITHUB_APP_OPS_ID: "555",
+        LEGION_GITHUB_APP_OPS_PRIVATE_KEY_PATH: "/tmp/ops.pem",
+        LEGION_GITHUB_APP_OPS_INSTALLATION_ID: "666",
+      });
+
+      expect(config.githubApps).toEqual({
+        impl: {
+          appId: "111",
+          privateKeyPath: "/tmp/impl.pem",
+          installationId: "222",
+        },
+        review: {
+          appId: "333",
+          privateKeyPath: "/tmp/review.pem",
+          installationId: "444",
+        },
+        ops: {
+          appId: "555",
+          privateKeyPath: "/tmp/ops.pem",
+          installationId: "666",
+        },
+      });
+    });
+
+    it("does not load partially configured role", () => {
+      const config = loadConfig({
+        LEGION_GITHUB_APP_IMPL_ID: "12345",
+      });
+
+      expect(config.githubApps).toBeUndefined();
+    });
+  });
 });

--- a/packages/daemon/src/daemon/__tests__/github-apps.test.ts
+++ b/packages/daemon/src/daemon/__tests__/github-apps.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { GitHubAppsConfig } from "../config";
+import {
+  exchangeToken,
+  generateJwt,
+  getGitIdentity,
+  modeToRole,
+  TokenManager,
+} from "../github-apps";
+
+function decodeBase64Url(input: string): Buffer {
+  const padded = input + "=".repeat((4 - (input.length % 4)) % 4);
+  const base64 = padded.replace(/-/g, "+").replace(/_/g, "/");
+  return Buffer.from(base64, "base64");
+}
+
+function toPem(label: string, der: ArrayBuffer): string {
+  const base64 = Buffer.from(new Uint8Array(der)).toString("base64");
+  const chunks = base64.match(/.{1,64}/g) ?? [];
+  return [`-----BEGIN ${label}-----`, ...chunks, `-----END ${label}-----`, ""].join("\n");
+}
+
+describe("modeToRole", () => {
+  it("maps all worker modes to expected roles", () => {
+    expect(modeToRole("implement")).toBe("impl");
+    expect(modeToRole("merge")).toBe("impl");
+    expect(modeToRole("review")).toBe("review");
+    expect(modeToRole("test")).toBe("ops");
+    expect(modeToRole("architect")).toBe("ops");
+    expect(modeToRole("plan")).toBe("ops");
+  });
+
+  it("throws for unknown mode", () => {
+    expect(() => modeToRole("unknown")).toThrow("Unknown worker mode: unknown");
+  });
+});
+
+describe("generateJwt", () => {
+  it("creates RS256 JWT with valid signature and expected claims", async () => {
+    const keyPair = await crypto.subtle.generateKey(
+      {
+        name: "RSASSA-PKCS1-v1_5",
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      true,
+      ["sign", "verify"]
+    );
+
+    const exportedPrivate = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+    const privatePem = toPem("PRIVATE KEY", exportedPrivate);
+    const jwt = await generateJwt("12345", privatePem);
+
+    const [headerPart, payloadPart, signaturePart] = jwt.split(".");
+    expect(headerPart).toBeDefined();
+    expect(payloadPart).toBeDefined();
+    expect(signaturePart).toBeDefined();
+
+    const header = JSON.parse(decodeBase64Url(headerPart ?? "").toString("utf8")) as {
+      alg: string;
+      typ: string;
+    };
+    const payload = JSON.parse(decodeBase64Url(payloadPart ?? "").toString("utf8")) as {
+      iss: string;
+      iat: number;
+      exp: number;
+    };
+
+    expect(header).toEqual({ alg: "RS256", typ: "JWT" });
+    expect(payload.iss).toBe("12345");
+    expect(payload.exp - payload.iat).toBe(660);
+
+    const signedInput = `${headerPart}.${payloadPart}`;
+    const isValid = await crypto.subtle.verify(
+      { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+      keyPair.publicKey,
+      new Uint8Array(decodeBase64Url(signaturePart ?? "")).buffer as ArrayBuffer,
+      new TextEncoder().encode(signedInput)
+    );
+    expect(isValid).toBe(true);
+  });
+});
+
+describe("exchangeToken", () => {
+  it("posts to GitHub API and returns token payload", async () => {
+    const fetchFn = mock(async (input: string | URL | Request, init?: RequestInit) => {
+      expect(String(input)).toBe("https://api.github.com/app/installations/42/access_tokens");
+      expect(init?.method).toBe("POST");
+      const headers = init?.headers as Record<string, string>;
+      expect(headers.Authorization).toBe("Bearer jwt-token");
+      expect(headers.Accept).toBe("application/vnd.github+v3+json");
+      expect(headers["User-Agent"]).toBe("legion-daemon");
+
+      return new Response(
+        JSON.stringify({ token: "ghs_abc", expires_at: "2099-01-01T00:00:00Z" }),
+        {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        }
+      );
+    }) as unknown as typeof fetch;
+
+    const result = await exchangeToken("jwt-token", "42", fetchFn);
+    expect(result).toEqual({ token: "ghs_abc", expiresAt: "2099-01-01T00:00:00Z" });
+  });
+
+  it("throws descriptive error on non-2xx response", async () => {
+    const fetchFn = mock(async () => {
+      return new Response(JSON.stringify({ message: "forbidden" }), { status: 403 });
+    }) as unknown as typeof fetch;
+
+    await expect(exchangeToken("jwt-token", "42", fetchFn)).rejects.toThrow(
+      "Failed to exchange GitHub App token"
+    );
+  });
+});
+
+describe("TokenManager", () => {
+  it("returns null when role is not configured", async () => {
+    const manager = new TokenManager({});
+    await expect(manager.getCredentials("impl")).resolves.toBeNull();
+  });
+
+  it("caches token and reuses it before refresh window", async () => {
+    const keyPair = await crypto.subtle.generateKey(
+      {
+        name: "RSASSA-PKCS1-v1_5",
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      true,
+      ["sign", "verify"]
+    );
+    const exportedPrivate = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+    const privatePem = toPem("PRIVATE KEY", exportedPrivate);
+    const readFileFn = mock(async (filePath: string) => {
+      expect(filePath).toBe("/tmp/impl.pem");
+      return privatePem;
+    });
+    const fetchFn = mock(async () => {
+      return new Response(
+        JSON.stringify({ token: "cached-token", expires_at: "2099-01-01T00:00:00Z" }),
+        {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        }
+      );
+    }) as unknown as typeof fetch;
+
+    const config: GitHubAppsConfig = {
+      impl: {
+        appId: "123",
+        privateKeyPath: "/tmp/impl.pem",
+        installationId: "999",
+      },
+    };
+    const manager = new TokenManager(config, fetchFn, readFileFn);
+
+    const first = await manager.getCredentials("impl");
+    const second = await manager.getCredentials("impl");
+
+    expect(first).toEqual({ token: "cached-token", expiresAt: "2099-01-01T00:00:00Z" });
+    expect(second).toEqual({ token: "cached-token", expiresAt: "2099-01-01T00:00:00Z" });
+    expect(readFileFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes token when cached token is within 5 minutes of expiry", async () => {
+    const originalDateNow = Date.now;
+    Date.now = () => 1_700_000_000_000;
+
+    try {
+      const keyPair = await crypto.subtle.generateKey(
+        {
+          name: "RSASSA-PKCS1-v1_5",
+          modulusLength: 2048,
+          publicExponent: new Uint8Array([1, 0, 1]),
+          hash: "SHA-256",
+        },
+        true,
+        ["sign", "verify"]
+      );
+      const exportedPrivate = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+      const privatePem = toPem("PRIVATE KEY", exportedPrivate);
+      const readFileFn = mock(async () => privatePem);
+
+      let callCount = 0;
+      const fetchFn = mock(async () => {
+        callCount += 1;
+        const soonExpiring = new Date(Date.now() + 4 * 60 * 1000).toISOString();
+        const futureExpiring = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+        const response =
+          callCount === 1
+            ? { token: "token-1", expires_at: soonExpiring }
+            : { token: "token-2", expires_at: futureExpiring };
+        return new Response(JSON.stringify(response), {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        });
+      }) as unknown as typeof fetch;
+
+      const manager = new TokenManager(
+        {
+          impl: {
+            appId: "app-1",
+            privateKeyPath: "/tmp/impl.pem",
+            installationId: "inst-1",
+          },
+        },
+        fetchFn,
+        readFileFn
+      );
+
+      const first = await manager.getCredentials("impl");
+      const second = await manager.getCredentials("impl");
+
+      expect(first?.token).toBe("token-1");
+      expect(second?.token).toBe("token-2");
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+    } finally {
+      Date.now = originalDateNow;
+    }
+  });
+
+  it("reports whether role has github app credentials", () => {
+    const manager = new TokenManager({
+      review: {
+        appId: "321",
+        privateKeyPath: "/tmp/review.pem",
+        installationId: "654",
+      },
+    });
+
+    expect(manager.isConfigured("review")).toBe(true);
+    expect(manager.isConfigured("impl")).toBe(false);
+    expect(manager.isConfigured("ops")).toBe(false);
+  });
+
+  it("returns git identity for configured role", () => {
+    const manager = new TokenManager({
+      impl: {
+        appId: "42",
+        privateKeyPath: "/tmp/impl.pem",
+        installationId: "100",
+      },
+    });
+
+    expect(manager.getGitIdentity("impl")).toEqual({
+      name: "legion-impl[bot]",
+      email: "42+legion-impl[bot]@users.noreply.github.com",
+    });
+  });
+
+  it("returns null for unconfigured role", () => {
+    const manager = new TokenManager({});
+    expect(manager.getGitIdentity("impl")).toBeNull();
+  });
+});
+
+describe("getGitIdentity", () => {
+  it("returns identity for impl role", () => {
+    expect(getGitIdentity("impl", "1001")).toEqual({
+      name: "legion-impl[bot]",
+      email: "1001+legion-impl[bot]@users.noreply.github.com",
+    });
+  });
+
+  it("returns identity for review role", () => {
+    expect(getGitIdentity("review", "1002")).toEqual({
+      name: "legion-review[bot]",
+      email: "1002+legion-review[bot]@users.noreply.github.com",
+    });
+  });
+
+  it("returns identity for ops role", () => {
+    expect(getGitIdentity("ops", "1003")).toEqual({
+      name: "legion-ops[bot]",
+      email: "1003+legion-ops[bot]@users.noreply.github.com",
+    });
+  });
+});

--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -43,6 +43,22 @@ describe("daemon server", () => {
     };
   }
 
+  function makeTokenManager(overrides?: {
+    getCredentials?: (role: string) => Promise<{ token: string; expiresAt: string } | null>;
+    isConfigured?: (role: string) => boolean;
+    getGitIdentity?: (role: string) => { name: string; email: string } | null;
+  }): {
+    getCredentials: (role: string) => Promise<{ token: string; expiresAt: string } | null>;
+    isConfigured: (role: string) => boolean;
+    getGitIdentity: (role: string) => { name: string; email: string } | null;
+  } {
+    return {
+      getCredentials: overrides?.getCredentials ?? (async () => null),
+      isConfigured: overrides?.isConfigured ?? (() => false),
+      getGitIdentity: overrides?.getGitIdentity ?? (() => null),
+    };
+  }
+
   async function startTestServer(options?: {
     state?: PersistedWorkerState;
     adapterOverrides?: Partial<RuntimeAdapter>;
@@ -50,6 +66,11 @@ describe("daemon server", () => {
     repoManagerDeps?: RepoManagerDeps;
     runtime?: string;
     tmuxSession?: string;
+    tokenManager?: {
+      getCredentials: (role: string) => Promise<{ token: string; expiresAt: string } | null>;
+      isConfigured: (role: string) => boolean;
+      getGitIdentity: (role: string) => { name: string; email: string } | null;
+    };
   }) {
     createSessionCalls = [];
     let adapter = makeAdapter();
@@ -61,7 +82,7 @@ describe("daemon server", () => {
     if (options?.state) {
       await writeStateFile(stateFilePath, options.state);
     }
-    const { server, stop } = startServer({
+    const serverOptions = {
       port: 0,
       hostname: "127.0.0.1",
       legionId,
@@ -72,7 +93,10 @@ describe("daemon server", () => {
       stateFilePath,
       runtime: options?.runtime,
       tmuxSession: options?.tmuxSession,
-    });
+      ...(options?.tokenManager ? { tokenManager: options.tokenManager } : {}),
+    };
+
+    const { server, stop } = startServer(serverOptions);
     stopServer = stop;
     baseUrl = `http://127.0.0.1:${server.port}`;
   }
@@ -876,6 +900,76 @@ describe("daemon server", () => {
       expect(response.status).toBe(500);
       const body = (await response.json()) as { error: string };
       expect(body.error).toContain("Failed to send prompt");
+    });
+  });
+
+  describe("GET /credentials/{role}", () => {
+    it("returns 400 for invalid role", async () => {
+      await startTestServer();
+      const response = await requestJson("/credentials/invalid");
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error: "invalid_role" });
+    });
+
+    it("returns 400 when token manager not configured", async () => {
+      await startTestServer();
+      const response = await requestJson("/credentials/impl");
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error: "github_apps_not_configured" });
+    });
+
+    it("returns 404 when role not configured", async () => {
+      const tokenManager = makeTokenManager({
+        isConfigured: (role) => role === "impl",
+      });
+      await startTestServer({ tokenManager });
+      const response = await requestJson("/credentials/review");
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({ error: "role_not_configured" });
+    });
+
+    it("returns token for configured role", async () => {
+      const expiresAt = "2026-03-25T12:00:00.000Z";
+      const tokenManager = makeTokenManager({
+        isConfigured: (role) => role === "impl",
+        getCredentials: async (role) =>
+          role === "impl"
+            ? {
+                token: "ghs_abc123",
+                expiresAt,
+              }
+            : null,
+        getGitIdentity: (role) =>
+          role === "impl"
+            ? { name: "legion-impl[bot]", email: "123+legion-impl[bot]@users.noreply.github.com" }
+            : null,
+      });
+      await startTestServer({ tokenManager });
+
+      const response = await requestJson("/credentials/impl");
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        token: "ghs_abc123",
+        expiresAt,
+        gitIdentity: {
+          name: "legion-impl[bot]",
+          email: "123+legion-impl[bot]@users.noreply.github.com",
+        },
+      });
+    });
+
+    it("returns 500 on token generation failure", async () => {
+      const tokenManager = makeTokenManager({
+        isConfigured: () => true,
+        getCredentials: async () => {
+          throw new Error("boom");
+        },
+      });
+      await startTestServer({ tokenManager });
+
+      const response = await requestJson("/credentials/impl");
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({ error: "token_generation_failed" });
     });
   });
 

--- a/packages/daemon/src/daemon/config.ts
+++ b/packages/daemon/src/daemon/config.ts
@@ -3,6 +3,18 @@ import path from "node:path";
 import type { LegionPaths } from "./paths";
 import { resolveLegionPaths } from "./paths";
 
+export interface GitHubAppCredentials {
+  appId: string;
+  privateKeyPath: string;
+  installationId: string;
+}
+
+export interface GitHubAppsConfig {
+  impl?: GitHubAppCredentials;
+  review?: GitHubAppCredentials;
+  ops?: GitHubAppCredentials;
+}
+
 export interface DaemonConfig {
   daemonPort: number;
   legionId?: string;
@@ -16,6 +28,7 @@ export interface DaemonConfig {
   controllerPrompt?: string;
   issueBackend: "linear" | "github";
   runtime: "opencode" | "claude-code";
+  githubApps?: GitHubAppsConfig;
 }
 
 const BASE_DAEMON_PORT = 13370;
@@ -31,6 +44,22 @@ function parseNumber(value: string | undefined, fallback: number): number {
     return fallback;
   }
   return parsed;
+}
+
+function parseGitHubAppRole(
+  appId: string | undefined,
+  privateKeyPath: string | undefined,
+  installationId: string | undefined
+): GitHubAppCredentials | undefined {
+  if (!appId || !privateKeyPath || !installationId) {
+    return undefined;
+  }
+
+  return {
+    appId,
+    privateKeyPath,
+    installationId,
+  };
 }
 
 export function validateControllerPrompt(prompt: string | undefined): void {
@@ -89,6 +118,30 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): DaemonConfig {
     throw new Error(`LEGION_RUNTIME must be 'opencode' or 'claude-code' (got: ${rawRuntime})`);
   }
   const runtime = rawRuntime === "claude-code" ? "claude-code" : "opencode";
+
+  const githubApps: GitHubAppsConfig = {
+    impl: parseGitHubAppRole(
+      env.LEGION_GITHUB_APP_IMPL_ID,
+      env.LEGION_GITHUB_APP_IMPL_PRIVATE_KEY_PATH,
+      env.LEGION_GITHUB_APP_IMPL_INSTALLATION_ID
+    ),
+    review: parseGitHubAppRole(
+      env.LEGION_GITHUB_APP_REVIEW_ID,
+      env.LEGION_GITHUB_APP_REVIEW_PRIVATE_KEY_PATH,
+      env.LEGION_GITHUB_APP_REVIEW_INSTALLATION_ID
+    ),
+    ops: parseGitHubAppRole(
+      env.LEGION_GITHUB_APP_OPS_ID,
+      env.LEGION_GITHUB_APP_OPS_PRIVATE_KEY_PATH,
+      env.LEGION_GITHUB_APP_OPS_INSTALLATION_ID
+    ),
+  };
+
+  const hasGithubAppRoles =
+    githubApps.impl !== undefined ||
+    githubApps.review !== undefined ||
+    githubApps.ops !== undefined;
+
   return {
     daemonPort: parseNumber(env.LEGION_DAEMON_PORT, BASE_DAEMON_PORT),
     legionId,
@@ -102,5 +155,6 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): DaemonConfig {
     controllerPrompt,
     issueBackend,
     runtime,
+    githubApps: hasGithubAppRoles ? githubApps : undefined,
   };
 }

--- a/packages/daemon/src/daemon/github-apps.ts
+++ b/packages/daemon/src/daemon/github-apps.ts
@@ -1,0 +1,226 @@
+import type { GitHubAppsConfig } from "./config";
+
+export type RoleName = "impl" | "review" | "ops";
+
+const MODE_TO_ROLE: Record<string, RoleName> = {
+  implement: "impl",
+  merge: "impl",
+  review: "review",
+  test: "ops",
+  architect: "ops",
+  plan: "ops",
+};
+
+const APP_NAMES: Record<RoleName, string> = {
+  impl: "legion-impl",
+  review: "legion-review",
+  ops: "legion-ops",
+};
+
+function toBase64Url(data: Uint8Array): string {
+  return Buffer.from(data)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function encodeDerLength(length: number): Uint8Array {
+  if (length < 128) {
+    return new Uint8Array([length]);
+  }
+
+  const bytes: number[] = [];
+  let value = length;
+  while (value > 0) {
+    bytes.unshift(value & 0xff);
+    value >>= 8;
+  }
+
+  return new Uint8Array([0x80 | bytes.length, ...bytes]);
+}
+
+function der(tag: number, value: Uint8Array): Uint8Array {
+  const length = encodeDerLength(value.length);
+  return new Uint8Array([tag, ...length, ...value]);
+}
+
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const output = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    output.set(part, offset);
+    offset += part.length;
+  }
+  return output;
+}
+
+function decodeBase64ToBytes(base64: string): Uint8Array {
+  return new Uint8Array(Buffer.from(base64, "base64"));
+}
+
+function parsePem(pem: string): { derBytes: Uint8Array; type: string } {
+  const trimmed = pem.trim();
+  const match = trimmed.match(/-----BEGIN ([^-]+)-----([\s\S]*?)-----END \1-----/);
+  if (!match) {
+    throw new Error("Invalid PEM format for GitHub App private key");
+  }
+
+  const type = match[1]?.trim() ?? "";
+  const body = (match[2] ?? "").replace(/\s+/g, "");
+  if (!body) {
+    throw new Error("GitHub App private key PEM body is empty");
+  }
+
+  return {
+    derBytes: decodeBase64ToBytes(body),
+    type,
+  };
+}
+
+function wrapPkcs1InPkcs8(pkcs1Der: Uint8Array): Uint8Array {
+  const version = der(0x02, new Uint8Array([0x00]));
+  const rsaEncryptionOid = der(
+    0x06,
+    new Uint8Array([0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01])
+  );
+  const nullParam = der(0x05, new Uint8Array());
+  const algorithmIdentifier = der(0x30, concatBytes(rsaEncryptionOid, nullParam));
+  const privateKey = der(0x04, pkcs1Der);
+
+  return der(0x30, concatBytes(version, algorithmIdentifier, privateKey));
+}
+
+async function importPrivateKey(privateKeyPem: string): Promise<CryptoKey> {
+  const { derBytes, type } = parsePem(privateKeyPem);
+  const pkcs8Der =
+    type === "RSA PRIVATE KEY" ? wrapPkcs1InPkcs8(derBytes) : new Uint8Array(derBytes);
+
+  return crypto.subtle.importKey(
+    "pkcs8",
+    pkcs8Der.buffer as ArrayBuffer,
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      hash: "SHA-256",
+    },
+    false,
+    ["sign"]
+  );
+}
+
+export function modeToRole(mode: string): RoleName {
+  const role = MODE_TO_ROLE[mode];
+  if (!role) {
+    throw new Error(`Unknown worker mode: ${mode}`);
+  }
+  return role;
+}
+
+export async function generateJwt(appId: string, privateKeyPem: string): Promise<string> {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const header = { alg: "RS256", typ: "JWT" };
+  const payload = {
+    iss: appId,
+    iat: nowSeconds - 60,
+    exp: nowSeconds + 600,
+  };
+
+  const encodedHeader = toBase64Url(new TextEncoder().encode(JSON.stringify(header)));
+  const encodedPayload = toBase64Url(new TextEncoder().encode(JSON.stringify(payload)));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+
+  const privateKey = await importPrivateKey(privateKeyPem);
+  const signature = await crypto.subtle.sign(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      hash: "SHA-256",
+    },
+    privateKey,
+    new TextEncoder().encode(signingInput)
+  );
+
+  const encodedSignature = toBase64Url(new Uint8Array(signature));
+  return `${signingInput}.${encodedSignature}`;
+}
+
+export async function exchangeToken(
+  jwt: string,
+  installationId: string,
+  fetchFn: typeof fetch = globalThis.fetch
+): Promise<{ token: string; expiresAt: string }> {
+  const response = await fetchFn(
+    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: "application/vnd.github+v3+json",
+        "User-Agent": "legion-daemon",
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const bodyText = await response.text();
+    throw new Error(`Failed to exchange GitHub App token (status ${response.status}): ${bodyText}`);
+  }
+
+  const body = (await response.json()) as { token?: string; expires_at?: string };
+  if (!body.token || !body.expires_at) {
+    throw new Error("Failed to exchange GitHub App token: missing token or expires_at");
+  }
+
+  return {
+    token: body.token,
+    expiresAt: body.expires_at,
+  };
+}
+
+export class TokenManager {
+  private cache = new Map<RoleName, { token: string; expiresAt: string }>();
+
+  constructor(
+    private config: GitHubAppsConfig,
+    private fetchFn: typeof fetch = globalThis.fetch,
+    private readFileFn: (path: string) => Promise<string> = (p) => Bun.file(p).text()
+  ) {}
+
+  async getCredentials(role: RoleName): Promise<{ token: string; expiresAt: string } | null> {
+    const roleConfig = this.config[role];
+    if (!roleConfig) {
+      return null;
+    }
+
+    const cached = this.cache.get(role);
+    if (cached && Date.parse(cached.expiresAt) - Date.now() >= 5 * 60 * 1000) {
+      return cached;
+    }
+
+    const privateKeyPem = await this.readFileFn(roleConfig.privateKeyPath);
+    const jwt = await generateJwt(roleConfig.appId, privateKeyPem);
+    const token = await exchangeToken(jwt, roleConfig.installationId, this.fetchFn);
+    this.cache.set(role, token);
+    return token;
+  }
+
+  isConfigured(role: RoleName): boolean {
+    return this.config[role] !== undefined;
+  }
+
+  getGitIdentity(role: RoleName): { name: string; email: string } | null {
+    const roleConfig = this.config[role];
+    if (!roleConfig) {
+      return null;
+    }
+    return getGitIdentity(role, roleConfig.appId);
+  }
+}
+
+export function getGitIdentity(role: RoleName, appId: string): { name: string; email: string } {
+  const appName = APP_NAMES[role];
+  return {
+    name: `${appName}[bot]`,
+    email: `${appId}+${appName}[bot]@users.noreply.github.com`,
+  };
+}

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -1,6 +1,7 @@
 import { mkdirSync } from "node:fs";
 import { computeControllerSessionId } from "../state/types";
 import { type DaemonConfig, loadConfig, validateControllerPrompt } from "./config";
+import { TokenManager } from "./github-apps";
 import {
   allocatePort,
   readLegionsRegistry,
@@ -134,6 +135,8 @@ export async function startDaemon(
     baseWorkerPort: actualServePort,
   };
 
+  const tokenManager = config.githubApps ? new TokenManager(config.githubApps) : undefined;
+
   const resolvedDeps = resolveDependencies(config, deps);
 
   const sharedServePort = config.baseWorkerPort;
@@ -221,6 +224,7 @@ export async function startDaemon(
             ? `legion-${config.legionId}`
             : undefined,
         getControllerState: () => controllerState,
+        tokenManager,
         shutdownFn: async () => {
           resolvedDeps.setTimeout(async () => {
             await shutdown(true);

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -9,6 +9,7 @@ import {
   WorkerMode,
   type WorkerModeLiteral,
 } from "../state/types";
+import type { RoleName } from "./github-apps";
 import type { LegionPaths } from "./paths";
 import {
   cleanupWorkspace,
@@ -28,6 +29,12 @@ import {
 
 type Server = ReturnType<typeof Bun.serve>;
 
+interface CredentialsProvider {
+  getCredentials(role: RoleName): Promise<{ token: string; expiresAt: string } | null>;
+  isConfigured(role: RoleName): boolean;
+  getGitIdentity(role: RoleName): { name: string; email: string } | null;
+}
+
 export interface ServerOptions {
   port?: number;
   hostname?: string;
@@ -43,6 +50,7 @@ export interface ServerOptions {
   getControllerState?: () => ControllerState | undefined;
   runtime?: string;
   tmuxSession?: string;
+  tokenManager?: CredentialsProvider;
 }
 
 interface ErrorResponse {
@@ -52,6 +60,11 @@ interface ErrorResponse {
 const JSON_HEADERS = { "content-type": "application/json" };
 const MAX_CRASHES = 3;
 const ONE_HOUR_MS = 60 * 60 * 1000;
+const VALID_CREDENTIAL_ROLES: RoleName[] = ["impl", "review", "ops"];
+
+function isRoleName(value: string): value is RoleName {
+  return VALID_CREDENTIAL_ROLES.includes(value as RoleName);
+}
 
 function jsonResponse(payload: unknown, status = 200): Response {
   return new Response(JSON.stringify(payload), { status, headers: JSON_HEADERS });
@@ -563,6 +576,34 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
         if (method === "POST" && url.pathname === "/shutdown") {
           await opts.shutdownFn?.();
           return jsonResponse({ status: "shutting_down" });
+        }
+
+        if (method === "GET" && segments.length === 2 && segments[0] === "credentials") {
+          const role = segments[1];
+          if (!isRoleName(role)) {
+            return badRequest("invalid_role");
+          }
+          if (!opts.tokenManager) {
+            return badRequest("github_apps_not_configured");
+          }
+          if (!opts.tokenManager.isConfigured(role)) {
+            return notFound("role_not_configured");
+          }
+
+          try {
+            const result = await opts.tokenManager.getCredentials(role);
+            if (!result) {
+              return notFound("role_not_configured");
+            }
+            const gitIdentity = opts.tokenManager.getGitIdentity(role);
+            return jsonResponse({
+              token: result.token,
+              expiresAt: result.expiresAt,
+              ...(gitIdentity ? { gitIdentity } : {}),
+            });
+          } catch {
+            return serverError("token_generation_failed");
+          }
         }
 
         return notFound();


### PR DESCRIPTION
Closes #107

## Summary

- Add per-role GitHub App authentication so workers get distinct identities (required for PR review compliance where implementer ≠ reviewer)
- New `github-apps.ts` module: RS256 JWT generation via Web Crypto API, installation token exchange, lazy-refresh caching with 5-minute expiry window
- New `GET /credentials/{role}` daemon endpoint returning `{token, expiresAt, gitIdentity}`
- Mode-to-role mapping: `implement`/`merge` → `impl`, `review` → `review`, `test`/`architect`/`plan` → `ops`
- Config via `LEGION_GITHUB_APP_{IMPL,REVIEW,OPS}_{ID,PRIVATE_KEY_PATH,INSTALLATION_ID}` env vars
- Fallback: unconfigured roles use ambient credentials
- Controller skill documentation for credential fetch before dispatch
- Step-by-step setup guide (`docs/setup/github-apps.md`)
- 14 new unit tests (JWT generation with crypto verification, token caching, refresh, mode mapping, git identity) + 5 server endpoint tests