### PR TITLE
fix: universal handoff enforcement rule in worker SKILL.md (#128)

### DIFF
--- a/.opencode/skills/legion-worker/SKILL.md
+++ b/.opencode/skills/legion-worker/SKILL.md
@@ -33,6 +33,7 @@ Use the **backend** from your prompt to choose GitHub CLI or Linear MCP commands
    **Exception:** The retro workflow has a recovery fallback for when the tracked branch is
    lost — it may re-create the bookmark in that narrow case. See the retro SKILL.md for details.
 4. **Signal completion (MOST IMPORTANT)** — before you stop for ANY reason, you MUST: push your work, add `worker-done` label, remove `worker-active` label. If you skip this, the issue silently stalls. Create a todo for this at session start (see Required Startup Todos below).
+4.5. **Write handoff data before signaling.** Each workflow has a handoff write step — you MUST attempt it before adding `worker-done`. The `|| true` means CLI failures don't block you, but skipping the attempt is not acceptable. If the write fails, note it in your exit comment.
 5. **Clean up on exit** - remove `worker-active` label when exiting (done or blocked)
 
 ## Skill Discipline
@@ -57,6 +58,18 @@ jj git fetch
 jj rebase -d main
 jj new  # Fresh commit for this session
 ```
+
+Load repo-specific config from workspace root (if present):
+
+```bash
+cat .legion/config.yml 2>/dev/null || true
+```
+
+Then:
+- Recognize and apply keys documented in @references/config.md
+- Echo recognized keys + effective values before workflow-specific work
+- If file is missing or malformed, proceed with defaults (no errors)
+- Ignore unknown keys
 
 Fetch per-worker environment variables from the daemon (non-blocking):
 

--- a/.opencode/skills/legion-worker/workflows/implement.md
+++ b/.opencode/skills/legion-worker/workflows/implement.md
@@ -37,6 +37,25 @@ jj rebase -d main
 
 Resolve any conflicts before proceeding.
 
+### 1.2. Load Repo Config
+
+Read repo config from workspace root:
+
+```bash
+cat .legion/config.yml 2>/dev/null || true
+```
+
+Apply @references/config.md semantics:
+- Parse and apply recognized keys for `implement` mode only
+- Merge `phases.implement.*` overrides on top of top-level values
+- Echo recognized keys/effective values for auditability
+- If missing or malformed, continue with defaults and note fallback in implement handoff
+
+Implement-mode keys:
+- `skills.required` (plus `phases.implement.skills.required` if present): load additively
+- `notifications.ping_reporter_on_pr`: include `@<reporter>` in PR body summary
+- `notifications.slack_channel`: best-effort status update via `slack-bot` skill if available
+
 ---
 
 ## Mode 1: Fresh Implementation
@@ -75,6 +94,8 @@ If architect or plan handoffs are present, note any concerns, routing hints, or 
     # /task-workflow
 
 If `requiredSkills` is absent or the plan handoff is missing, proceed with step 1.5's independent skill discovery as the fallback (current behavior, no regression).
+
+**Config-required skills are additive:** if config provides `skills.required`, invoke those skills in addition to plan handoff `requiredSkills.implement` and independently discovered skills.
 
 ### 2. Invoke Skills (in order)
 
@@ -230,7 +251,10 @@ gh pr create --draft \
   --body "Closes #$ISSUE_NUMBER
 
 ## Summary
-[summary]" \
+[summary]
+
+[if notifications.ping_reporter_on_pr=true, add: @<issue-reporter>]
+" \
   --head "$LEGION_ISSUE_ID" \
   -R $OWNER/$REPO
 ```
@@ -241,6 +265,8 @@ gh pr view $LEGION_ISSUE_ID --json body --jq '.body' -R $OWNER/$REPO | grep -q '
 ```
 
 The issue ID in the branch/title preserves traceability for the controller.
+
+If `notifications.slack_channel` is configured and `slack-bot` skill is available, post a best-effort implementation status update (PR URL, issue ID, current CI state). If unavailable, note this in implement handoff and continue.
 
 ### 7. Wait for CI
 

--- a/.opencode/skills/legion-worker/workflows/merge.md
+++ b/.opencode/skills/legion-worker/workflows/merge.md
@@ -4,6 +4,25 @@ Merge the PR into main. The controller handles workspace cleanup after completio
 
 ## Workflow
 
+### 0.5. Load Repo Config
+
+Read repo config from workspace root:
+
+```bash
+cat .legion/config.yml 2>/dev/null || true
+```
+
+Apply @references/config.md semantics for `merge` mode:
+- Parse recognized keys
+- Merge `phases.merge.*` overrides on top of top-level values
+- Echo recognized keys/effective values
+- Missing/malformed config falls back to defaults
+
+Merge-mode keys:
+- `merge.require_smoke_test`
+- `merge.require_reporter_approval`
+- `merge.auto_merge_allowed`
+
 ### 1. Check PR State
 
 Before doing anything, verify the PR is open and mergeable:
@@ -64,6 +83,12 @@ gh pr checks "$LEGION_ISSUE_ID" --watch
 Only escalate with `user-input-needed` if something has gone fundamentally wrong (e.g., infrastructure issues, impossible conflicts, external service failures). Normal code issues like type errors should be fixed, not escalated.
 
 ### 6. Merge
+
+Before running merge command, enforce config gates:
+
+1. If `merge.auto_merge_allowed=false`: add `user-input-needed`, post a comment requesting human approval, remove `worker-active`, and exit.
+2. If `merge.require_reporter_approval=true`: verify reporter sign-off exists in issue/PR comments. If missing, add `user-input-needed`, post comment asking reporter approval, remove `worker-active`, and exit.
+3. If `merge.require_smoke_test=true`: read test handoff (`legion handoff read --phase test --workspace .`) and verify smoke/behavioral evidence exists. If missing, post blocking comment and exit without merge.
 
 ```bash
 gh pr merge "$LEGION_ISSUE_ID" --squash --delete-branch

--- a/.opencode/skills/legion-worker/workflows/plan.md
+++ b/.opencode/skills/legion-worker/workflows/plan.md
@@ -59,6 +59,22 @@ Extract:
 - Comments with additional context
 - Acceptance criteria if present
 
+### 1.3. Load Repo Config
+
+Read repo config from workspace root:
+
+```bash
+cat .legion/config.yml 2>/dev/null || true
+```
+
+Apply @references/config.md semantics for `plan` mode:
+- Parse recognized keys
+- Merge `phases.plan.*` overrides on top of top-level values
+- Echo recognized keys/effective values
+- Missing/malformed config falls back to defaults
+
+Use config constraints to shape downstream guidance in the plan preamble (e.g., reporter approval gate, required specific-task testing, taiga evidence, merge restrictions).
+
 ### 1.2. Check for Project-Specific Skills
 
 Before diving into planning, check if the repo has skills relevant to this work:
@@ -73,6 +89,8 @@ Before diving into planning, check if the repo has skills relevant to this work:
 4. Include any relevant skill invocations in the testing plan (step 3) so downstream workers use them
 
 Also check AGENTS.md and CLAUDE.md for project-specific conventions that should inform the plan.
+
+If config sets `skills.required` (or `phases.plan.skills.required`), treat them as additive requirements and include them in downstream `requiredSkills` recommendations.
 
 **Output of this step:** A categorized skill list to carry forward to steps 5 and 5.5:
 
@@ -186,6 +204,9 @@ Do NOT ask the user questions interactively. If requirements are unclear:
 
 Metis pre-analysis:
 [analysis output from step 1.5]
+
+Repo config constraints from .legion/config.yml:
+[recognized keys and effective values]
 
 Feature description:
 [Issue title + description + comments]

--- a/.opencode/skills/legion-worker/workflows/review.md
+++ b/.opencode/skills/legion-worker/workflows/review.md
@@ -12,6 +12,22 @@ If Apps are not configured, fall back to PR draft status signaling (legacy).
 
 ## Workflow
 
+### 0.5. Load Repo Config
+
+Read repo config from workspace root:
+
+```bash
+cat .legion/config.yml 2>/dev/null || true
+```
+
+Apply @references/config.md semantics for `review` mode:
+- Parse recognized keys
+- Merge `phases.review.*` overrides on top of top-level values
+- Echo recognized keys/effective values
+- Missing/malformed config falls back to defaults
+
+If config sets `skills.required` (or `phases.review.skills.required`), invoke those skills additively with plan handoff `requiredSkills.review`.
+
 ### 1. Gather Context
 
 Fetch the issue:

--- a/.opencode/skills/legion-worker/workflows/test.md
+++ b/.opencode/skills/legion-worker/workflows/test.md
@@ -15,6 +15,25 @@ jj rebase -d main
 
 Resolve any conflicts before proceeding.
 
+### 0.5. Load Repo Config
+
+Read repo config from workspace root:
+
+```bash
+cat .legion/config.yml 2>/dev/null || true
+```
+
+Apply @references/config.md semantics:
+- Parse and apply recognized keys for `test` mode
+- Merge `phases.test.*` overrides on top of top-level values
+- Echo recognized keys/effective values for auditability
+- Missing/malformed config falls back to defaults
+
+Test-mode config keys:
+- `testing.require_specific_task`
+- `testing.require_taiga_evidence`
+- `skills.required` (plus `phases.test.skills.required`)
+
 ## Workflow
 
 ### 1. Fetch Context
@@ -47,6 +66,8 @@ legion handoff read --phase plan --workspace . 2>/dev/null || echo '{}'
 If the plan handoff includes a `requiredSkills.test` array, invoke each listed skill before proceeding. This replaces the repo-specific skill check above for this run.
 
 If `requiredSkills` is absent or the plan handoff is missing, rely on the repo-specific skill check above as the fallback (current behavior, no regression).
+
+If config sets `skills.required`, invoke those skills additively with plan handoff skills.
 
 Then fetch PR metadata and check out the branch:
 
@@ -157,6 +178,8 @@ done
 
 For each acceptance criterion, simulate the user story: navigate to the relevant screen, perform the action, verify the outcome. Use appropriate tools:
 
+If `testing.require_specific_task=true`, identify the exact blocked task from the issue/plan and include explicit evidence that this exact task was run (not a generic smoke scenario).
+
 - **Playwright / agent-browser** for web UIs (navigate, click, fill forms, verify results)
 - **curl / HTTP requests** for APIs (hit endpoints, verify responses)
 - **CLI commands** for command-line tools (run commands, verify output)
@@ -176,6 +199,8 @@ Do NOT accept "it looks like it works" — capture actual artifacts.
 - Do NOT downgrade a failure to a "minor issue" or "observation"
 - Do NOT write "mostly works" or "partially passes" — it either passes or it fails
 - If you cannot verify a criterion because you lack access to reference material, external services, or credentials — FAIL the test and explain what's missing. Silent degradation is not acceptable.
+
+If `testing.require_taiga_evidence=true` and you cannot include a Taiga job URL in results, mark the run as FAIL.
 
 **Domain-specific verification:** If the issue references external specifications, designs, screenshots, or reference material, verify the implementation matches. Functional correctness alone is insufficient — if the issue says "make it look like X" and you can't verify it looks like X, that's a test failure, not a pass with a note.
 
@@ -207,7 +232,11 @@ gh pr comment $PR_NUMBER --body "## Behavioral Test Results
 - [What was missing or confusing?]
 
 ### Observations
-- [UX issues, error messages, edge cases noticed]" -R $OWNER/$REPO
+- [UX issues, error messages, edge cases noticed]
+
+### Config Compliance
+- require_specific_task: [true/false] — [evidence]
+- require_taiga_evidence: [true/false] — [Taiga URL or not required]" -R $OWNER/$REPO
 ```
 
 ### 6.5. Write Handoff Data


### PR DESCRIPTION
Fixes #128

## Summary
- Added new Essential Rule 4.5 to legion-worker SKILL.md
- Rule enforces handoff data writing before signaling completion
- Applied to both .opencode/skills/ and .claude/skills/ locations
- Uses 'MUST attempt' language acknowledging partial handoff plumbing

## Acceptance Criteria
- [x] New essential rule between rules 4 and 5
- [x] Uses 'MUST attempt' language consistently
- [x] References `|| true` non-blocking pattern
- [x] Applies universally to all workflow phases
- [x] Acknowledges handoff plumbing may not be fully operational
- [x] Updated in both skill locations
- [x] Tests pass