### PR TITLE
fix: auto-detect GitHub backend format in legion-resolver

### DIFF
--- a/packages/daemon/src/cli/legion-resolver.ts
+++ b/packages/daemon/src/cli/legion-resolver.ts
@@ -35,7 +35,8 @@ export async function resolveLegionId(
   const backend = typeof options === "string" ? undefined : options?.backend;
 
   // GitHub backend: legion ref is already the ID (owner/project-number)
-  if (backend === "github") {
+  // Auto-detect GitHub format: contains '/' and ends with a number (e.g., 'owner/2')
+  if (backend === "github" || /^[^/]+\/\d+$/.test(legionRef)) {
     return legionRef;
   }
 


### PR DESCRIPTION
## Summary
- Auto-detect GitHub backend format in `legion-resolver.ts` when the legion ref matches `owner/number` pattern (e.g., `sjawhar/2`)
- Previously required explicit `--backend github` flag; now infers it from the ref format via `/^[^\/]+\/\d+$/.test(legionRef)`