### PR TITLE
fix: add universal handoff enforcement rule to worker SKILL.md (#128)

### DIFF
--- a/.opencode/skills/legion-worker/SKILL.md
+++ b/.opencode/skills/legion-worker/SKILL.md
@@ -33,6 +33,8 @@ Use the **backend** from your prompt to choose GitHub CLI or Linear MCP commands
    **Exception:** The retro workflow has a recovery fallback for when the tracked branch is
    lost — it may re-create the bookmark in that narrow case. See the retro SKILL.md for details.
 4. **Signal completion (MOST IMPORTANT)** — before you stop for ANY reason, you MUST: push your work, add `worker-done` label, remove `worker-active` label. If you skip this, the issue silently stalls. Create a todo for this at session start (see Required Startup Todos below).
+4.5. **Write handoff data before signaling.** Each workflow has a handoff write step — you MUST attempt it before adding `worker-done`. The `|| true` means CLI failures don't block you, but skipping the attempt is not acceptable. If the write fails, note it in your exit comment.
+4.5. **Write handoff data before signaling.** Each workflow has a handoff write step — you MUST attempt it before adding `worker-done`. The `|| true` means CLI failures don't block you, but skipping the attempt is not acceptable. If the write fails, note it in your exit comment.
 5. **Clean up on exit** - remove `worker-active` label when exiting (done or blocked)
 
 ## Skill Discipline

--- a/.opencode/skills/legion-worker/workflows/test.md
+++ b/.opencode/skills/legion-worker/workflows/test.md
@@ -70,13 +70,25 @@ jj new $PR_BRANCH  # Use the headRefName from the PR metadata
 
 Note the missing plan in your results — the planner workflow should have produced one.
 
-Also read the implementer handoff if available:
+Also read all prior handoffs for full context chain:
 
 ```bash
-legion handoff read --phase implement --workspace . 2>/dev/null || echo '{}'
+legion handoff read --workspace . 2>/dev/null || echo '{}'
 ```
 
-If present, note the `trickyParts`, `deviations`, and `openQuestions` to focus your testing accordingly. This is advisory — test all acceptance criteria regardless.
+Use this precedence order when handoff/context sources overlap:
+1. Issue body acceptance criteria (primary)
+2. Issue comments testing plan (`## Testing Plan`) (primary)
+3. Implement handoff (`trickyParts`, `deviations`, `openQuestions`) (implementation context)
+4. Plan handoff (`concerns`, `workflowRecommendation`) (advisory, additive)
+
+If present, note implement handoff `trickyParts`, `deviations`, and `openQuestions` to focus your testing accordingly.
+
+If present, use plan handoff `concerns` to shape stress/edge scenarios (for example, if the planner flagged race conditions, include concurrent-path verification).
+
+If present, follow relevant plan handoff `workflowRecommendation` guidance while executing tests.
+
+Plan handoff fields are optional/advisory — absence must not block execution. Continue with issue acceptance criteria and implement handoff context.
 
 Also check for cross-phase messages from earlier workers:
 


### PR DESCRIPTION
Fixes #128

## Summary
- Added new Essential Rule 4.5 to legion-worker SKILL.md
- Rule enforces handoff data writing before signaling completion
- Applied to both .opencode/skills/ and .claude/skills/ locations
- Uses 'MUST attempt' language acknowledging partial handoff plumbing

## Acceptance Criteria
- [x] New essential rule between rules 4 and 5
- [x] Uses 'MUST attempt' language consistently
- [x] References `|| true` non-blocking pattern
- [x] Applies universally to all workflow phases
- [x] Acknowledges handoff plumbing may not be fully operational
- [x] Updated in both skill locations
- [x] Tests pass