### PR TITLE
fix: add universal handoff enforcement rule to worker SKILL.md (#128)

### DIFF
--- a/.opencode/skills/legion-worker/SKILL.md
+++ b/.opencode/skills/legion-worker/SKILL.md
@@ -33,6 +33,7 @@ Use the **backend** from your prompt to choose GitHub CLI or Linear MCP commands
    **Exception:** The retro workflow has a recovery fallback for when the tracked branch is
    lost — it may re-create the bookmark in that narrow case. See the retro SKILL.md for details.
 4. **Signal completion (MOST IMPORTANT)** — before you stop for ANY reason, you MUST: push your work, add `worker-done` label, remove `worker-active` label. If you skip this, the issue silently stalls. Create a todo for this at session start (see Required Startup Todos below).
+4.5. **Write handoff data before signaling.** Each workflow has a handoff write step — you MUST attempt it before adding `worker-done`. The `|| true` means CLI failures don't block you, but skipping the attempt is not acceptable. If the write fails, note it in your exit comment.
 5. **Clean up on exit** - remove `worker-active` label when exiting (done or blocked)
 
 ## Skill Discipline


### PR DESCRIPTION
Fixes #128

## Summary
- Added new Essential Rule 4.5 to legion-worker SKILL.md
- Rule enforces handoff data writing before signaling completion
- Uses 'MUST attempt' language acknowledging partial handoff plumbing

## Acceptance Criteria
- [x] New essential rule between rules 4 and 5
- [x] Uses 'MUST attempt' language consistently
- [x] References `|| true` non-blocking pattern
- [x] Applies universally to all workflow phases
- [x] Acknowledges handoff plumbing may not be fully operational
- [x] Tests pass