### PR TITLE
fix(ci): handle first release where version is already correct

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,7 +180,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add package.json packages/daemon/package.json packages/opencode-plugin/package.json
-          git commit -m "chore: release v${VERSION} [skip ci]"
+          git diff --staged --quiet || git commit -m "chore: release v${VERSION} [skip ci]"
           git tag "v${VERSION}"
           git push origin main --tags
 


### PR DESCRIPTION
## Summary
- Fix release workflow failing on first release when package.json already has the target version
- Skip `git commit` when there are no staged changes (version unchanged), but still tag and push