### PR TITLE
fix(plugin): update default models and hide sub-agents from picker

### DIFF
--- a/packages/opencode-plugin/src/agents/index.ts
+++ b/packages/opencode-plugin/src/agents/index.ts
@@ -14,16 +14,16 @@ import type { AgentDefinition } from "./types";
 export type { AgentDefinition } from "./types";
 
 const DEFAULT_MODELS: Record<string, string> = {
-  orchestrator: "anthropic/claude-sonnet-4-20250514",
-  executor: "anthropic/claude-sonnet-4-20250514",
+  orchestrator: "anthropic/claude-sonnet-4-6",
+  executor: "anthropic/claude-sonnet-4-6",
   oracle: "anthropic/claude-opus-4-6",
-  explorer: "anthropic/claude-sonnet-4-20250514",
-  librarian: "anthropic/claude-sonnet-4-20250514",
-  metis: "anthropic/claude-sonnet-4-20250514",
-  momus: "anthropic/claude-sonnet-4-20250514",
-  multimodal: "anthropic/claude-sonnet-4-20250514",
-  conductor: "anthropic/claude-sonnet-4-20250514",
-  "simplicity-reviewer": "anthropic/claude-sonnet-4-20250514",
+  explorer: "anthropic/claude-sonnet-4-6",
+  librarian: "anthropic/claude-sonnet-4-6",
+  metis: "anthropic/claude-sonnet-4-6",
+  momus: "anthropic/claude-sonnet-4-6",
+  multimodal: "anthropic/claude-sonnet-4-6",
+  conductor: "anthropic/claude-sonnet-4-6",
+  "simplicity-reviewer": "anthropic/claude-sonnet-4-6",
 };
 
 function getModel(config: PluginConfig | undefined, agentName: string): string {

--- a/packages/opencode-plugin/src/index.ts
+++ b/packages/opencode-plugin/src/index.ts
@@ -37,6 +37,7 @@ interface AgentConfigEntry {
   temperature: number;
   prompt: string;
   description: string;
+  mode?: "primary" | "subagent" | "all";
   permission?: PermissionConfig;
 }
 
@@ -100,6 +101,7 @@ const OpenCodeLegion: Plugin = async (ctx) => {
     name: "opencode-legion",
     config: async (opencodeConfig: Record<string, unknown>) => {
       const agents = createAgents(pluginConfig);
+      const PRIMARY_AGENTS = new Set(["orchestrator", "conductor"]);
       const agentMap: Record<string, AgentConfigEntry> = {};
       for (const agent of agents) {
         agentMap[agent.name] = {
@@ -107,6 +109,7 @@ const OpenCodeLegion: Plugin = async (ctx) => {
           temperature: agent.config.temperature,
           prompt: agent.config.prompt,
           description: agent.description,
+          mode: PRIMARY_AGENTS.has(agent.name) ? "primary" : "subagent",
         };
       }
 


### PR DESCRIPTION
## Summary
- Update default models from `claude-sonnet-4-20250514` to `claude-sonnet-4-6` (oracle stays on `claude-opus-4-6`)
- Set `mode: "subagent"` on internal agents so they don't appear in the agent picker — only orchestrator and conductor are user-selectable (`mode: "primary"`)

### Agents now hidden from picker
executor, explorer, librarian, oracle, metis, momus, multimodal, simplicity-reviewer

These are still available for delegation via `background_task` — they just don't clutter the agent selector.