### PR TITLE
sjawhar-legion-122: Add .legion/ handoff file preservation guidance to worker workflows

### DIFF
--- a/.opencode/skills/legion-worker/workflows/implement.md
+++ b/.opencode/skills/legion-worker/workflows/implement.md
@@ -215,6 +215,8 @@ jj diff --stat --from main    # File count should match expectations — no unre
 
 If unrelated commits are in the ancestry, rebase to isolate your changes before creating the PR.
 
+**Note:** `.legion/` handoff files (written in step 7.5) are expected in the diff — they are part of the PR deliverable, not build artifacts. Do not remove them or add `.legion/` to `.gitignore`.
+
 **CRITICAL: The PR body MUST include `Closes #$ISSUE_NUMBER`.** This is how GitHub links PRs to
 issues and auto-closes them on merge. Without it, merged PRs leave orphaned issues that stall
 the pipeline. This is NOT optional.

--- a/.opencode/skills/legion-worker/workflows/merge.md
+++ b/.opencode/skills/legion-worker/workflows/merge.md
@@ -40,6 +40,8 @@ If rebase produces conflicts:
   - **Linear:** `linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="...")`
 - Exit
 
+**Protected files:** The `.legion/` directory contains handoff data between pipeline phases. These files are intentional and must be preserved during merge — do not remove them or add `.legion/` to `.gitignore`.
+
 ### 4. Push
 
 ```bash

--- a/.opencode/skills/legion-worker/workflows/review.md
+++ b/.opencode/skills/legion-worker/workflows/review.md
@@ -64,6 +64,16 @@ legion handoff messages --workspace . 2>/dev/null || echo '[]'
 
 Messages may contain warnings, blockers, or context from earlier workers.
 
+### 1.5. Protected Files — Do NOT Flag
+
+The `.legion/` directory contains **structured handoff data** committed intentionally as part of the Legion pipeline. Files include: `architect.json`, `plan.json`, `implement.json`, `test.json`, `review.json`, `retro.json`.
+
+- They carry context between pipeline phases (architect → planner → implementer → tester → reviewer)
+- They provide human reviewers with visibility into what information was passed between agents
+- They are NOT build artifacts, NOT tooling debris, and must NOT be added to `.gitignore`
+
+**Do NOT flag `.legion/` files for removal or suggest gitignoring them.** They are part of the PR deliverable.
+
 ### 2. Run Review
 
 Invoke `/ce:review` with the branch name.
@@ -190,3 +200,4 @@ linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "
 | Softening language ("consider", "might want to", "could improve") | Be direct: "This is wrong because X. Fix it." |
 | Passing a PR that has CI failures | CI failures are P1. The implementer's job was to ship with green CI. |
 | Not checking for dropped requirements | Cross-reference every acceptance criterion. A missing criterion is a CRITICAL issue. |
+| Flagging `.legion/` handoff files for removal | `.legion/` files are intentional pipeline data committed by design. Do NOT suggest removing them or adding `.legion/` to `.gitignore`. |


### PR DESCRIPTION
Closes #122

## Summary

Adds explicit guidance to Legion worker workflows so reviewers, mergers, and implementers know that `.legion/` handoff files are intentional pipeline data — not build artifacts to be removed.

- **review.md**: New "Protected Files — Do NOT Flag" section + Common Mistakes table row
- **merge.md**: Preservation note in conflict resolution section
- **implement.md**: Note in Ship section clarifying `.legion/` files are expected in the diff