### PR TITLE
sjawhar-legion-160: Fix daemon HTTP server blocked by stale workers.json session recreation

### DIFF
--- a/packages/daemon/src/daemon/__tests__/index.test.ts
+++ b/packages/daemon/src/daemon/__tests__/index.test.ts
@@ -36,7 +36,7 @@ let mockedRegistry: Record<
 > = {};
 let mockedAllocatedPorts = { daemonPort: 13370, servePort: 13381 };
 
-import { startDaemon } from "../index";
+import { pruneStaleWorkers, STALE_WORKER_TTL_MS, startDaemon } from "../index";
 
 type TimeoutCallback = (...args: unknown[]) => Promise<void> | void;
 
@@ -154,6 +154,7 @@ function startDaemonForTest(
 ): Promise<Awaited<ReturnType<typeof startDaemon>>> {
   return startDaemon(
     {
+      staleWorkerTtlMs: Number.MAX_SAFE_INTEGER,
       paths: TEST_PATHS,
       readLegionsRegistry: async () => mockedRegistry,
       allocatePort: () => mockedAllocatedPorts,
@@ -1082,5 +1083,237 @@ describe("daemon entry", () => {
     } finally {
       console.warn = originalWarn;
     }
+  });
+
+  it("starts HTTP server before re-creating worker sessions", async () => {
+    const callOrder: string[] = [];
+
+    await startDaemonForTest(
+      {
+        stateFilePath: "/tmp/daemon-workers.json",
+        legionId: TEAM_ID,
+        controllerSessionId: "ses_test",
+      },
+      {
+        readStateFile: async () => ({
+          workers: {
+            [baseEntry.id]: baseEntry,
+            [secondEntry.id]: secondEntry,
+          },
+          crashHistory: {},
+        }),
+        writeStateFile: async () => {},
+        adapter: {
+          ...makeAdapter(),
+          createSession: async (sessionId: string, _workspace: string) => {
+            callOrder.push(`createSession:${sessionId}`);
+            return sessionId;
+          },
+        },
+        startServer: (opts) => {
+          callOrder.push("startServer");
+          return {
+            server: { port: opts.port } as ReturnType<typeof Bun.serve>,
+            stop: () => {},
+          };
+        },
+        setTimeout: silentSetTimeout,
+        clearTimeout: noopClearTimeout,
+        fetch: originalFetch,
+      }
+    );
+
+    const serverIndex = callOrder.indexOf("startServer");
+    const workerSessionIndices = callOrder
+      .map((call, i) => ({ call, i }))
+      .filter(
+        ({ call }) =>
+          call === `createSession:${baseEntry.sessionId}` ||
+          call === `createSession:${secondEntry.sessionId}`
+      )
+      .map(({ i }) => i);
+
+    expect(serverIndex).toBeGreaterThanOrEqual(0);
+    expect(workerSessionIndices.length).toBe(2);
+    for (const idx of workerSessionIndices) {
+      expect(idx).toBeGreaterThan(serverIndex);
+    }
+  });
+
+  it("prunes stale workers from state file on startup", async () => {
+    const writeStateCalls: Array<{ path: string; state: PersistedWorkerState }> = [];
+    const NOW = Date.now();
+    const staleEntry: WorkerEntry = {
+      ...baseEntry,
+      id: "stale-worker",
+      sessionId: "ses-stale",
+      startedAt: new Date(NOW - 10 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+    const freshEntry: WorkerEntry = {
+      ...baseEntry,
+      id: "fresh-worker",
+      sessionId: "ses-fresh",
+      startedAt: new Date(NOW - 1 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+
+    await startDaemonForTest(
+      {
+        stateFilePath: "/tmp/daemon-workers.json",
+        legionId: TEAM_ID,
+        controllerSessionId: "ses_test",
+        staleWorkerTtlMs: STALE_WORKER_TTL_MS,
+      },
+      {
+        readStateFile: async () => ({
+          workers: {
+            [staleEntry.id]: staleEntry,
+            [freshEntry.id]: freshEntry,
+          },
+          crashHistory: {},
+        }),
+        writeStateFile: async (p, state) => {
+          writeStateCalls.push({ path: p, state });
+        },
+        adapter: makeAdapter(),
+        startServer: () => ({
+          server: { port: 15555 } as ReturnType<typeof Bun.serve>,
+          stop: () => {},
+        }),
+        setTimeout: silentSetTimeout,
+        clearTimeout: noopClearTimeout,
+        fetch: originalFetch,
+      }
+    );
+
+    // Should write pruned state (stale removed, fresh kept)
+    expect(writeStateCalls.length).toBeGreaterThanOrEqual(1);
+    const pruneWrite = writeStateCalls[0];
+    expect(pruneWrite.state.workers).toHaveProperty("fresh-worker");
+    expect(pruneWrite.state.workers).not.toHaveProperty("stale-worker");
+  });
+
+  it("does not rewrite state file when no workers are stale", async () => {
+    const writeStateCalls: Array<{ path: string; state: PersistedWorkerState }> = [];
+    const freshEntry: WorkerEntry = {
+      ...baseEntry,
+      id: "fresh-worker",
+      sessionId: "ses-fresh",
+      startedAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+
+    await startDaemonForTest(
+      {
+        stateFilePath: "/tmp/daemon-workers.json",
+        legionId: TEAM_ID,
+        controllerSessionId: "ses_test",
+        staleWorkerTtlMs: STALE_WORKER_TTL_MS,
+      },
+      {
+        readStateFile: async () => ({
+          workers: { [freshEntry.id]: freshEntry },
+          crashHistory: {},
+        }),
+        writeStateFile: async (p, state) => {
+          writeStateCalls.push({ path: p, state });
+        },
+        adapter: makeAdapter(),
+        startServer: () => ({
+          server: { port: 15555 } as ReturnType<typeof Bun.serve>,
+          stop: () => {},
+        }),
+        setTimeout: silentSetTimeout,
+        clearTimeout: noopClearTimeout,
+        fetch: originalFetch,
+      }
+    );
+
+    // No pruning write should occur — only shutdown writes
+    expect(writeStateCalls).toHaveLength(0);
+  });
+});
+
+describe("pruneStaleWorkers", () => {
+  const NOW = new Date("2026-03-28T12:00:00.000Z").getTime();
+
+  it("keeps workers newer than 7 days", () => {
+    const workers: Record<string, WorkerEntry> = {
+      fresh: {
+        ...baseEntry,
+        id: "fresh",
+        startedAt: new Date(NOW - 3 * 24 * 60 * 60 * 1000).toISOString(),
+      },
+    };
+    const result = pruneStaleWorkers(workers, STALE_WORKER_TTL_MS, NOW);
+    expect(Object.keys(result)).toEqual(["fresh"]);
+  });
+
+  it("prunes workers older than 7 days", () => {
+    const workers: Record<string, WorkerEntry> = {
+      stale: {
+        ...baseEntry,
+        id: "stale",
+        startedAt: new Date(NOW - 10 * 24 * 60 * 60 * 1000).toISOString(),
+      },
+    };
+    const result = pruneStaleWorkers(workers, STALE_WORKER_TTL_MS, NOW);
+    expect(Object.keys(result)).toEqual([]);
+  });
+
+  it("prunes workers with invalid startedAt dates", () => {
+    const workers: Record<string, WorkerEntry> = {
+      invalid: {
+        ...baseEntry,
+        id: "invalid",
+        startedAt: "not-a-date",
+      },
+    };
+    const result = pruneStaleWorkers(workers, STALE_WORKER_TTL_MS, NOW);
+    expect(Object.keys(result)).toEqual([]);
+  });
+
+  it("handles mix of fresh and stale workers", () => {
+    const workers: Record<string, WorkerEntry> = {
+      fresh: {
+        ...baseEntry,
+        id: "fresh",
+        startedAt: new Date(NOW - 1 * 24 * 60 * 60 * 1000).toISOString(),
+      },
+      stale: {
+        ...baseEntry,
+        id: "stale",
+        startedAt: new Date(NOW - 10 * 24 * 60 * 60 * 1000).toISOString(),
+      },
+    };
+    const result = pruneStaleWorkers(workers, STALE_WORKER_TTL_MS, NOW);
+    expect(Object.keys(result)).toEqual(["fresh"]);
+  });
+
+  it("returns empty for empty input", () => {
+    const result = pruneStaleWorkers({}, STALE_WORKER_TTL_MS, NOW);
+    expect(result).toEqual({});
+  });
+
+  it("keeps workers exactly at the 7-day boundary", () => {
+    const workers: Record<string, WorkerEntry> = {
+      boundary: {
+        ...baseEntry,
+        id: "boundary",
+        startedAt: new Date(NOW - STALE_WORKER_TTL_MS).toISOString(),
+      },
+    };
+    const result = pruneStaleWorkers(workers, STALE_WORKER_TTL_MS, NOW);
+    expect(Object.keys(result)).toEqual(["boundary"]);
+  });
+
+  it("prunes workers 1ms past the boundary", () => {
+    const workers: Record<string, WorkerEntry> = {
+      expired: {
+        ...baseEntry,
+        id: "expired",
+        startedAt: new Date(NOW - STALE_WORKER_TTL_MS - 1).toISOString(),
+      },
+    };
+    const result = pruneStaleWorkers(workers, STALE_WORKER_TTL_MS, NOW);
+    expect(Object.keys(result)).toEqual([]);
   });
 });

--- a/packages/daemon/src/daemon/config.ts
+++ b/packages/daemon/src/daemon/config.ts
@@ -27,10 +27,12 @@ export interface DaemonConfig {
   issueBackend: "linear" | "github";
   runtime: "opencode" | "claude-code";
   githubApps?: GitHubAppsConfig;
+  staleWorkerTtlMs: number;
 }
 
 const BASE_DAEMON_PORT = 13370;
 const DEFAULT_CHECK_INTERVAL_MS = 60_000;
+const DEFAULT_STALE_WORKER_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const DEFAULT_BASE_WORKER_PORT = 13381;
 
 function parseNumber(value: string | undefined, fallback: number): number {
@@ -107,6 +109,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): DaemonConfig {
     legionDir,
     paths,
     checkIntervalMs: DEFAULT_CHECK_INTERVAL_MS,
+    staleWorkerTtlMs: DEFAULT_STALE_WORKER_TTL_MS,
     baseWorkerPort: DEFAULT_BASE_WORKER_PORT,
     stateFilePath,
     logDir,

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -19,6 +19,7 @@ import { RoleServeManager } from "./multi-serve";
 import { isPortFree } from "./ports";
 import { createAdapter } from "./runtime";
 import type { RuntimeAdapter } from "./runtime/types";
+import type { WorkerEntry } from "./serve-manager";
 import { startServer } from "./server";
 import { type ControllerState, readStateFile, writeStateFile } from "./state-file";
 
@@ -140,6 +141,26 @@ function buildControllerEnv(config: DaemonConfig): Record<string, string> {
   };
 }
 
+export const STALE_WORKER_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export function pruneStaleWorkers(
+  workers: Record<string, WorkerEntry>,
+  ttlMs: number = STALE_WORKER_TTL_MS,
+  nowMs: number = Date.now()
+): Record<string, WorkerEntry> {
+  const cutoff = nowMs - ttlMs;
+  const result: Record<string, WorkerEntry> = {};
+  for (const [id, entry] of Object.entries(workers)) {
+    const startedAt = new Date(entry.startedAt).getTime();
+    if (Number.isNaN(startedAt) || startedAt < cutoff) {
+      console.log(`Pruning stale worker ${id} (started ${entry.startedAt})`);
+    } else {
+      result[id] = entry;
+    }
+  }
+  return result;
+}
+
 export async function startDaemon(
   overrides: DaemonOverrides = {},
   deps?: Partial<DaemonDependencies>
@@ -239,23 +260,18 @@ export async function startDaemon(
   const preState = await resolvedDeps.readStateFile(config.stateFilePath);
   let controllerState: ControllerState | undefined = preState.controller;
 
-  for (const entry of Object.values(preState.workers)) {
-    try {
-      const actualId = await resolvedDeps.adapter.createSession(entry.sessionId, entry.workspace);
-      if (actualId !== entry.sessionId) {
-        console.warn(`Worker ${entry.id}: session ID changed ${entry.sessionId} -> ${actualId}`);
-      }
-    } catch (error) {
-      console.error(`Failed to re-create session for ${entry.id}: ${error}`);
-    }
+  // Prune stale workers (>7 days old) to prevent startup blocking
+  const prunedWorkers = pruneStaleWorkers(preState.workers, config.staleWorkerTtlMs);
+  const prunedCount = Object.keys(preState.workers).length - Object.keys(prunedWorkers).length;
+  if (prunedCount > 0) {
+    console.log(`Pruned ${prunedCount} stale worker(s) from state file`);
+    await resolvedDeps.writeStateFile(config.stateFilePath, {
+      ...preState,
+      workers: prunedWorkers,
+    });
   }
 
-  if (hasIndexRoot) {
-    const startedIndexBuildAt = Date.now();
-    await indexManager.initialize();
-    console.log(`Codebase index ready in ${Date.now() - startedIndexBuildAt}ms`);
-  }
-
+  // Start HTTP server BEFORE session recreation so the daemon is always reachable
   let shuttingDown = false;
   let healthTickTimeout: ReturnType<typeof setTimeout> | null = null;
   let stopServer: () => void = () => {};
@@ -347,6 +363,24 @@ export async function startDaemon(
     pid: process.pid,
     startedAt: new Date().toISOString(),
   });
+
+  // Re-create sessions for persisted workers (after HTTP server is running)
+  for (const entry of Object.values(prunedWorkers)) {
+    try {
+      const actualId = await resolvedDeps.adapter.createSession(entry.sessionId, entry.workspace);
+      if (actualId !== entry.sessionId) {
+        console.warn(`Worker ${entry.id}: session ID changed ${entry.sessionId} -> ${actualId}`);
+      }
+    } catch (error) {
+      console.error(`Failed to re-create session for ${entry.id}: ${error}`);
+    }
+  }
+
+  if (hasIndexRoot) {
+    const startedIndexBuildAt = Date.now();
+    await indexManager.initialize();
+    console.log(`Codebase index ready in ${Date.now() - startedIndexBuildAt}ms`);
+  }
 
   const existingController = controllerState;
 


### PR DESCRIPTION
Closes #160

## Summary

- Move HTTP server startup **before** the session recreation loop so the daemon is always reachable, even when workers.json contains hundreds of stale entries
- Add 7-day TTL auto-pruning of stale worker entries on startup — entries older than 7 days are removed from the state file before session recreation begins
- Add `staleWorkerTtlMs` to `DaemonConfig` (default: 7 days) for configurable TTL

## Changes

- `packages/daemon/src/daemon/index.ts` — Reorder `startDaemon()`: HTTP server binds → registry write → session recreation (was: session recreation → HTTP server). Add exported `pruneStaleWorkers()` function.
- `packages/daemon/src/daemon/config.ts` — Add `staleWorkerTtlMs` config field with 7-day default
- `packages/daemon/src/daemon/__tests__/index.test.ts` — 10 new tests: 7 unit tests for pruning logic (fresh/stale/invalid/mix/empty/boundary), 3 integration tests (server-before-recreation ordering, prune-and-rewrite, no-rewrite-when-clean)