### PR TITLE
feat: per-role GitHub App credential isolation for workers

### DIFF
--- a/.opencode/skills/legion-controller/SKILL.md
+++ b/.opencode/skills/legion-controller/SKILL.md
@@ -384,6 +384,37 @@ from the issue identifier:
   identifier (format: `owner-repo-number`, e.g. `acme-widgets-42` → `acme/widgets`)
 - **Linear:** `(linear backend)`
 
+### GitHub App Credentials (Worker Identity)
+
+When GitHub App credentials are configured on the daemon, each worker mode maps to a
+specific role identity. The daemon **automatically injects** role-specific credentials
+into each worker's env during `POST /workers` — the controller does not need to fetch
+or pass credentials manually.
+
+**Mode-to-role mapping (handled by daemon):**
+
+| Mode | Role | App Name |
+|------|------|----------|
+| `implement`, `merge` | `impl` | `legion-impl` |
+| `review`, `test`, `architect`, `plan` | `review` | `legion-review` |
+
+**How it works:**
+1. Controller dispatches worker normally (no credential handling needed)
+2. Daemon's `POST /workers` automatically:
+   - Maps mode → role
+   - Generates a fresh installation token for that role
+   - Stores `GH_TOKEN`, `GIT_AUTHOR_*`, `GIT_COMMITTER_*` in worker's env
+3. Worker startup sequence fetches env from `GET /workers/{id}/env`
+4. Worker uses role-specific identity for all `gh` and `jj` operations
+
+**Important constraints:**
+- Never call `gh auth login`, `git config --global`, or write to `~/.config/gh/` or `~/.gitconfig`
+- Credential injection is automatic — no `--env` flag needed for credentials
+- If credentials are not configured for a role, workers use ambient credentials
+- Tokens expire after ~1 hour; the daemon refreshes automatically
+- Workers on separate role serves cannot access other roles' credentials (process isolation)
+- Private key paths are scrubbed from all serve environments
+
 ### Dispatch (New Worker)
 
 **Always use skill invocation (`/skill-name`), not file paths.** Workers load skills via the

--- a/.opencode/skills/legion-worker/SKILL.md
+++ b/.opencode/skills/legion-worker/SKILL.md
@@ -58,6 +58,27 @@ jj rebase -d main
 jj new  # Fresh commit for this session
 ```
 
+Fetch per-worker environment variables from the daemon (non-blocking):
+
+```bash
+# Fetch and export per-worker env vars (requires LEGION_DAEMON_PORT)
+# ISSUE_ID and MODE are extracted from your dispatch prompt (see "Context from Prompt" above).
+# Example: dispatched with "implement mode for sjawhar-legion-106" → ISSUE_ID=sjawhar-legion-106, MODE=implement
+if [ -n "$LEGION_DAEMON_PORT" ]; then
+  _WORKER_ID="$(echo "${ISSUE_ID}-${MODE}" | tr '[:upper:]' '[:lower:]')"
+  _ENV_FILE=$(mktemp) && \
+    curl -fsS "http://127.0.0.1:$LEGION_DAEMON_PORT/workers/$_WORKER_ID/env" 2>/dev/null \
+    | jq -r '.env // {} | to_entries[] | "export " + .key + "=" + (.value | @sh)' \
+    > "$_ENV_FILE" && \
+    . "$_ENV_FILE"; \
+    rm -f "$_ENV_FILE"
+fi
+```
+
+The daemon stores per-worker env vars passed via `legion dispatch --env '{"KEY":"VALUE"}'`.
+This step retrieves them so tools like `gh` and `jj` see role-specific credentials. If the
+endpoint is unavailable or returns empty, the worker proceeds with the shared process environment.
+
 Optionally read prior handoff data (advisory, non-blocking):
 
 ```bash

--- a/.opencode/skills/legion-worker/workflows/review.md
+++ b/.opencode/skills/legion-worker/workflows/review.md
@@ -4,10 +4,11 @@ Deep PR review with line-level comments. Code is already local in the workspace.
 
 **Your job is to protect the codebase.** Be direct, be specific, and do not soften your findings. If the code is wrong, say it's wrong. If a requirement was dropped, that's a CRITICAL issue — not a suggestion. Do not praise the implementer for effort. Focus exclusively on whether the code meets the requirements and is correct.
 
-## Constraint
+## Identity
 
-**Cannot approve/request changes via GitHub API** - same user as PR author.
-Signal outcome via PR draft status instead (draft = changes requested, ready = approved).
+When GitHub Apps are configured, you run as `legion-review[bot]` — a separate identity from
+the implementer (`legion-impl[bot]`). This means you CAN use GitHub's native review API.
+If Apps are not configured, fall back to PR draft status signaling (legacy).
 
 ## Workflow
 
@@ -160,18 +161,29 @@ Replace the example counts and findings with actual review results:
 You MUST attempt the handoff write before setting PR draft status or signaling completion. The `|| true` ensures CLI failures don't block you, but skipping this step entirely is not acceptable. If the write fails, note it in your PR comment.
 
 
-### 5. Set PR Draft Status
+### 5. Submit Review
 
-**Order matters:** Set draft status BEFORE `worker-done` to avoid race condition with controller.
+**Order matters:** Submit review BEFORE `worker-done` to avoid race condition with controller.
 
-Every review MUST set the PR draft status based on findings. This is how the controller knows the review outcome.
+Every review MUST signal its outcome. Use native GitHub review when running under a separate identity:
 
 ```bash
-# If any CRITICAL/P1 issues found — convert to draft (changes requested):
-gh pr ready "$LEGION_ISSUE_ID" --undo
-
-# If no CRITICAL issues — mark ready for merge (approved):
-gh pr ready "$LEGION_ISSUE_ID"
+# Check if running as App-based reviewer (LEGION_APP_ROLE set by daemon credential injection)
+if [ "$LEGION_APP_ROLE" = "review" ]; then
+  # Native review — running as legion-review[bot], separate identity from implementer
+  if [[ $CRITICAL_COUNT -gt 0 ]]; then
+    gh pr review "$LEGION_ISSUE_ID" --request-changes --body "Changes requested: $CRITICAL_COUNT critical issue(s) found. See review comments." -R $OWNER/$REPO
+  else
+    gh pr review "$LEGION_ISSUE_ID" --approve --body "Approved. No critical issues found." -R $OWNER/$REPO
+  fi
+else
+  # Legacy fallback — same identity as implementer, can't use review API
+  if [[ $CRITICAL_COUNT -gt 0 ]]; then
+    gh pr ready "$LEGION_ISSUE_ID" --undo -R $OWNER/$REPO
+  else
+    gh pr ready "$LEGION_ISSUE_ID" -R $OWNER/$REPO
+  fi
+fi
 ```
 
 ### 6. Signal Completion

--- a/docs/setup/github-apps.md
+++ b/docs/setup/github-apps.md
@@ -1,0 +1,138 @@
+# GitHub App Setup for Worker Identity
+
+Legion uses GitHub Apps to give each worker role a distinct identity. This enables proper PR review flows where the implementer and reviewer are different actors — GitHub blocks same-actor PR approvals.
+
+## Why GitHub Apps?
+
+- **PR compliance**: Implementer and reviewer must be different identities
+- **Least privilege**: Each role gets only the permissions it needs
+- **Free**: GitHub Apps don't consume org seats
+- **Audit trail**: Commits and PR actions are attributed to specific roles
+- **Process isolation**: Each role runs in a separate serve process with its own credentials
+
+## Architecture
+
+Two GitHub Apps, one per role group:
+
+| App Name | Used By | Permissions |
+|----------|---------|-------------|
+| `legion-impl` | Implementer, Merger | Contents: write, Pull requests: write, Issues: write |
+| `legion-review` | Reviewer, Tester, Architect, Planner, Controller | Pull requests: write, Issues: write |
+
+### Isolation Model
+
+When configured, the daemon starts **separate `opencode serve` instances per role**:
+
+```
+Daemon Process
+├── Controller serve (port 13381) — user's personal identity
+├── impl serve (port 13382) — legion-impl[bot] token
+└── review serve (port 13383) — legion-review[bot] token
+```
+
+Each serve process has:
+- Role-specific `GH_TOKEN` (installation token, auto-refreshed)
+- `GH_CONFIG_DIR=/dev/null` (prevents gh CLI from finding personal credentials)
+- Scrubbed `GITHUB_TOKEN`, `GH_HOST` (prevents ambient credential leakage)
+
+Workers on one serve **cannot read another serve's environment variables** (separate processes).
+
+**Remaining limitations**: Workers share the OS user. A determined misbehaving worker with knowledge of the host filesystem could potentially read `/proc/{pid}/environ` of other serves. For full isolation, use separate OS users (future improvement).
+
+## Step 1: Create the GitHub Apps
+
+For each of the two apps (`legion-impl`, `legion-review`):
+
+1. Go to **GitHub Settings → Developer settings → GitHub Apps → New GitHub App**
+2. Set **GitHub App name** to the app name (e.g., `legion-impl`)
+3. Set **Homepage URL** to your repository URL
+4. Uncheck **Webhook → Active** (not needed)
+5. Under **Permissions**, set the permissions from the table above:
+   - For `legion-impl`: Repository → Contents: Read & Write, Pull requests: Read & Write, Issues: Read & Write
+   - For `legion-review`: Repository → Pull requests: Read & Write, Issues: Read & Write
+6. Under **Where can this GitHub App be installed?**, select "Only on this account" (or make public if installing across orgs)
+7. Click **Create GitHub App**
+8. **Note the App ID** from the app's settings page (shown near the top)
+
+## Step 2: Generate Private Keys
+
+For each app:
+
+1. On the app's settings page, scroll to **Private keys**
+2. Click **Generate a private key**
+3. A `.pem` file downloads automatically
+4. Store it securely (e.g., `/etc/legion/keys/legion-impl.pem`)
+5. Set permissions: `chmod 600 /etc/legion/keys/*.pem`
+
+## Step 3: Install Apps on Repository
+
+For each app:
+
+1. On the app's settings page, click **Install App** in the sidebar
+2. Select your organization/account
+3. Choose **Only select repositories** and pick the target repo
+4. Click **Install**
+5. **Note the Installation ID** from the URL: `https://github.com/settings/installations/<INSTALLATION_ID>`
+
+## Step 4: Configure Daemon Environment
+
+Set these environment variables before starting the daemon. A role is configured only when all three variables are set for that role:
+
+```bash
+# Implementer + Merger identity
+export LEGION_GITHUB_APP_IMPL_ID="<app-id-from-step-1>"
+export LEGION_GITHUB_APP_IMPL_PRIVATE_KEY_PATH="/etc/legion/keys/legion-impl.pem"
+export LEGION_GITHUB_APP_IMPL_INSTALLATION_ID="<installation-id-from-step-3>"
+
+# Reviewer + Tester + Architect + Planner identity
+export LEGION_GITHUB_APP_REVIEW_ID="<app-id>"
+export LEGION_GITHUB_APP_REVIEW_PRIVATE_KEY_PATH="/etc/legion/keys/legion-review.pem"
+export LEGION_GITHUB_APP_REVIEW_INSTALLATION_ID="<installation-id>"
+```
+
+## Step 5: Verify
+
+After starting the daemon, verify credentials are working by dispatching a test worker
+and checking its injected environment:
+
+```bash
+DAEMON_PORT=13370  # or your configured port
+
+# Dispatch a test worker
+curl -s http://127.0.0.1:$DAEMON_PORT/workers -X POST \
+  -H 'content-type: application/json' \
+  -d '{"issueId": "verify-test", "mode": "implement", "workspace": "/tmp/verify"}' | jq .
+# Expected: {"id": "verify-test-implement", "port": ..., "sessionId": ...}
+
+# Check the worker's env for injected credentials (credential values are stripped for security)
+curl -s http://127.0.0.1:$DAEMON_PORT/workers/verify-test-implement/env | jq .
+# Expected: {"env": {}} or {"env": {"CUSTOM_KEY": "value"}} (only non-credential vars shown)
+
+# Check daemon logs for credential injection messages
+# You should see: 'Role serves started: impl:13382, review:13383'
+# If a role fails, you'll see: 'Failed to inject role credentials for ...'
+
+# Cleanup the test worker
+curl -s http://127.0.0.1:$DAEMON_PORT/workers/verify-test-implement -X DELETE | jq .
+```
+
+If no role serves start (no `Role serves started` log line), check that all three env vars
+are set for at least one role. Partial configuration (e.g., missing `_PRIVATE_KEY_PATH`) silently
+skips that role.
+
+## Token Lifecycle
+
+- Installation tokens expire after **1 hour**
+- The daemon caches tokens and refreshes automatically when within **5 minutes** of expiry
+- The controller fetches fresh credentials before each worker dispatch
+- The daemon health loop monitors role serves and restarts unhealthy ones with fresh tokens
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| 400 `github_apps_not_configured` | No App credentials in env | Set the `LEGION_GITHUB_APP_*` env vars |
+| 404 `role_not_configured` | Specific role not configured | Set all 3 env vars for that role |
+| 500 `token_generation_failed` | Key file unreadable or API error | Check key path permissions, verify installation ID |
+| JWT errors in daemon logs | Key format issue | Ensure `.pem` file is PKCS#1 or PKCS#8 format |
+| Worker uses wrong identity | Missing env fetch at startup | Check worker's startup log for env fetch errors |

--- a/packages/daemon/src/cli/__tests__/index.test.ts
+++ b/packages/daemon/src/cli/__tests__/index.test.ts
@@ -36,6 +36,7 @@ import {
   getDaemonPort,
   legionsCommand,
   loadLegionsCache,
+  parseEnvJson,
   promptCommand,
   resetCrashesCommand,
   startCommand,
@@ -281,6 +282,53 @@ describe("cmdDispatch", () => {
     expect(JSON.parse((promptInit as RequestInit).body as string)).toEqual({
       text: "/legion-worker implement mode for LEG-42",
     });
+  });
+
+  it("sends env in POST body when provided", async () => {
+    const fetchMock = installFetchMock((input: string | URL) => {
+      const url = input.toString();
+      if (url.endsWith("/health")) {
+        return Promise.resolve(new Response(JSON.stringify({ status: "ok" }), { status: 200 }));
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ id: "leg-42-implement", port: 18000, sessionId: "s-env" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      );
+    });
+    await cmdDispatch("LEG-42", "implement", {
+      daemonPort: 13371,
+      repo: "sjawhar/legion",
+      env: { GH_TOKEN: "ghs_test", GIT_AUTHOR_NAME: "bot[bot]" },
+    });
+
+    const [, postInit] = fetchMock.mock.calls[1] as FetchCall;
+    const body = JSON.parse((postInit as RequestInit).body as string) as Record<string, unknown>;
+    expect(body.env).toEqual({ GH_TOKEN: "ghs_test", GIT_AUTHOR_NAME: "bot[bot]" });
+  });
+
+  it("does not include env in POST body when not provided", async () => {
+    const fetchMock = installFetchMock((input: string | URL) => {
+      const url = input.toString();
+      if (url.endsWith("/health")) {
+        return Promise.resolve(new Response(JSON.stringify({ status: "ok" }), { status: 200 }));
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ id: "leg-42-implement", port: 18000, sessionId: "s-noenv" }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      );
+    });
+    await cmdDispatch("LEG-42", "implement", {
+      daemonPort: 13371,
+      repo: "sjawhar/legion",
+    });
+
+    const [, postInit] = fetchMock.mock.calls[1] as FetchCall;
+    const body = JSON.parse((postInit as RequestInit).body as string) as Record<string, unknown>;
+    expect(body).not.toHaveProperty("env");
   });
 
   it("uses workspace for backward compatibility when provided", async () => {
@@ -1261,5 +1309,26 @@ describe("CLI XDG path migration", () => {
       }
       fs.rmSync(stateHome, { recursive: true, force: true });
     }
+  });
+});
+
+describe("parseEnvJson", () => {
+  it("rejects invalid JSON", () => {
+    expect(() => parseEnvJson("not json")).toThrow("Invalid --env value: must be valid JSON");
+  });
+
+  it("rejects non-string values", () => {
+    expect(() => parseEnvJson('{"KEY": 123}')).toThrow(
+      'Invalid --env value: key "KEY" must have a string value'
+    );
+  });
+
+  it("rejects array value", () => {
+    expect(() => parseEnvJson('["a", "b"]')).toThrow("Invalid --env value: must be a JSON object");
+  });
+
+  it("parses valid JSON object", () => {
+    const result = parseEnvJson('{"KEY": "VALUE"}');
+    expect(result).toEqual({ KEY: "VALUE" });
   });
 });

--- a/packages/daemon/src/cli/index.ts
+++ b/packages/daemon/src/cli/index.ts
@@ -29,6 +29,28 @@ export class CliError extends Error {
   }
 }
 
+export function parseEnvJson(raw: string): Record<string, string> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new CliError("Invalid --env value: must be valid JSON");
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new CliError("Invalid --env value: must be a JSON object");
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  for (const [key, value] of Object.entries(obj)) {
+    if (typeof value !== "string") {
+      throw new CliError(`Invalid --env value: key "${key}" must have a string value`);
+    }
+  }
+
+  return obj as Record<string, string>;
+}
+
 async function readStdin(): Promise<string> {
   const chunks: Buffer[] = [];
   for await (const chunk of Bun.stdin.stream()) {
@@ -67,6 +89,7 @@ interface DispatchOptions {
   repo?: string;
   workspace?: string;
   version?: number;
+  env?: Record<string, string>;
 }
 
 interface PromptOptions {
@@ -349,6 +372,9 @@ export async function cmdDispatch(
     body.workspace = opts.legionDir;
   } else {
     throw new CliError("Either --repo or --workspace is required");
+  }
+  if (opts.env) {
+    body.env = opts.env;
   }
 
   let response: Response;
@@ -795,6 +821,10 @@ export const dispatchCommand = defineCommand({
       description:
         "Session version override for fresh dispatch (e.g., --version 1, then --version 2)",
     },
+    env: {
+      type: "string",
+      description: 'Worker env as JSON object (e.g. --env \'{"KEY":"VALUE"}\')',
+    },
   },
   async run({ args }) {
     try {
@@ -806,14 +836,18 @@ export const dispatchCommand = defineCommand({
         }
         version = parsed;
       }
-      await cmdDispatch(args.issue, args.mode, {
-        // Legacy transition: keep LEGION_DIR fallback for users not passing --workspace.
+      const dispatchOpts: DispatchOptions = {
         legionDir: process.env.LEGION_DIR,
         prompt: args.prompt,
         repo: args.repo,
         workspace: args.workspace,
         version,
-      });
+      };
+      if (args.env) {
+        const envObj = parseEnvJson(args.env as string);
+        dispatchOpts.env = envObj;
+      }
+      await cmdDispatch(args.issue, args.mode, dispatchOpts);
     } catch (e) {
       if (e instanceof CliError) {
         console.error(e.message);

--- a/packages/daemon/src/daemon/__tests__/config.test.ts
+++ b/packages/daemon/src/daemon/__tests__/config.test.ts
@@ -113,4 +113,77 @@ describe("daemon config", () => {
       expect(() => loadConfig({ LEGION_ID: "test", LEGION_RUNTIME: "invalid" })).toThrow();
     });
   });
+
+  describe("githubApps", () => {
+    it("is undefined when no github app env vars are set", () => {
+      const config = loadConfig({});
+      expect(config.githubApps).toBeUndefined();
+    });
+
+    it("loads a single configured role when all role vars are present", () => {
+      const config = loadConfig({
+        LEGION_GITHUB_APP_IMPL_ID: "12345",
+        LEGION_GITHUB_APP_IMPL_PRIVATE_KEY_PATH: "/tmp/impl.pem",
+        LEGION_GITHUB_APP_IMPL_INSTALLATION_ID: "777",
+      });
+
+      expect(config.githubApps).toEqual({
+        impl: {
+          appId: "12345",
+          privateKeyPath: "/tmp/impl.pem",
+          installationId: "777",
+        },
+      });
+    });
+
+    it("loads all configured roles simultaneously", () => {
+      const config = loadConfig({
+        LEGION_GITHUB_APP_IMPL_ID: "111",
+        LEGION_GITHUB_APP_IMPL_PRIVATE_KEY_PATH: "/tmp/impl.pem",
+        LEGION_GITHUB_APP_IMPL_INSTALLATION_ID: "222",
+        LEGION_GITHUB_APP_REVIEW_ID: "333",
+        LEGION_GITHUB_APP_REVIEW_PRIVATE_KEY_PATH: "/tmp/review.pem",
+        LEGION_GITHUB_APP_REVIEW_INSTALLATION_ID: "444",
+      });
+
+      expect(config.githubApps).toEqual({
+        impl: {
+          appId: "111",
+          privateKeyPath: "/tmp/impl.pem",
+          installationId: "222",
+        },
+        review: {
+          appId: "333",
+          privateKeyPath: "/tmp/review.pem",
+          installationId: "444",
+        },
+      });
+    });
+
+    it("does not load partially configured role", () => {
+      const config = loadConfig({
+        LEGION_GITHUB_APP_IMPL_ID: "12345",
+      });
+
+      expect(config.githubApps).toBeUndefined();
+    });
+
+    it("loads only fully configured roles from mixed env", () => {
+      const config = loadConfig({
+        LEGION_GITHUB_APP_IMPL_ID: "111",
+        LEGION_GITHUB_APP_IMPL_PRIVATE_KEY_PATH: "/tmp/impl.pem",
+        LEGION_GITHUB_APP_IMPL_INSTALLATION_ID: "222",
+        LEGION_GITHUB_APP_REVIEW_ID: "333",
+        // review missing PRIVATE_KEY_PATH and INSTALLATION_ID
+      });
+
+      expect(config.githubApps).toEqual({
+        impl: {
+          appId: "111",
+          privateKeyPath: "/tmp/impl.pem",
+          installationId: "222",
+        },
+      });
+    });
+  });
 });

--- a/packages/daemon/src/daemon/__tests__/github-apps.test.ts
+++ b/packages/daemon/src/daemon/__tests__/github-apps.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { GitHubAppsConfig } from "../config";
+import {
+  buildRoleEnv,
+  exchangeToken,
+  generateJwt,
+  getGitIdentity,
+  modeToRole,
+  TokenManager,
+} from "../github-apps";
+
+function decodeBase64Url(input: string): Buffer {
+  const padded = input + "=".repeat((4 - (input.length % 4)) % 4);
+  const base64 = padded.replace(/-/g, "+").replace(/_/g, "/");
+  return Buffer.from(base64, "base64");
+}
+
+function toPem(label: string, der: ArrayBuffer): string {
+  const base64 = Buffer.from(new Uint8Array(der)).toString("base64");
+  const chunks = base64.match(/.{1,64}/g) ?? [];
+  return [`-----BEGIN ${label}-----`, ...chunks, `-----END ${label}-----`, ""].join("\n");
+}
+
+async function generateTestKeyPair() {
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"]
+  );
+  const exportedPrivate = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+  return {
+    privatePem: toPem("PRIVATE KEY", exportedPrivate),
+    publicKey: keyPair.publicKey,
+  };
+}
+
+describe("modeToRole", () => {
+  it("maps implement and merge to impl", () => {
+    expect(modeToRole("implement")).toBe("impl");
+    expect(modeToRole("merge")).toBe("impl");
+  });
+
+  it("maps review to review", () => {
+    expect(modeToRole("review")).toBe("review");
+  });
+
+  it("maps test, architect, plan to review", () => {
+    expect(modeToRole("test")).toBe("review");
+    expect(modeToRole("architect")).toBe("review");
+    expect(modeToRole("plan")).toBe("review");
+  });
+
+  it("throws for unknown mode", () => {
+    expect(() => modeToRole("unknown")).toThrow("Unknown worker mode: unknown");
+  });
+});
+
+describe("getGitIdentity", () => {
+  it("returns bot-format name and email", () => {
+    const identity = getGitIdentity("12345", "legion-impl");
+    expect(identity).toEqual({
+      name: "legion-impl[bot]",
+      email: "12345+legion-impl[bot]@users.noreply.github.com",
+    });
+  });
+});
+
+describe("generateJwt", () => {
+  it("creates RS256 JWT with valid signature and expected claims", async () => {
+    const { privatePem, publicKey } = await generateTestKeyPair();
+    const jwt = await generateJwt("12345", privatePem);
+
+    const parts = jwt.split(".");
+    expect(parts).toHaveLength(3);
+    const headerPart = parts[0];
+    const payloadPart = parts[1];
+    const signaturePart = parts[2];
+
+    const header = JSON.parse(decodeBase64Url(headerPart).toString("utf8")) as {
+      alg: string;
+      typ: string;
+    };
+    const payload = JSON.parse(decodeBase64Url(payloadPart).toString("utf8")) as {
+      iss: string;
+      iat: number;
+      exp: number;
+    };
+
+    expect(header).toEqual({ alg: "RS256", typ: "JWT" });
+    expect(payload.iss).toBe("12345");
+    expect(payload.exp - payload.iat).toBe(660); // 60s drift + 600s = 660s window
+
+    const signedInput = `${headerPart}.${payloadPart}`;
+    const isValid = await crypto.subtle.verify(
+      { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+      publicKey,
+      new Uint8Array(decodeBase64Url(signaturePart)).buffer as ArrayBuffer,
+      new TextEncoder().encode(signedInput)
+    );
+    expect(isValid).toBe(true);
+  });
+});
+
+describe("exchangeToken", () => {
+  it("posts to GitHub API and returns token payload", async () => {
+    const fetchFn = mock(async (input: string | URL | Request, init?: RequestInit) => {
+      expect(String(input)).toBe("https://api.github.com/app/installations/42/access_tokens");
+      expect(init?.method).toBe("POST");
+      const headers = init?.headers as Record<string, string>;
+      expect(headers.Authorization).toBe("Bearer jwt-token");
+      expect(headers.Accept).toBe("application/vnd.github+v3+json");
+      expect(headers["User-Agent"]).toBe("legion-daemon");
+
+      return new Response(
+        JSON.stringify({ token: "ghs_abc", expires_at: "2099-01-01T00:00:00Z" }),
+        { status: 201, headers: { "content-type": "application/json" } }
+      );
+    }) as unknown as typeof fetch;
+
+    const result = await exchangeToken("jwt-token", "42", fetchFn);
+    expect(result).toEqual({ token: "ghs_abc", expiresAt: "2099-01-01T00:00:00Z" });
+  });
+
+  it("throws descriptive error on non-2xx response", async () => {
+    const fetchFn = mock(async () => {
+      return new Response(JSON.stringify({ message: "forbidden" }), { status: 403 });
+    }) as unknown as typeof fetch;
+
+    await expect(exchangeToken("jwt", "42", fetchFn)).rejects.toThrow(
+      "GitHub App token exchange failed (403)"
+    );
+  });
+});
+
+describe("TokenManager", () => {
+  const implConfig: GitHubAppsConfig = {
+    impl: {
+      appId: "111",
+      privateKeyPath: "/tmp/impl.pem",
+      installationId: "222",
+    },
+  };
+
+  it("reports configured roles", () => {
+    const manager = new TokenManager(implConfig);
+    expect(manager.isConfigured("impl")).toBe(true);
+    expect(manager.isConfigured("review")).toBe(false);
+    expect(manager.getConfiguredRoles()).toEqual(["impl"]);
+  });
+
+  it("throws for unconfigured role", async () => {
+    const manager = new TokenManager(implConfig);
+    await expect(manager.getToken("review")).rejects.toThrow("role_not_configured: review");
+  });
+
+  it("generates and caches tokens", async () => {
+    const { privatePem } = await generateTestKeyPair();
+    let fetchCalls = 0;
+
+    const fetchFn = mock(async () => {
+      fetchCalls++;
+      const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      return new Response(
+        JSON.stringify({ token: `ghs_token_${fetchCalls}`, expires_at: expiresAt }),
+        { status: 201, headers: { "content-type": "application/json" } }
+      );
+    }) as unknown as typeof fetch;
+
+    const readFile = mock(async () => privatePem);
+
+    const manager = new TokenManager(implConfig, { fetchFn, readFile });
+
+    const first = await manager.getToken("impl");
+    expect(first.token).toBe("ghs_token_1");
+    expect(first.gitIdentity.name).toBe("legion-impl[bot]");
+
+    // Second call should return cached token
+    const second = await manager.getToken("impl");
+    expect(second.token).toBe("ghs_token_1");
+    expect(fetchCalls).toBe(1);
+  });
+
+  it("deduplicates concurrent requests", async () => {
+    const { privatePem } = await generateTestKeyPair();
+    let fetchCalls = 0;
+
+    const fetchFn = mock(async () => {
+      fetchCalls++;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      return new Response(
+        JSON.stringify({ token: `ghs_token_${fetchCalls}`, expires_at: expiresAt }),
+        { status: 201, headers: { "content-type": "application/json" } }
+      );
+    }) as unknown as typeof fetch;
+
+    const readFile = mock(async () => privatePem);
+    const manager = new TokenManager(implConfig, { fetchFn, readFile });
+
+    // Fire two concurrent requests
+    const [r1, r2] = await Promise.all([manager.getToken("impl"), manager.getToken("impl")]);
+
+    expect(r1.token).toBe(r2.token);
+    expect(fetchCalls).toBe(1);
+  });
+});
+
+describe("buildRoleEnv", () => {
+  it("scrubs sensitive env vars and adds role-specific ones", () => {
+    const baseEnv: Record<string, string> = {
+      PATH: "/usr/bin",
+      HOME: "/home/user",
+      GH_TOKEN: "personal-token",
+      GITHUB_TOKEN: "another-token",
+      GH_HOST: "github.com",
+      GH_CONFIG_DIR: "/home/user/.config/gh",
+      LEGION_ID: "team-1",
+    };
+
+    const identity = {
+      name: "legion-impl[bot]",
+      email: "111+legion-impl[bot]@users.noreply.github.com",
+    };
+    const result = buildRoleEnv("ghs_role_token", identity, baseEnv);
+
+    // Scrubbed keys should be absent or replaced
+    expect(result.HOME).toBe("/home/user"); // HOME preserved — GH_CONFIG_DIR handles credential isolation
+    expect(result.GITHUB_TOKEN).toBeUndefined();
+    expect(result.GH_HOST).toBeUndefined();
+
+    // Role-specific values
+    expect(result.GH_TOKEN).toBe("ghs_role_token");
+    expect(result.GH_CONFIG_DIR).toBe("/dev/null");
+    expect(result.GIT_AUTHOR_NAME).toBe("legion-impl[bot]");
+    expect(result.GIT_AUTHOR_EMAIL).toBe("111+legion-impl[bot]@users.noreply.github.com");
+    expect(result.GIT_COMMITTER_NAME).toBe("legion-impl[bot]");
+    expect(result.GIT_COMMITTER_EMAIL).toBe("111+legion-impl[bot]@users.noreply.github.com");
+
+    // Non-sensitive keys preserved
+    expect(result.PATH).toBe("/usr/bin");
+    expect(result.LEGION_ID).toBe("team-1");
+  });
+
+  it("scrubs LEGION_GITHUB_APP_* env vars containing private key paths", () => {
+    const baseEnv: Record<string, string> = {
+      PATH: "/usr/bin",
+      LEGION_ID: "team-1",
+      LEGION_GITHUB_APP_IMPL_ID: "12345",
+      LEGION_GITHUB_APP_IMPL_PRIVATE_KEY_PATH: "/etc/legion/keys/impl.pem",
+      LEGION_GITHUB_APP_IMPL_INSTALLATION_ID: "777",
+      LEGION_GITHUB_APP_REVIEW_ID: "333",
+      LEGION_GITHUB_APP_REVIEW_PRIVATE_KEY_PATH: "/etc/legion/keys/review.pem",
+      LEGION_GITHUB_APP_REVIEW_INSTALLATION_ID: "444",
+    };
+
+    const identity = {
+      name: "legion-impl[bot]",
+      email: "12345+legion-impl[bot]@users.noreply.github.com",
+    };
+    const result = buildRoleEnv("ghs_token", identity, baseEnv);
+
+    // LEGION_GITHUB_APP_* vars should all be scrubbed
+    expect(result.LEGION_GITHUB_APP_IMPL_ID).toBeUndefined();
+    expect(result.LEGION_GITHUB_APP_IMPL_PRIVATE_KEY_PATH).toBeUndefined();
+    expect(result.LEGION_GITHUB_APP_IMPL_INSTALLATION_ID).toBeUndefined();
+    expect(result.LEGION_GITHUB_APP_REVIEW_ID).toBeUndefined();
+    expect(result.LEGION_GITHUB_APP_REVIEW_PRIVATE_KEY_PATH).toBeUndefined();
+    expect(result.LEGION_GITHUB_APP_REVIEW_INSTALLATION_ID).toBeUndefined();
+
+    // Non-LEGION_GITHUB_APP vars preserved
+    expect(result.PATH).toBe("/usr/bin");
+    expect(result.LEGION_ID).toBe("team-1");
+  });
+});

--- a/packages/daemon/src/daemon/__tests__/multi-serve.test.ts
+++ b/packages/daemon/src/daemon/__tests__/multi-serve.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { GitHubAppsConfig } from "../config";
+import { TokenManager } from "../github-apps";
+import { RoleServeManager } from "../multi-serve";
+import type { RuntimeAdapter, RuntimeStartOptions } from "../runtime/types";
+
+function createMockAdapter(port: number): RuntimeAdapter & {
+  startCalls: RuntimeStartOptions[];
+  sessions: Map<string, string>;
+  _healthy: boolean;
+} {
+  const startCalls: RuntimeStartOptions[] = [];
+  const sessions = new Map<string, string>();
+  const _healthy = true;
+
+  return {
+    startCalls,
+    sessions,
+    _healthy,
+    async start(opts: RuntimeStartOptions) {
+      startCalls.push(opts);
+    },
+    async stop() {},
+    async healthy() {
+      return _healthy;
+    },
+    async createSession(sessionId: string, workspace: string) {
+      sessions.set(sessionId, workspace);
+      return sessionId;
+    },
+    async sendPrompt() {},
+    getPort() {
+      return port;
+    },
+    async getSessionStatus() {
+      return { data: { type: "idle" } };
+    },
+  };
+}
+
+function createTestKeyPem(): string {
+  // Minimal valid PEM for test — we won't actually sign JWTs in these tests
+  return "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----";
+}
+
+function createTestConfig(): GitHubAppsConfig {
+  return {
+    impl: {
+      appId: "111",
+      privateKeyPath: "/tmp/impl.pem",
+      installationId: "222",
+    },
+    review: {
+      appId: "333",
+      privateKeyPath: "/tmp/review.pem",
+      installationId: "444",
+    },
+  };
+}
+
+function createTestTokenManager(config: GitHubAppsConfig): TokenManager {
+  const fetchFn = mock(async () => {
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    return new Response(JSON.stringify({ token: "ghs_test_token", expires_at: expiresAt }), {
+      status: 201,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+
+  // Generate a real key pair synchronously for tests
+  const readFile = mock(async () => {
+    // We need a real key for TokenManager — but since we mock fetch,
+    // generateJwt will be called with this key. Let's use a pre-generated one.
+    // Actually, for unit tests of multi-serve, we can mock at a higher level.
+    // Let's create a TokenManager with a fake key that will work with mocked fetch.
+    return createTestKeyPem();
+  });
+
+  return new TokenManager(config, { fetchFn, readFile });
+}
+
+describe("RoleServeManager", () => {
+  it("routes modes to correct adapters", async () => {
+    const config = createTestConfig();
+    const fallback = createMockAdapter(13381);
+
+    // We need a real TokenManager for getConfiguredRoles, but we'll mock
+    // the start to avoid actual crypto operations
+    const manager = new RoleServeManager({
+      githubApps: config,
+      tokenManager: createTestTokenManager(config),
+      runtime: "opencode",
+      basePort: 13382,
+      shortId: "test",
+      fallbackAdapter: fallback,
+    });
+
+    // Before start, all modes should fall back to fallback adapter
+    const preStartAdapter = manager.getAdapterForMode("implement");
+    expect(preStartAdapter).toBe(fallback);
+
+    expect(manager.hasRoleServes()).toBe(false);
+  });
+
+  it("falls back to shared adapter for unconfigured roles", () => {
+    const config: GitHubAppsConfig = {
+      impl: {
+        appId: "111",
+        privateKeyPath: "/tmp/impl.pem",
+        installationId: "222",
+      },
+    };
+    const fallback = createMockAdapter(13381);
+
+    const manager = new RoleServeManager({
+      githubApps: config,
+      tokenManager: createTestTokenManager(config),
+      runtime: "opencode",
+      basePort: 13382,
+      shortId: "test",
+      fallbackAdapter: fallback,
+    });
+
+    // review is not configured, should use fallback
+    const adapter = manager.getAdapterForMode("review");
+    expect(adapter).toBe(fallback);
+  });
+
+  it("getAdapterForRole returns fallback when role not started", () => {
+    // Config with only impl — review should fall back
+    const config: GitHubAppsConfig = {
+      impl: {
+        appId: "111",
+        privateKeyPath: "/tmp/impl.pem",
+        installationId: "222",
+      },
+    };
+    const fallback = createMockAdapter(13381);
+
+    const manager = new RoleServeManager({
+      githubApps: config,
+      tokenManager: createTestTokenManager(config),
+      runtime: "opencode",
+      basePort: 13382,
+      shortId: "test",
+      fallbackAdapter: fallback,
+    });
+
+    // review is not in config
+    expect(manager.getAdapterForRole("review")).toBe(fallback);
+  });
+
+  it("getEntries returns empty before start", () => {
+    const config = createTestConfig();
+    const fallback = createMockAdapter(13381);
+
+    const manager = new RoleServeManager({
+      githubApps: config,
+      tokenManager: createTestTokenManager(config),
+      runtime: "opencode",
+      basePort: 13382,
+      shortId: "test",
+      fallbackAdapter: fallback,
+    });
+
+    expect(manager.getEntries()).toEqual([]);
+  });
+
+  it("stop clears all entries", async () => {
+    const config = createTestConfig();
+    const fallback = createMockAdapter(13381);
+
+    const manager = new RoleServeManager({
+      githubApps: config,
+      tokenManager: createTestTokenManager(config),
+      runtime: "opencode",
+      basePort: 13382,
+      shortId: "test",
+      fallbackAdapter: fallback,
+    });
+
+    await manager.stop();
+    expect(manager.getEntries()).toEqual([]);
+    expect(manager.hasRoleServes()).toBe(false);
+  });
+});

--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -1025,4 +1025,156 @@ describe("daemon server", () => {
       expect(workerIds.length).toBe(5);
     });
   });
+
+  describe("per-worker env", () => {
+    it("POST /workers stores env and GET /workers/{id}/env returns it", async () => {
+      await startTestServer();
+      const createRes = await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({
+          issueId: "ENG-500",
+          mode: "implement",
+          workspace: "/tmp/work-500",
+          env: { GH_TOKEN: "ghs_test", GIT_AUTHOR_NAME: "bot[bot]" },
+        }),
+      });
+      expect(createRes.status).toBe(200);
+      const created = (await createRes.json()) as { id: string };
+
+      const envRes = await requestJson(`/workers/${created.id}/env`);
+      expect(envRes.status).toBe(200);
+      const envBody = (await envRes.json()) as { env: Record<string, string> };
+      // Credential vars are stripped from the response
+      expect(envBody.env).toEqual({});
+    });
+
+    it("GET /workers/{id}/env returns empty when no env set", async () => {
+      await startTestServer();
+      await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({
+          issueId: "ENG-501",
+          mode: "review",
+          workspace: "/tmp/work-501",
+        }),
+      });
+
+      const envRes = await requestJson("/workers/eng-501-review/env");
+      expect(envRes.status).toBe(200);
+      const envBody = (await envRes.json()) as { env: Record<string, string> };
+      expect(envBody.env).toEqual({});
+    });
+
+    it("GET /workers list does not leak env", async () => {
+      await startTestServer();
+      await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({
+          issueId: "ENG-502",
+          mode: "implement",
+          workspace: "/tmp/work-502",
+          env: { SECRET: "should-not-leak", CUSTOM_VAR: "visible" },
+        }),
+      });
+
+      const listRes = await requestJson("/workers");
+      expect(listRes.status).toBe(200);
+      const workers = (await listRes.json()) as Array<Record<string, unknown>>;
+      for (const w of workers) {
+        expect(w).not.toHaveProperty("env");
+      }
+    });
+
+    it("GET /workers/{id} does not leak env", async () => {
+      await startTestServer();
+      await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({
+          issueId: "ENG-503",
+          mode: "implement",
+          workspace: "/tmp/work-503",
+          env: { SECRET: "should-not-leak" },
+        }),
+      });
+
+      const detailRes = await requestJson("/workers/eng-503-implement");
+      expect(detailRes.status).toBe(200);
+      const body = (await detailRes.json()) as Record<string, unknown>;
+      expect(body).not.toHaveProperty("env");
+    });
+
+    it("PATCH /workers/{id} response does not leak env", async () => {
+      await startTestServer();
+      await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({
+          issueId: "ENG-504",
+          mode: "implement",
+          workspace: "/tmp/work-504",
+          env: { SECRET: "should-not-leak" },
+        }),
+      });
+
+      const patchRes = await requestJson("/workers/eng-504-implement", {
+        method: "PATCH",
+        body: JSON.stringify({ status: "stopped" }),
+      });
+      expect(patchRes.status).toBe(200);
+      const body = (await patchRes.json()) as Record<string, unknown>;
+      expect(body).not.toHaveProperty("env");
+    });
+  });
+
+  it("GET /credentials/{role} endpoint is removed", async () => {
+    await startTestServer();
+    const res = await requestJson("/credentials/impl");
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /workers/{id}/env strips credential vars from response", async () => {
+    await startTestServer();
+    await requestJson("/workers", {
+      method: "POST",
+      body: JSON.stringify({
+        issueId: "ENG-510",
+        mode: "implement",
+        workspace: "/tmp/work-510",
+        env: {
+          GH_TOKEN: "ghs_secret",
+          GIT_AUTHOR_NAME: "bot[bot]",
+          GIT_AUTHOR_EMAIL: "bot@example.com",
+          GIT_COMMITTER_NAME: "bot[bot]",
+          GIT_COMMITTER_EMAIL: "bot@example.com",
+          LEGION_APP_ROLE: "impl",
+          CUSTOM_VAR: "visible",
+        },
+      }),
+    });
+
+    const envRes = await requestJson("/workers/eng-510-implement/env");
+    expect(envRes.status).toBe(200);
+    const envBody = (await envRes.json()) as { env: Record<string, string> };
+    // Only non-credential vars should be returned
+    expect(envBody.env).toEqual({ CUSTOM_VAR: "visible" });
+    // Credential vars must not be present
+    expect(envBody.env).not.toHaveProperty("GH_TOKEN");
+    expect(envBody.env).not.toHaveProperty("GIT_AUTHOR_NAME");
+    expect(envBody.env).not.toHaveProperty("LEGION_APP_ROLE");
+  });
+
+  it("POST /workers rejects non-string env values", async () => {
+    await startTestServer();
+    const res = await requestJson("/workers", {
+      method: "POST",
+      body: JSON.stringify({
+        issueId: "ENG-511",
+        mode: "implement",
+        workspace: "/tmp/work-511",
+        env: { GOOD: "string", BAD: 123 },
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('env values must be strings (key "BAD")');
+  });
 });

--- a/packages/daemon/src/daemon/config.ts
+++ b/packages/daemon/src/daemon/config.ts
@@ -3,6 +3,16 @@ import path from "node:path";
 import type { LegionPaths } from "./paths";
 import { resolveLegionPaths } from "./paths";
 
+export type GitHubAppRole = "impl" | "review";
+
+export interface GitHubAppRoleConfig {
+  appId: string;
+  privateKeyPath: string;
+  installationId: string;
+}
+
+export type GitHubAppsConfig = Partial<Record<GitHubAppRole, GitHubAppRoleConfig>>;
+
 export interface DaemonConfig {
   daemonPort: number;
   legionId?: string;
@@ -16,6 +26,7 @@ export interface DaemonConfig {
   controllerPrompt?: string;
   issueBackend: "linear" | "github";
   runtime: "opencode" | "claude-code";
+  githubApps?: GitHubAppsConfig;
 }
 
 const BASE_DAEMON_PORT = 13370;
@@ -89,6 +100,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): DaemonConfig {
     throw new Error(`LEGION_RUNTIME must be 'opencode' or 'claude-code' (got: ${rawRuntime})`);
   }
   const runtime = rawRuntime === "claude-code" ? "claude-code" : "opencode";
+  const githubApps = loadGitHubApps(env);
   return {
     daemonPort: parseNumber(env.LEGION_DAEMON_PORT, BASE_DAEMON_PORT),
     legionId,
@@ -102,5 +114,27 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): DaemonConfig {
     controllerPrompt,
     issueBackend,
     runtime,
+    githubApps,
   };
+}
+
+const GITHUB_APP_ROLES: GitHubAppRole[] = ["impl", "review"];
+
+function loadGitHubApps(env: NodeJS.ProcessEnv): GitHubAppsConfig | undefined {
+  const config: GitHubAppsConfig = {};
+  let hasAny = false;
+
+  for (const role of GITHUB_APP_ROLES) {
+    const prefix = `LEGION_GITHUB_APP_${role.toUpperCase()}`;
+    const appId = env[`${prefix}_ID`];
+    const privateKeyPath = env[`${prefix}_PRIVATE_KEY_PATH`];
+    const installationId = env[`${prefix}_INSTALLATION_ID`];
+
+    if (appId && privateKeyPath && installationId) {
+      config[role] = { appId, privateKeyPath, installationId };
+      hasAny = true;
+    }
+  }
+
+  return hasAny ? config : undefined;
 }

--- a/packages/daemon/src/daemon/github-apps.ts
+++ b/packages/daemon/src/daemon/github-apps.ts
@@ -1,0 +1,254 @@
+import { createPrivateKey } from "node:crypto";
+import type { GitHubAppRole, GitHubAppsConfig } from "./config";
+
+const MODE_TO_ROLE: Record<string, GitHubAppRole> = {
+  implement: "impl",
+  merge: "impl",
+  review: "review",
+  test: "review",
+  architect: "review",
+  plan: "review",
+};
+
+const ROLE_TO_APP_NAME: Record<GitHubAppRole, string> = {
+  impl: "legion-impl",
+  review: "legion-review",
+};
+
+/** Token refresh window — regenerate when within 5 minutes of expiry */
+const REFRESH_WINDOW_MS = 5 * 60 * 1000;
+
+export function modeToRole(mode: string): GitHubAppRole {
+  const role = MODE_TO_ROLE[mode];
+  if (!role) {
+    throw new Error(`Unknown worker mode: ${mode}`);
+  }
+  return role;
+}
+
+export function getGitIdentity(appId: string, appName: string): { name: string; email: string } {
+  return {
+    name: `${appName}[bot]`,
+    email: `${appId}+${appName}[bot]@users.noreply.github.com`,
+  };
+}
+
+function toBase64Url(buffer: ArrayBuffer | Uint8Array): string {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  return Buffer.from(bytes)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function toPkcs8Pem(privateKeyPem: string): string {
+  if (privateKeyPem.includes("BEGIN PRIVATE KEY")) {
+    return privateKeyPem;
+  }
+  // PKCS#1 → PKCS#8 via node:crypto
+  return createPrivateKey(privateKeyPem).export({
+    type: "pkcs8",
+    format: "pem",
+  }) as string;
+}
+
+function pemToDer(pem: string): ArrayBuffer {
+  const base64 = pem
+    .replace(/-----BEGIN [^-]+-----/, "")
+    .replace(/-----END [^-]+-----/, "")
+    .replace(/\s/g, "");
+  const binary = Buffer.from(base64, "base64");
+  return binary.buffer.slice(binary.byteOffset, binary.byteOffset + binary.byteLength);
+}
+
+export async function generateJwt(appId: string, privateKeyPem: string): Promise<string> {
+  const pkcs8Pem = toPkcs8Pem(privateKeyPem);
+  const der = pemToDer(pkcs8Pem);
+
+  const key = await crypto.subtle.importKey(
+    "pkcs8",
+    der,
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = toBase64Url(
+    new TextEncoder().encode(JSON.stringify({ alg: "RS256", typ: "JWT" }))
+  );
+  const payload = toBase64Url(
+    new TextEncoder().encode(JSON.stringify({ iss: appId, iat: now - 60, exp: now + 600 }))
+  );
+  const signingInput = `${header}.${payload}`;
+  const signature = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    key,
+    new TextEncoder().encode(signingInput)
+  );
+
+  return `${signingInput}.${toBase64Url(signature)}`;
+}
+
+export async function exchangeToken(
+  jwt: string,
+  installationId: string,
+  fetchFn: typeof fetch = globalThis.fetch
+): Promise<{ token: string; expiresAt: string }> {
+  const url = `https://api.github.com/app/installations/${installationId}/access_tokens`;
+  const res = await fetchFn(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      Accept: "application/vnd.github+v3+json",
+      "User-Agent": "legion-daemon",
+    },
+  });
+
+  if (!res.ok) {
+    let body = "";
+    try {
+      body = await res.text();
+    } catch {
+      // ignore
+    }
+    throw new Error(`GitHub App token exchange failed (${res.status}): ${body}`);
+  }
+
+  const data = (await res.json()) as { token: string; expires_at: string };
+  return { token: data.token, expiresAt: data.expires_at };
+}
+
+interface CachedToken {
+  token: string;
+  expiresAt: Date;
+  gitIdentity: { name: string; email: string };
+}
+
+export class TokenManager {
+  private readonly cache = new Map<GitHubAppRole, CachedToken>();
+  private readonly pending = new Map<GitHubAppRole, Promise<CachedToken>>();
+  private readonly keyCache = new Map<GitHubAppRole, string>();
+  private readonly fetchFn: typeof fetch;
+  private readonly readFile: (path: string) => Promise<string>;
+
+  constructor(
+    private readonly config: GitHubAppsConfig,
+    opts?: {
+      fetchFn?: typeof fetch;
+      readFile?: (path: string) => Promise<string>;
+    }
+  ) {
+    this.fetchFn = opts?.fetchFn ?? globalThis.fetch;
+    this.readFile = opts?.readFile ?? ((p: string) => Bun.file(p).text());
+  }
+
+  isConfigured(role: GitHubAppRole): boolean {
+    return this.config[role] !== undefined;
+  }
+
+  getConfiguredRoles(): GitHubAppRole[] {
+    return (Object.keys(this.config) as GitHubAppRole[]).filter(
+      (role) => this.config[role] !== undefined
+    );
+  }
+
+  async getToken(
+    role: GitHubAppRole
+  ): Promise<{ token: string; expiresAt: string; gitIdentity: { name: string; email: string } }> {
+    const roleConfig = this.config[role];
+    if (!roleConfig) {
+      throw new Error(`role_not_configured: ${role}`);
+    }
+
+    // Check cache
+    const cached = this.cache.get(role);
+    if (cached && cached.expiresAt.getTime() - Date.now() > REFRESH_WINDOW_MS) {
+      return {
+        token: cached.token,
+        expiresAt: cached.expiresAt.toISOString(),
+        gitIdentity: cached.gitIdentity,
+      };
+    }
+
+    // Deduplicate concurrent requests
+    const existing = this.pending.get(role);
+    if (existing) {
+      const result = await existing;
+      return {
+        token: result.token,
+        expiresAt: result.expiresAt.toISOString(),
+        gitIdentity: result.gitIdentity,
+      };
+    }
+
+    const promise = this.generateToken(role, roleConfig);
+    this.pending.set(role, promise);
+
+    try {
+      const result = await promise;
+      return {
+        token: result.token,
+        expiresAt: result.expiresAt.toISOString(),
+        gitIdentity: result.gitIdentity,
+      };
+    } finally {
+      this.pending.delete(role);
+    }
+  }
+
+  private async generateToken(
+    role: GitHubAppRole,
+    roleConfig: { appId: string; privateKeyPath: string; installationId: string }
+  ): Promise<CachedToken> {
+    let privateKey = this.keyCache.get(role);
+    if (!privateKey) {
+      privateKey = await this.readFile(roleConfig.privateKeyPath);
+      this.keyCache.set(role, privateKey);
+    }
+    const jwt = await generateJwt(roleConfig.appId, privateKey);
+    const { token, expiresAt } = await exchangeToken(jwt, roleConfig.installationId, this.fetchFn);
+
+    const appName = ROLE_TO_APP_NAME[role];
+    const gitIdentity = getGitIdentity(roleConfig.appId, appName);
+    const result: CachedToken = {
+      token,
+      expiresAt: new Date(expiresAt),
+      gitIdentity,
+    };
+
+    this.cache.set(role, result);
+    return result;
+  }
+}
+
+/**
+ * Environment variables to strip from role serves to prevent credential leakage.
+ * Workers should only have access to their role's GH_TOKEN.
+ */
+const SCRUBBED_ENV_KEYS = ["GH_TOKEN", "GITHUB_TOKEN", "GH_HOST", "GH_CONFIG_DIR"];
+const SCRUBBED_ENV_PREFIX = "LEGION_GITHUB_APP_";
+
+export function buildRoleEnv(
+  token: string,
+  gitIdentity: { name: string; email: string },
+  baseEnv: Record<string, string>
+): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(baseEnv)) {
+    if (!SCRUBBED_ENV_KEYS.includes(key) && !key.startsWith(SCRUBBED_ENV_PREFIX)) {
+      env[key] = value;
+    }
+  }
+
+  env.GH_TOKEN = token;
+  env.GH_CONFIG_DIR = "/dev/null";
+  env.GIT_AUTHOR_NAME = gitIdentity.name;
+  env.GIT_AUTHOR_EMAIL = gitIdentity.email;
+  env.GIT_COMMITTER_NAME = gitIdentity.name;
+  env.GIT_COMMITTER_EMAIL = gitIdentity.email;
+
+  return env;
+}

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -1,12 +1,14 @@
 import { mkdirSync } from "node:fs";
 import { computeControllerSessionId } from "../state/types";
 import { type DaemonConfig, loadConfig, validateControllerPrompt } from "./config";
+import { modeToRole, TokenManager } from "./github-apps";
 import {
   allocatePort,
   readLegionsRegistry,
   removeLegionEntry,
   writeLegionEntry,
 } from "./legions-registry";
+import { RoleServeManager } from "./multi-serve";
 import { isPortFree } from "./ports";
 import { createAdapter } from "./runtime";
 import type { RuntimeAdapter } from "./runtime/types";
@@ -151,6 +153,30 @@ export async function startDaemon(
     console.log(`Shared serve started on port ${sharedServePort}`);
   }
 
+  // Initialize per-role serves for credential isolation (when GitHub Apps configured)
+  let roleServeManager: RoleServeManager | undefined;
+  let tokenManager: TokenManager | undefined;
+  if (config.githubApps) {
+    tokenManager = new TokenManager(config.githubApps);
+    roleServeManager = new RoleServeManager({
+      githubApps: config.githubApps,
+      tokenManager,
+      runtime: config.runtime,
+      basePort: sharedServePort + 1,
+      shortId: legionId.slice(0, 8),
+      fallbackAdapter: resolvedDeps.adapter,
+    });
+    try {
+      await roleServeManager.start(buildControllerEnv(config), controllerWorkspace, config.logDir);
+      const entries = roleServeManager.getEntries();
+      console.log(`Role serves started: ${entries.map((e) => `${e.role}:${e.port}`).join(", ")}`);
+    } catch (error) {
+      console.error(`Failed to start role serves: ${error}`);
+      console.error("Falling back to shared serve for all workers");
+      roleServeManager = undefined;
+    }
+  }
+
   const preState = await resolvedDeps.readStateFile(config.stateFilePath);
   let controllerState: ControllerState | undefined = preState.controller;
 
@@ -185,6 +211,9 @@ export async function startDaemon(
     } catch {}
 
     await resolvedDeps.adapter.stop();
+    if (roleServeManager) {
+      await roleServeManager.stop();
+    }
 
     controllerState = undefined;
     const state = await resolvedDeps.readStateFile(config.stateFilePath);
@@ -221,6 +250,10 @@ export async function startDaemon(
             ? `legion-${config.legionId}`
             : undefined,
         getControllerState: () => controllerState,
+        getWorkerAdapter: roleServeManager
+          ? (mode) => roleServeManager.getAdapterForMode(mode)
+          : undefined,
+        tokenManager,
         shutdownFn: async () => {
           resolvedDeps.setTimeout(async () => {
             await shutdown(true);
@@ -358,6 +391,38 @@ export async function startDaemon(
             }
           } catch (error) {
             console.error(`Failed to restart shared serve: ${error}`);
+          }
+        }
+
+        // Check role serves health
+        if (roleServeManager?.hasRoleServes()) {
+          const unhealthyRoles = await roleServeManager.checkHealth();
+          for (const role of unhealthyRoles) {
+            console.error(`Role serve '${role}' is unhealthy, restarting...`);
+            try {
+              await roleServeManager.restartRole(
+                role,
+                buildControllerEnv(config),
+                controllerWorkspace,
+                config.logDir
+              );
+              console.log(`Role serve '${role}' restarted`);
+              // Re-create sessions for workers on this role
+              const roleAdapter = roleServeManager.getAdapterForRole(role);
+              const state = await resolvedDeps.readStateFile(config.stateFilePath);
+              for (const workerEntry of Object.values(state.workers)) {
+                try {
+                  const workerMode = workerEntry.id.split("-").pop();
+                  if (workerMode && modeToRole(workerMode) === role) {
+                    await roleAdapter.createSession(workerEntry.sessionId, workerEntry.workspace);
+                  }
+                } catch {
+                  // Best effort — worker may not match this role
+                }
+              }
+            } catch (restartError) {
+              console.error(`Failed to restart role serve '${role}': ${restartError}`);
+            }
           }
         }
       } finally {

--- a/packages/daemon/src/daemon/multi-serve.ts
+++ b/packages/daemon/src/daemon/multi-serve.ts
@@ -1,0 +1,167 @@
+import type { GitHubAppRole, GitHubAppsConfig } from "./config";
+import { buildRoleEnv, modeToRole, type TokenManager } from "./github-apps";
+import { isPortFree } from "./ports";
+import { createAdapter } from "./runtime";
+import type { RuntimeAdapter } from "./runtime/types";
+
+/**
+ * Manages per-role serve instances for credential isolation.
+ *
+ * When GitHub Apps are configured, each role (impl, review) gets its own
+ * `opencode serve` process with role-specific GH_TOKEN and scrubbed environment.
+ * Workers are routed to the appropriate serve based on their mode.
+ *
+ * When GitHub Apps are NOT configured, all workers share the controller's serve
+ * (backward compatible single-serve behavior).
+ */
+
+export interface RoleServeEntry {
+  role: GitHubAppRole;
+  adapter: RuntimeAdapter;
+  port: number;
+}
+
+export interface RoleServeManagerOptions {
+  githubApps: GitHubAppsConfig;
+  tokenManager: TokenManager;
+  runtime: "opencode" | "claude-code";
+  basePort: number;
+  shortId: string;
+  /** Fallback adapter when role serves are not available */
+  fallbackAdapter: RuntimeAdapter;
+}
+
+export class RoleServeManager {
+  private readonly serves = new Map<GitHubAppRole, RoleServeEntry>();
+  private readonly tokenManager: TokenManager;
+  private readonly fallbackAdapter: RuntimeAdapter;
+  private readonly runtime: "opencode" | "claude-code";
+  private readonly shortId: string;
+
+  constructor(private readonly opts: RoleServeManagerOptions) {
+    this.tokenManager = opts.tokenManager;
+    this.fallbackAdapter = opts.fallbackAdapter;
+    this.runtime = opts.runtime;
+    this.shortId = opts.shortId;
+  }
+
+  /**
+   * Start per-role serve instances. Allocates sequential ports starting from basePort.
+   * Only starts serves for configured roles.
+   */
+  async start(
+    controllerEnv: Record<string, string>,
+    workspace: string,
+    logDir?: string
+  ): Promise<void> {
+    const roles = this.tokenManager.getConfiguredRoles();
+    let nextPort = this.opts.basePort;
+
+    for (const role of roles) {
+      while (!(await isPortFree(nextPort))) {
+        nextPort++;
+      }
+
+      const { token, gitIdentity } = await this.tokenManager.getToken(role);
+      const roleEnv = buildRoleEnv(token, gitIdentity, controllerEnv);
+
+      const adapter = createAdapter(this.runtime, {
+        port: nextPort,
+        shortId: `${this.shortId}-${role}`,
+      });
+
+      await adapter.start({
+        env: roleEnv,
+        workspace,
+        logDir: logDir ? `${logDir}/${role}` : undefined,
+      });
+
+      this.serves.set(role, { role, adapter, port: nextPort });
+      nextPort++;
+    }
+  }
+
+  /**
+   * Get the adapter for a worker mode. Routes mode → role → adapter.
+   * Falls back to the shared adapter if the role's serve isn't available.
+   */
+  getAdapterForMode(mode: string): RuntimeAdapter {
+    const role = modeToRole(mode);
+    const entry = this.serves.get(role);
+    return entry?.adapter ?? this.fallbackAdapter;
+  }
+
+  /**
+   * Get the adapter for a specific role.
+   * Falls back to the shared adapter if the role's serve isn't available.
+   */
+  getAdapterForRole(role: GitHubAppRole): RuntimeAdapter {
+    const entry = this.serves.get(role);
+    return entry?.adapter ?? this.fallbackAdapter;
+  }
+
+  /** Check health of all role serves. Returns roles that are unhealthy. */
+  async checkHealth(): Promise<GitHubAppRole[]> {
+    const unhealthy: GitHubAppRole[] = [];
+    for (const [role, entry] of this.serves) {
+      const healthy = await entry.adapter.healthy();
+      if (!healthy) {
+        unhealthy.push(role);
+      }
+    }
+    return unhealthy;
+  }
+
+  /**
+   * Restart a role's serve with fresh token.
+   * Used by health loop when a serve becomes unhealthy or token nears expiry.
+   */
+  async restartRole(
+    role: GitHubAppRole,
+    controllerEnv: Record<string, string>,
+    workspace: string,
+    logDir?: string
+  ): Promise<void> {
+    const entry = this.serves.get(role);
+    if (!entry) {
+      return;
+    }
+
+    try {
+      await entry.adapter.stop();
+    } catch {
+      // Best effort — serve may already be dead
+    }
+
+    const { token, gitIdentity } = await this.tokenManager.getToken(role);
+    const roleEnv = buildRoleEnv(token, gitIdentity, controllerEnv);
+
+    await entry.adapter.start({
+      env: roleEnv,
+      workspace,
+      logDir: logDir ? `${logDir}/${role}` : undefined,
+    });
+  }
+
+  /** Stop all role serves */
+  async stop(): Promise<void> {
+    for (const entry of this.serves.values()) {
+      try {
+        await entry.adapter.stop();
+      } catch {
+        // Best effort
+      }
+    }
+    this.serves.clear();
+  }
+
+  /** Get all active role serve entries */
+  getEntries(): RoleServeEntry[] {
+    return Array.from(this.serves.values());
+  }
+
+  /** Check if any role serves are running */
+  hasRoleServes(): boolean {
+    return this.serves.size > 0;
+  }
+}

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -9,6 +9,8 @@ import {
   WorkerMode,
   type WorkerModeLiteral,
 } from "../state/types";
+import type { TokenManager } from "./github-apps";
+import { modeToRole } from "./github-apps";
 import type { LegionPaths } from "./paths";
 import {
   cleanupWorkspace,
@@ -17,7 +19,7 @@ import {
   type RepoManagerDeps,
 } from "./repo-manager";
 import type { RuntimeAdapter } from "./runtime/types";
-import type { WorkerEntry } from "./serve-manager";
+import type { WorkerEntry as BaseWorkerEntry } from "./serve-manager";
 import {
   type ControllerState,
   type CrashHistoryEntry,
@@ -28,6 +30,9 @@ import {
 
 type Server = ReturnType<typeof Bun.serve>;
 
+interface WorkerEntry extends BaseWorkerEntry {
+  env?: Record<string, string>;
+}
 export interface ServerOptions {
   port?: number;
   hostname?: string;
@@ -43,6 +48,8 @@ export interface ServerOptions {
   getControllerState?: () => ControllerState | undefined;
   runtime?: string;
   tmuxSession?: string;
+  getWorkerAdapter?: (mode: WorkerModeLiteral) => RuntimeAdapter;
+  tokenManager?: TokenManager;
 }
 
 interface ErrorResponse {
@@ -94,6 +101,15 @@ function extractIssueIdFromWorkerId(workerId: string): string | null {
     const suffix = `-${mode}`;
     if (workerId.endsWith(suffix)) {
       return workerId.slice(0, -suffix.length);
+    }
+  }
+  return null;
+}
+
+function extractModeFromWorkerId(workerId: string): WorkerModeLiteral | null {
+  for (const mode of Object.values(WorkerMode)) {
+    if (workerId.endsWith(`-${mode}`)) {
+      return mode;
     }
   }
   return null;
@@ -160,7 +176,8 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
         if (segments.length === 1 && segments[0] === "workers") {
           if (method === "GET") {
             await stateLoaded;
-            return jsonResponse(Array.from(workers.values()));
+            const safeWorkers = Array.from(workers.values()).map(({ env: _env, ...rest }) => rest);
+            return jsonResponse(safeWorkers);
           }
           if (method === "POST") {
             await stateLoaded;
@@ -176,6 +193,7 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
             const repo = payload.repo;
             const workspace = payload.workspace;
             const version = typeof payload.version === "number" ? payload.version : 0;
+            const envPayload = payload.env;
 
             if (typeof issueId !== "string" || typeof mode !== "string") {
               return badRequest("missing_fields");
@@ -279,16 +297,52 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
               version
             );
 
+            const workerAdapter =
+              opts.getWorkerAdapter?.(mode as WorkerModeLiteral) ?? opts.adapter;
+
+            // Auto-inject role credentials when GitHub Apps configured
+            let workerEnv: Record<string, string> | undefined = isRecord(envPayload)
+              ? (envPayload as Record<string, string>)
+              : undefined;
+            if (workerEnv) {
+              for (const [k, v] of Object.entries(workerEnv)) {
+                if (typeof v !== "string") {
+                  return badRequest(`env values must be strings (key "${k}")`);
+                }
+              }
+            }
+            if (opts.tokenManager) {
+              try {
+                const role = modeToRole(mode);
+                if (opts.tokenManager.isConfigured(role)) {
+                  const cred = await opts.tokenManager.getToken(role);
+                  workerEnv = {
+                    ...workerEnv,
+                    GH_TOKEN: cred.token,
+                    GIT_AUTHOR_NAME: cred.gitIdentity.name,
+                    GIT_AUTHOR_EMAIL: cred.gitIdentity.email,
+                    GIT_COMMITTER_NAME: cred.gitIdentity.name,
+                    GIT_COMMITTER_EMAIL: cred.gitIdentity.email,
+                    LEGION_APP_ROLE: role,
+                  };
+                }
+              } catch (error) {
+                console.error(
+                  `Failed to inject role credentials for ${mode}: ${(error as Error).message}`
+                );
+              }
+            }
+
             let actualSessionId = sessionId;
             try {
-              actualSessionId = await opts.adapter.createSession(sessionId, resolvedWorkspace);
+              actualSessionId = await workerAdapter.createSession(sessionId, resolvedWorkspace);
             } catch (error) {
               return serverError(`Failed to create session: ${(error as Error).message}`);
             }
 
             const entry: WorkerEntry = {
               id: workerId,
-              port: opts.adapter.getPort(),
+              port: workerAdapter.getPort(),
               sessionId: actualSessionId,
               workspace: resolvedWorkspace,
               startedAt: new Date().toISOString(),
@@ -296,6 +350,7 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
               crashCount: crashHistoryEntry?.crashCount ?? 0,
               lastCrashAt: crashHistoryEntry?.lastCrashAt ?? null,
               version,
+              ...(workerEnv ? { env: workerEnv } : {}),
             };
 
             workers.set(entry.id, entry);
@@ -303,7 +358,7 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
 
             return jsonResponse({
               id: entry.id,
-              port: opts.adapter.getPort(),
+              port: workerAdapter.getPort(),
               sessionId: entry.sessionId,
             });
           }
@@ -369,6 +424,30 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
           return jsonResponse({ status: "cleaned" });
         }
 
+        if (segments.length === 3 && segments[0] === "workers" && segments[2] === "env") {
+          await stateLoaded;
+          if (method !== "GET") {
+            return notFound();
+          }
+          const id = segments[1].toLowerCase();
+          const entry = workers.get(id);
+          if (!entry) {
+            return notFound();
+          }
+          const safeEnv: Record<string, string> = {};
+          for (const [k, v] of Object.entries(entry.env ?? {})) {
+            if (
+              k !== "GH_TOKEN" &&
+              !k.startsWith("GIT_AUTHOR_") &&
+              !k.startsWith("GIT_COMMITTER_") &&
+              k !== "LEGION_APP_ROLE"
+            ) {
+              safeEnv[k] = v;
+            }
+          }
+          return jsonResponse({ env: safeEnv });
+        }
+
         if (segments.length === 2 && segments[0] === "workers") {
           await stateLoaded;
           const id = segments[1].toLowerCase();
@@ -377,7 +456,8 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
             return notFound();
           }
           if (method === "GET") {
-            return jsonResponse(entry);
+            const { env: _getEnv, ...safeEntry } = entry;
+            return jsonResponse(safeEntry);
           }
           if (method === "PATCH") {
             let payload: Record<string, unknown>;
@@ -420,7 +500,8 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
               });
             }
             await persistState();
-            return jsonResponse(updated);
+            const { env: _patchEnv, ...safeUpdated } = updated;
+            return jsonResponse(safeUpdated);
           }
           if (method === "DELETE") {
             crashHistory.set(id, {
@@ -445,7 +526,11 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
           }
 
           try {
-            const result = await opts.adapter.getSessionStatus(entry.sessionId);
+            const statusMode = extractModeFromWorkerId(entry.id);
+            const statusAdapter = statusMode
+              ? (opts.getWorkerAdapter?.(statusMode) ?? opts.adapter)
+              : opts.adapter;
+            const result = await statusAdapter.getSessionStatus(entry.sessionId);
             if (result.error || !result.data) {
               return badGateway();
             }
@@ -477,12 +562,18 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
             return badRequest("missing_fields");
           }
           try {
-            await opts.adapter.sendPrompt(entry.sessionId, text);
+            const promptMode = extractModeFromWorkerId(entry.id);
+            const promptAdapter = promptMode
+              ? (opts.getWorkerAdapter?.(promptMode) ?? opts.adapter)
+              : opts.adapter;
+            await promptAdapter.sendPrompt(entry.sessionId, text);
             return jsonResponse({ ok: true });
           } catch (error) {
             return serverError(`Failed to send prompt: ${(error as Error).message}`);
           }
         }
+
+        // Credential endpoint removed — credentials are auto-injected in POST /workers
 
         if (method === "POST" && url.pathname === "/state/collect") {
           let payload: Record<string, unknown>;


### PR DESCRIPTION
## Summary

Rebased and fixed version of #111. Adds per-role GitHub App credential isolation so implementers and reviewers operate under distinct GitHub identities.

### Changes from original PR
- **Removed `HOME` override** — broke mise and other tool managers that derive config paths from `$HOME`. `GH_CONFIG_DIR=/dev/null` is sufficient for credential isolation.
- **Consolidated `ops` role into `review`** — only 2 Apps needed (impl + review). `test`, `architect`, `plan` modes now map to `review` role.
- **Updated docs and tests** to reflect 2-App architecture.

### What it does
- Each worker mode maps to a role: `implement`/`merge` → `impl`, everything else → `review`
- Daemon starts per-role `opencode serve` processes with role-specific `GH_TOKEN` and git identity
- Workers are routed to the correct serve based on their mode
- Credential injection is automatic on `POST /workers` — controller doesn't need to handle credentials
- `GET /workers/{id}/env` strips credential vars from response

### Smoke tested
- Real GitHub Apps created (Legion Implementer + Legion Reviewer)
- Installed on `sjawhar/legion` and `trajectory-labs-pbc/agent-c`
- Full daemon startup with per-role serves confirmed healthy
- Workers dispatched with correct role-specific tokens and identities
- No interference with live daemon

### Setup
See `docs/setup/github-apps.md` for step-by-step instructions.