### PR TITLE
feat: integrate Envoy packages into the Legion monorepo

### DIFF
--- a/.github/workflows/envoy-and-contracts.yaml
+++ b/.github/workflows/envoy-and-contracts.yaml
@@ -1,0 +1,105 @@
+name: Legion Envoy and Contracts
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/envoy/**"
+      - "packages/contracts/**"
+      - "packages/envoy-plugin/**"
+  pull_request:
+    paths:
+      - "packages/envoy/**"
+      - "packages/contracts/**"
+      - "packages/envoy-plugin/**"
+
+jobs:
+  contracts:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Lint contracts
+        run: bun run lint
+        working-directory: packages/contracts
+      - name: Typecheck contracts
+        run: bun run typecheck
+        working-directory: packages/contracts
+      - name: Test contracts
+        run: bun run test
+        working-directory: packages/contracts
+      - name: Build contracts
+        run: bun run build
+        working-directory: packages/contracts
+
+  envoy-plugin:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Lint envoy plugin
+        run: bun run lint
+        working-directory: packages/envoy-plugin
+      - name: Typecheck envoy plugin
+        run: bun run typecheck
+        working-directory: packages/envoy-plugin
+      - name: Build envoy plugin
+        run: bun run build
+        working-directory: packages/envoy-plugin
+      - name: Pack envoy plugin
+        run: bun pm pack --destination ../../out/pr-artifacts
+        working-directory: packages/envoy-plugin
+      - uses: actions/upload-artifact@v4
+        with:
+          name: opencode-legion-envoy-plugin-pr
+          path: out/pr-artifacts/*.tgz
+
+  envoy-go:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: packages/envoy/go.mod
+      - name: Generate Go contracts from shared schema
+        run: bun run gen:go
+        working-directory: packages/contracts
+      - name: Test envoy Go package
+        run: go test ./...
+        working-directory: packages/envoy
+      - name: Build envoy services
+        run: |
+          go build ./cmd/github
+          go build ./cmd/slack
+          go build ./cmd/listener
+        working-directory: packages/envoy
+      - name: Pack envoy binaries
+        run: |
+          mkdir -p ../../out/pr-artifacts/envoy-amd64
+          GOOS=linux GOARCH=amd64 go build -buildvcs=false -o ../../out/pr-artifacts/envoy-amd64/envoy-github ./cmd/github
+          GOOS=linux GOARCH=amd64 go build -buildvcs=false -o ../../out/pr-artifacts/envoy-amd64/envoy-slack ./cmd/slack
+          GOOS=linux GOARCH=amd64 go build -buildvcs=false -o ../../out/pr-artifacts/envoy-amd64/envoy-listener ./cmd/listener
+          tar czf ../../out/pr-artifacts/legion-envoy-amd64.tar.gz -C ../../out/pr-artifacts/envoy-amd64 envoy-github envoy-slack envoy-listener
+          mkdir -p ../../out/pr-artifacts/envoy-arm64
+          GOOS=linux GOARCH=arm64 go build -buildvcs=false -o ../../out/pr-artifacts/envoy-arm64/envoy-github ./cmd/github
+          GOOS=linux GOARCH=arm64 go build -buildvcs=false -o ../../out/pr-artifacts/envoy-arm64/envoy-slack ./cmd/slack
+          GOOS=linux GOARCH=arm64 go build -buildvcs=false -o ../../out/pr-artifacts/envoy-arm64/envoy-listener ./cmd/listener
+          tar czf ../../out/pr-artifacts/legion-envoy-arm64.tar.gz -C ../../out/pr-artifacts/envoy-arm64 envoy-github envoy-slack envoy-listener
+        working-directory: packages/envoy
+      - uses: actions/upload-artifact@v4
+        with:
+          name: legion-envoy-binaries-pr
+          path: |
+            out/pr-artifacts/legion-envoy-amd64.tar.gz
+            out/pr-artifacts/legion-envoy-arm64.tar.gz

--- a/.github/workflows/release-envoy-and-plugin.yaml
+++ b/.github/workflows/release-envoy-and-plugin.yaml
@@ -1,0 +1,99 @@
+name: Release Legion Envoy and Plugin
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/envoy/**"
+      - "packages/contracts/**"
+      - "packages/envoy-plugin/**"
+
+permissions:
+  contents: write
+
+jobs:
+  version:
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v5
+      - id: version
+        run: |
+          VERSION=$(jq -r .version package.json)
+          TAG="legion-envoy-v${VERSION}-${GITHUB_SHA::7}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+  plugin:
+    needs: version
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Build plugin
+        run: bun run build
+        working-directory: packages/envoy-plugin
+      - name: Pack plugin
+        run: bun pm pack
+        working-directory: packages/envoy-plugin
+      - uses: actions/upload-artifact@v4
+        with:
+          name: opencode-legion-envoy-plugin
+          path: packages/envoy-plugin/*.tgz
+
+  envoy:
+    needs: version
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: true
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: packages/envoy/go.mod
+      - name: Generate Go contracts from shared schema
+        run: bun run gen:go
+        working-directory: packages/contracts
+      - name: Build envoy binaries
+        run: |
+          mkdir -p out
+          GOOS=linux GOARCH=${{ matrix.arch }} go build -buildvcs=false -o out/envoy-github ./cmd/github
+          GOOS=linux GOARCH=${{ matrix.arch }} go build -buildvcs=false -o out/envoy-slack ./cmd/slack
+          GOOS=linux GOARCH=${{ matrix.arch }} go build -buildvcs=false -o out/envoy-listener ./cmd/listener
+          tar czf legion-envoy-${{ matrix.arch }}.tar.gz -C out envoy-github envoy-slack envoy-listener
+        working-directory: packages/envoy
+      - uses: actions/upload-artifact@v4
+        with:
+          name: legion-envoy-${{ matrix.arch }}
+          path: packages/envoy/legion-envoy-${{ matrix.arch }}.tar.gz
+
+  release:
+    needs: [version, plugin, envoy]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/download-artifact@v4
+      - name: Generate checksums
+        run: |
+          for dir in legion-envoy-amd64 legion-envoy-arm64 opencode-legion-envoy-plugin; do
+            (cd "$dir" && sha256sum * >> ../SHA256SUMS)
+          done
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ needs.version.outputs.tag }}" \
+            --title "${{ needs.version.outputs.tag }}" \
+            --notes "Automated Legion Envoy/plugin release from the Legion monorepo." \
+            legion-envoy-amd64/* \
+            legion-envoy-arm64/* \
+            opencode-legion-envoy-plugin/* \
+            SHA256SUMS

--- a/.opencode/skills/envoy/SKILL.md
+++ b/.opencode/skills/envoy/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: envoy
+description: Use when subscribing sessions to Envoy topics, sending agent-to-agent messages, or reasoning about topic formats for Slack/GitHub/agent routing.
+---
+
+# Envoy
+
+Envoy is Legion's event-routing subsystem. It delivers Slack, GitHub, and agent-to-agent events to OpenCode sessions.
+
+## What the tools do
+
+- `envoy_subscribe(topics)` — make the current session RECEIVE future events on those topics
+- `envoy_unsubscribe(topics?)` — stop receiving some or all topics
+- `envoy_list()` — show the session's current subscriptions
+- `envoy_send(target_session, message)` — SEND a message directly to another session
+
+## Topic formats
+
+### Agent-to-agent
+
+- Direct session route:
+  - `notifications.agent.<session_id>`
+
+Example:
+
+- `notifications.agent.ses_2e6ca3034ffejVikSZ8mDwk0mR`
+
+### GitHub
+
+- PR events (all PRs):
+  - `notifications.github.<owner>.<repo>.pr`
+- PR events (specific PR):
+  - `notifications.github.<owner>.<repo>.pr.<number>`
+- Issue events (all issues):
+  - `notifications.github.<owner>.<repo>.issue`
+- Issue events (specific issue):
+  - `notifications.github.<owner>.<repo>.issue.<number>`
+- Comment events (all):
+  - `notifications.github.<owner>.<repo>.comment`
+- Comment events (specific PR/issue):
+  - `notifications.github.<owner>.<repo>.comment.<number>`
+- Mention events (all):
+  - `notifications.github.<owner>.<repo>.mention`
+- Mention events (specific PR/issue):
+  - `notifications.github.<owner>.<repo>.mention.<number>`
+- CI/check events:
+  - `notifications.github.<owner>.<repo>.ci`
+- Push events:
+  - `notifications.github.<owner>.<repo>.push`
+
+Examples:
+
+- `notifications.github.trajectory-labs-pbc.agent-c.pr` (all PRs)
+- `notifications.github.trajectory-labs-pbc.agent-c.pr.7706` (PR #7706 only)
+- `notifications.github.sjawhar.legion.mention` (all mentions)
+- `notifications.github.sjawhar.legion.mention.171` (mentions on PR #171 only)
+
+### Slack
+
+- Channel message events:
+  - `notifications.slack.<team_id>.<channel_id>.message`
+- App mention events:
+  - `notifications.slack.<team_id>.<channel_id>.mention`
+- Thread events:
+  - `notifications.slack.<team_id>.<channel_id>.thread.<thread_ts>`
+
+Examples:
+
+- `notifications.slack.T09FRELLTS8.C0A0DHVU8HE.message`
+- `notifications.slack.T09FRELLTS8.C0A0DHVU8HE.mention`
+- `notifications.slack.T09FRELLTS8.C0A0DHVU8HE.thread.1234567890.123456`
+
+## When to use what
+
+### To receive future Slack/GitHub events
+
+1. Decide the exact topic(s)
+2. Call `envoy_subscribe([...])`
+3. Optionally call `envoy_list()` to confirm
+
+### To talk directly to another agent/session
+
+1. Get the target session ID
+2. Call `envoy_send(target_session, message)`
+
+You do NOT need to subscribe in order to send.
+
+## Patterns
+
+### Subscribe controller to a specific Slack channel mentions
+
+```text
+envoy_subscribe([
+  "notifications.slack.T09FRELLTS8.C0A0DHVU8HE.mention"
+])
+```
+
+### Subscribe controller to all PR events for agent-c
+
+```text
+envoy_subscribe([
+  "notifications.github.trajectory-labs-pbc.agent-c.pr"
+])
+```
+
+### Subscribe controller to GitHub @mentions for agent-c
+
+```text
+envoy_subscribe([
+  "notifications.github.trajectory-labs-pbc.agent-c.mention"
+])
+```
+
+### Message another session directly
+
+```text
+envoy_send(
+  target_session="ses_2e6ca3034ffejVikSZ8mDwk0mR",
+  message="Please continue the smoke test"
+)
+```
+
+## Important notes
+
+- Sessions choose their own Slack/GitHub subscriptions
+- Different sessions can subscribe to different channels/repos
+- Agent-to-agent delivery uses exact session IDs
+- If you are unsure what a session is currently subscribed to, call `envoy_list()` first
+- For Slack, use the real `team_id` in topics (for example `T09FRELLTS8`), not a workspace slug like `trajectorylabs`
+- GitHub mention routing is body-based because GitHub has no dedicated app mention webhook event

--- a/.opencode/skills/legion-controller/SKILL.md
+++ b/.opencode/skills/legion-controller/SKILL.md
@@ -19,6 +19,30 @@ Required:
 - `LEGION_SHORT_ID` - short ID for daemon identification
 - `LEGION_DAEMON_PORT` - daemon HTTP API port (default: 13370)
 
+## Daemon Launch
+
+Start the daemon from the Legion packages/daemon directory.
+
+```bash
+cd ~/legion/default/packages/daemon && \
+  PATH="$HOME/opencode/default/packages/opencode/dist/opencode-linux-x64/bin:$PATH" \
+  ENVOY_URL=http://127.0.0.1:9020 \
+  LEGION_CONTROLLER_SESSION_ID=$MY_SESSION_ID \
+  bun run src/cli/index.ts start trajectory-labs-pbc/2 -b github -r opencode
+```
+
+**Key details:**
+- **`LEGION_CONTROLLER_SESSION_ID` is required** — without it, the daemon spawns a separate controller session
+- **`ENVOY_URL`** is required so spawned opencode sessions can reach Envoy
+- **`-w` is NOT needed** — worker workspaces are auto-created by `ensureWorkspace()` (see Path Architecture below)
+- Only 2 env vars needed. Everything else is CLI args (`-b github -r opencode`).
+- Expected plugin stack: `@sjawhar/oh-my-opencode@sami` and `@sjawhar/opencode-legion-envoy@0.1.0-alpha.0`
+
+**Path architecture (all derived from XDG conventions, not `-w`):**
+- Repo clones: `~/.local/share/legion/repos/github.com/{owner}/{repo}/`
+- Worker workspaces: `~/.local/share/legion/workspaces/{projectId}/{issueId}/` (jj workspaces linked to repo clones)
+- State/logs: `~/.local/state/legion/legions/{projectId}/`
+- Controller workspace: same as state dir
 ## Core Principle
 
 **Keep work moving forward.** Priority order:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,24 +49,27 @@ legion handoff write|read|message    # Workers: write/read structured handoff da
 
 **jj (Jujutsu), not git.** Changes auto-accumulate. Push directly.
 
-| Task | Command |
-|------|---------|
+| Task                | Command                            |
+| ------------------- | ---------------------------------- |
 | Status / Log / Diff | `jj status` / `jj log` / `jj diff` |
-| Push / Fetch | `jj git push` / `jj git fetch` |
+| Push / Fetch        | `jj git push` / `jj git fetch`     |
 
 ## WHERE TO LOOK
 
-| Task | Location | Notes |
-|------|----------|-------|
-| Add CLI command | `packages/daemon/src/cli/index.ts` | citty `defineCommand` pattern |
-| Change HTTP API | `packages/daemon/src/daemon/server.ts` | See @packages/daemon/src/daemon/AGENTS.md |
-| Change state machine | `packages/daemon/src/state/decision.ts` | See @packages/daemon/src/state/AGENTS.md |
-| Add worker workflow | `.opencode/skills/legion-worker/workflows/` | See @.opencode/skills/AGENTS.md |
-| Change controller loop | `.opencode/skills/legion-controller/SKILL.md` | See @.opencode/skills/AGENTS.md |
-| Modify issue types | `packages/daemon/src/state/types.ts` | Shared by daemon + state |
-| Worker process mgmt | `packages/daemon/src/daemon/serve-manager.ts` | Spawns `opencode serve` |
-| Port allocation | `packages/daemon/src/daemon/ports.ts` | Sequential from base 13381 |
-| Handoff ledger | `.legion/` on issue branch | Per-phase JSON files written by workers |
+| Task                   | Location                                      | Notes                                     |
+| ---------------------- | --------------------------------------------- | ----------------------------------------- |
+| Add CLI command        | `packages/daemon/src/cli/index.ts`            | citty `defineCommand` pattern             |
+| Change HTTP API        | `packages/daemon/src/daemon/server.ts`        | See @packages/daemon/src/daemon/AGENTS.md |
+| Change state machine   | `packages/daemon/src/state/decision.ts`       | See @packages/daemon/src/state/AGENTS.md  |
+| Add worker workflow    | `.opencode/skills/legion-worker/workflows/`   | See @.opencode/skills/AGENTS.md           |
+| Change controller loop | `.opencode/skills/legion-controller/SKILL.md` | See @.opencode/skills/AGENTS.md           |
+| Modify issue types     | `packages/daemon/src/state/types.ts`          | Shared by daemon + state                  |
+| Worker process mgmt    | `packages/daemon/src/daemon/serve-manager.ts` | Spawns `opencode serve`                   |
+| Port allocation        | `packages/daemon/src/daemon/ports.ts`         | Sequential from base 13381                |
+| Handoff ledger         | `.legion/` on issue branch                    | Per-phase JSON files written by workers   |
+| Envoy event routing    | `packages/envoy/`                             | See @packages/envoy/AGENTS.md             |
+| Shared event contracts | `packages/contracts/`                         | See @packages/contracts/AGENTS.md         |
+| Envoy OpenCode bridge  | `packages/envoy-plugin/`                      | See @packages/envoy-plugin/AGENTS.md      |
 
 ## Conventions
 
@@ -104,3 +107,4 @@ Triage ──┬──► Icebox ──► Backlog ──► Todo ──► In P
 - Learnings: `docs/solutions/<category>/<slug>.md`
 
 > Many docs in `docs/plans/` and `docs/solutions/` predate the TypeScript rewrite and contain Python-era references. These are marked with `[HISTORICAL]` headers.
+```

--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,21 @@
     "": {
       "name": "legion",
     },
+    "packages/contracts": {
+      "name": "@legion/contracts",
+      "version": "0.10.0",
+      "dependencies": {
+        "zod": "^4.1.8",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.3.14",
+        "@types/bun": "latest",
+        "typescript": "^5.3.0",
+      },
+    },
     "packages/daemon": {
       "name": "legion",
-      "version": "0.1.0",
+      "version": "0.10.1",
       "bin": {
         "legion": "src/cli/index.ts",
       },
@@ -23,9 +35,21 @@
         "typescript": "^5.3.0",
       },
     },
+    "packages/envoy-plugin": {
+      "name": "@sjawhar/opencode-legion-envoy",
+      "version": "0.1.0-alpha.0",
+      "dependencies": {
+        "@opencode-ai/plugin": "^1.1.19",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.3.14",
+        "@types/bun": "latest",
+        "typescript": "^5.3.0",
+      },
+    },
     "packages/opencode-plugin": {
       "name": "opencode-legion",
-      "version": "0.1.0",
+      "version": "0.10.1",
       "bin": {
         "opencode-legion": "./src/cli/index.ts",
       },
@@ -63,15 +87,19 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.8", "", { "os": "win32", "cpu": "x64" }, "sha512-vAn7iXDoUbqFXqVocuq1sMYAd33p8+mmurqJkWl6CtIhobd/O6moe4rY5AJvzbunn/qZCdiDVcveqtkFh1e7Hg=="],
 
+    "@legion/contracts": ["@legion/contracts@workspace:packages/contracts"],
+
     "@opencode-ai/plugin": ["@opencode-ai/plugin@1.2.27", "", { "dependencies": { "@opencode-ai/sdk": "1.2.27", "zod": "4.1.8" } }, "sha512-h+8Bw9v9nghMg7T+SUCTzxlIhOrsTqXW7U0HVLGQST5DjbN7uyCUM51roZWZ8LRjGxzbzFhvPnY1bj8i+ioZyw=="],
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@https://github.com/sjawhar/opencode/releases/download/v1.2.4-post.2/opencode-ai-sdk-1.2.4-post.1.tgz", {}, "sha512-ZRTvyD3GnUpUJ8kMLdeBH9rbtb3oC3hVvMSMdxW8B4ohLfTgUh/5vdDd6nG4vaUG+KqtN56KDltu6s6/TpN3yQ=="],
 
-    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+    "@sjawhar/opencode-legion-envoy": ["@sjawhar/opencode-legion-envoy@workspace:packages/envoy-plugin"],
+
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
-    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "citty": ["citty@0.2.1", "", {}, "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg=="],
 
@@ -91,16 +119,24 @@
 
     "vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@opencode-ai/plugin/@opencode-ai/sdk": ["@opencode-ai/sdk@1.2.27", "", {}, "sha512-Wk0o/I+Fo+wE3zgvlJDs8Fb67KlKqX0PrV8dK5adSDkANq6r4Z25zXJg2iOir+a8ntg3rAcpel1OY4FV/TwRUA=="],
 
     "@opencode-ai/plugin/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
 
+    "legion/@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
+    "legion/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "opencode-legion/@opencode-ai/sdk": ["@opencode-ai/sdk@1.2.27", "", {}, "sha512-Wk0o/I+Fo+wE3zgvlJDs8Fb67KlKqX0PrV8dK5adSDkANq6r4Z25zXJg2iOir+a8ntg3rAcpel1OY4FV/TwRUA=="],
 
-    "opencode-legion/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "opencode-legion/@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
 
     "vscode-languageserver-protocol/vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
+
+    "legion/@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "opencode-legion/@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
   }
 }

--- a/packages/contracts/AGENTS.md
+++ b/packages/contracts/AGENTS.md
@@ -1,0 +1,31 @@
+# Contracts Package
+
+Shared event contract surface for Legion/Envoy.
+
+## Overview
+
+This package is the language-neutral source of truth for Envoy event shapes.
+
+Current scope:
+
+- envelope schema/type
+- subject helpers
+- JSON Schema source
+- Go contract generation into `packages/envoy/internal/contracts/generated.go`
+
+## Where to look
+
+| Task              | Location                            | Notes                             |
+| ----------------- | ----------------------------------- | --------------------------------- |
+| TS contract types | `src/envelope.ts`, `src/subject.ts` | current canonical TS surface      |
+| Package exports   | `src/index.ts`                      | public package API                |
+| Schema source     | `schemas/envelope.schema.json`      | canonical JSON Schema             |
+| Go generation     | `scripts/gen-go.ts`                 | writes generated Go contract file |
+| Contract tests    | `src/envelope.test.ts`              | basic shape validation            |
+
+## Critical conventions
+
+- If the envelope/subject shape changes, update the schema and regenerate Go output.
+- Do not hand-edit `packages/envoy/internal/contracts/generated.go`.
+- Prefer backward-compatible additions when extending the envelope.
+- Keep examples synchronized with the real receiver output (Slack team IDs, GitHub owner/repo segments, etc.).

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -1,0 +1,11 @@
+# @legion/contracts
+
+Shared event contracts for the Legion monorepo, including the Envoy subsystem.
+
+This package is the language-neutral contract layer for cross-runtime event payloads.
+
+Current scope:
+
+- envelope schema
+- subject helpers
+- JSON Schema source for future code generation

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@legion/contracts",
+  "version": "0.10.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "gen:go": "bun run scripts/gen-go.ts",
+    "build": "bun build src/index.ts --outdir dist --target bun --format esm",
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test",
+    "lint": "bunx biome check src/ schemas/"
+  },
+  "dependencies": {
+    "zod": "^4.1.8"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.3.14",
+    "@types/bun": "latest",
+    "typescript": "^5.3.0"
+  }
+}

--- a/packages/contracts/schemas/envelope.schema.json
+++ b/packages/contracts/schemas/envelope.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://legion.dev/schemas/envelope.schema.json",
+  "type": "object",
+  "required": [
+    "event_id",
+    "source",
+    "source_event_id",
+    "topic",
+    "dedupe_key",
+    "issued_at",
+    "payload_summary",
+    "trace_id"
+  ],
+  "properties": {
+    "event_id": { "type": "string", "minLength": 1 },
+    "source": {
+      "type": "string",
+      "enum": ["agent", "github", "slack", "whatsapp"]
+    },
+    "source_event_id": { "type": "string", "minLength": 1 },
+    "topic": { "type": "string", "minLength": 1 },
+    "dedupe_key": { "type": "string", "minLength": 1 },
+    "issued_at": { "type": "integer" },
+    "expires_at": { "type": "integer" },
+    "payload_summary": { "type": "string", "minLength": 1 },
+    "payload_ref": { "type": "string" },
+    "trace_id": { "type": "string", "minLength": 1 }
+  },
+  "additionalProperties": false
+}

--- a/packages/contracts/scripts/gen-go.ts
+++ b/packages/contracts/scripts/gen-go.ts
@@ -1,0 +1,158 @@
+import { mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+type Kind = "string" | "integer";
+
+type Prop = {
+  type: Kind;
+  enum?: string[];
+};
+
+type Schema = {
+  type: "object";
+  required?: string[];
+  properties: Record<string, Prop>;
+  additionalProperties?: boolean;
+};
+
+const out = resolve(
+  import.meta.dir,
+  "../../envoy/internal/contracts/generated.go",
+);
+
+const file = resolve(import.meta.dir, "../schemas/envelope.schema.json");
+
+const map = {
+  string: "string",
+  integer: "int64",
+} satisfies Record<Kind, string>;
+
+const keep = `func NowMillis() int64 {
+\treturn time.Now().UnixMilli()
+}
+
+func AgentSubject(session string) string {
+\treturn "notifications.agent." + session
+}
+
+func GithubSubject(owner string, repo string, kind string) string {
+\treturn "notifications.github." + owner + "." + repo + "." + kind
+}
+
+func SlackSubject(team string, channel string, kind string) string {
+\treturn "notifications.slack." + team + "." + channel + "." + kind
+}`;
+
+function title(text: string) {
+  if (text === "id") return "ID";
+  return text[0]?.toUpperCase() + text.slice(1);
+}
+
+function name(key: string) {
+  return key.split("_").map(title).join("");
+}
+
+function kind(prop: Prop, req: Set<string>, key: string) {
+  const base = map[prop.type];
+  if (!base) throw new Error(`unsupported schema type for ${key}`);
+  if (req.has(key) || prop.type === "string") return base;
+  return `*${base}`;
+}
+
+function field(
+  key: string,
+  prop: Prop,
+  req: Set<string>,
+  wide: number,
+  types: number,
+) {
+  const n = name(key);
+  const t = kind(prop, req, key);
+  const tag = req.has(key) ? key : `${key},omitempty`;
+  return `\t${n.padEnd(wide)} ${t.padEnd(types)} \`json:"${tag}"\``;
+}
+
+function check(key: string, prop: Prop) {
+  const n = name(key);
+  if (prop.type === "string") {
+    return `\tif strings.TrimSpace(e.${n}) == "" {\n\t\treturn fmt.Errorf("${key} is required")\n\t}`;
+  }
+  if (prop.type === "integer") {
+    return `\tif e.${n} == 0 {\n\t\treturn fmt.Errorf("${key} must be set")\n\t}`;
+  }
+  throw new Error(`unsupported required type for ${key}`);
+}
+
+function enums(key: string, prop: Prop) {
+  if (!prop.enum?.length) return "";
+  const n = name(key);
+  const list = prop.enum.map((item) => `\"${item}\"`).join(", ");
+  return [
+    `\tswitch e.${n} {`,
+    `\tcase ${list}:`,
+    `\tdefault:`,
+    `\t\treturn fmt.Errorf("${key} must be one of: ${prop.enum.join(", ")}")`,
+    `\t}`,
+  ].join("\n");
+}
+
+function render(schema: Schema) {
+  if (schema.type !== "object")
+    throw new Error("envelope schema must be an object");
+  const keys = Object.keys(schema.properties);
+  const req = new Set(schema.required ?? []);
+  const wide = Math.max(...keys.map((key) => name(key).length));
+  const types = Math.max(
+    ...keys.map((key) => kind(schema.properties[key], req, key).length),
+  );
+  const body = keys
+    .map((key) => field(key, schema.properties[key], req, wide, types))
+    .join("\n");
+  const checks = (schema.required ?? [])
+    .map((key) => {
+      const prop = schema.properties[key];
+      if (!prop) throw new Error(`missing property for required field ${key}`);
+      return check(key, prop);
+    })
+    .join("\n");
+  const source = schema.properties.source;
+  const extra = source ? enums("source", source) : "";
+  const validate = [checks, extra, "\treturn nil"].filter(Boolean).join("\n");
+  return `package contracts
+
+import (
+\t"fmt"
+\t"strings"
+\t"time"
+)
+
+type Envelope struct {
+${body}
+}
+
+func (e Envelope) Validate() error {
+${validate}
+}
+
+${keep}
+`;
+}
+
+const schema = (await Bun.file(file).json()) as Schema;
+
+mkdirSync(dirname(out), { recursive: true });
+await Bun.write(out, render(schema));
+
+const fmt = Bun.which("gofmt");
+
+if (fmt) {
+  const gofmt = Bun.spawnSync({
+    cmd: [fmt, "-w", out],
+    stderr: "inherit",
+    stdout: "inherit",
+  });
+
+  if (gofmt.exitCode !== 0) {
+    throw new Error("gofmt failed");
+  }
+}

--- a/packages/contracts/src/envelope.test.ts
+++ b/packages/contracts/src/envelope.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { EnvelopeSchema } from "./envelope";
+
+describe("EnvelopeSchema", () => {
+  test("accepts the envoy envelope shape", () => {
+    const item = EnvelopeSchema.parse({
+      event_id: "evt-1",
+      source: "agent",
+      source_event_id: "src-1",
+      topic: "notifications.agent.ses_123",
+      dedupe_key: "agent.ses_123.src-1",
+      issued_at: Date.now(),
+      payload_summary: "hello",
+      trace_id: "trace-1",
+    });
+
+    expect(item.topic).toBe("notifications.agent.ses_123");
+  });
+});

--- a/packages/contracts/src/envelope.ts
+++ b/packages/contracts/src/envelope.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const EnvelopeSchema = z.object({
+  event_id: z.string().min(1),
+  source: z.enum(["agent", "github", "slack", "whatsapp"]),
+  source_event_id: z.string().min(1),
+  topic: z.string().min(1),
+  dedupe_key: z.string().min(1),
+  issued_at: z.number().int(),
+  expires_at: z.number().int().optional(),
+  payload_summary: z.string().min(1),
+  payload_ref: z.string().optional(),
+  trace_id: z.string().min(1),
+});
+
+export type Envelope = z.infer<typeof EnvelopeSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./envelope";
+export * from "./subject";

--- a/packages/contracts/src/subject.ts
+++ b/packages/contracts/src/subject.ts
@@ -1,0 +1,11 @@
+export function agentSubject(session: string) {
+  return `notifications.agent.${session}`;
+}
+
+export function githubSubject(owner: string, repo: string, kind: string) {
+  return `notifications.github.${owner}.${repo}.${kind}`;
+}
+
+export function slackSubject(team: string, channel: string, kind: string) {
+  return `notifications.slack.${team}.${channel}.${kind}`;
+}

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/daemon/src/daemon/__tests__/telemetry.test.ts
+++ b/packages/daemon/src/daemon/__tests__/telemetry.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { readGauges, registerGauges, stop, takeSnapshot } from "../telemetry";
+
+afterEach(() => {
+  stop();
+});
+
+describe("daemon telemetry", () => {
+  test("merges registered gauges into snapshots", () => {
+    const releaseA = registerGauges("telemetry-test-a", () => ({
+      test_workers: 3,
+    }));
+    const releaseB = registerGauges("telemetry-test-b", () => ({
+      test_crashes: 1,
+    }));
+
+    const gauges = readGauges();
+    expect(gauges.test_workers).toBe(3);
+    expect(gauges.test_crashes).toBe(1);
+
+    const snap = takeSnapshot();
+    expect(snap.gauges.test_workers).toBe(3);
+    expect(snap.gauges.test_crashes).toBe(1);
+
+    releaseA();
+    releaseB();
+  });
+});

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -21,6 +21,12 @@ import { createAdapter } from "./runtime";
 import type { RuntimeAdapter } from "./runtime/types";
 import { startServer } from "./server";
 import { type ControllerState, readStateFile, writeStateFile } from "./state-file";
+import {
+  registerGauges,
+  registerSignals,
+  start as startMemoryTelemetry,
+  stop as stopMemoryTelemetry,
+} from "./telemetry";
 
 type ServerHandle = ReturnType<typeof startServer>;
 
@@ -187,6 +193,27 @@ export async function startDaemon(
   const resolvedDeps = resolveDependencies(config, deps);
 
   const sharedServePort = config.baseWorkerPort;
+  let healthTicks = 0;
+  let sharedServeRestarts = 0;
+  let roleServeRestarts = 0;
+  let controllerRecreates = 0;
+  let indexInitializations = 0;
+  let indexIncrementalUpdates = 0;
+
+  registerSignals();
+  startMemoryTelemetry();
+  const releaseDaemonGauges = registerGauges("daemon-index", () => ({
+    daemon_port: config.daemonPort,
+    daemon_shared_serve_port: sharedServePort,
+    daemon_health_ticks: healthTicks,
+    daemon_shared_restarts: sharedServeRestarts,
+    daemon_role_restarts: roleServeRestarts,
+    daemon_controller_recreates: controllerRecreates,
+    daemon_index_initializations: indexInitializations,
+    daemon_index_incrementals: indexIncrementalUpdates,
+    daemon_controller_present: controllerState ? 1 : 0,
+    daemon_role_serves: roleServeManager?.getEntries().length ?? 0,
+  }));
   const controllerWorkspace = config.paths.forLegion(legionId).legionStateDir;
   const hasIndexRoot = !!config.legionDir && existsSync(config.legionDir);
   if (config.legionDir && !hasIndexRoot) {
@@ -253,6 +280,7 @@ export async function startDaemon(
   if (hasIndexRoot) {
     const startedIndexBuildAt = Date.now();
     await indexManager.initialize();
+    indexInitializations += 1;
     console.log(`Codebase index ready in ${Date.now() - startedIndexBuildAt}ms`);
   }
 
@@ -287,6 +315,8 @@ export async function startDaemon(
       crashHistory: state.crashHistory,
       controller: undefined,
     });
+    releaseDaemonGauges();
+    stopMemoryTelemetry();
     stopServer();
     if (exitAfter) {
       process.exit(0);
@@ -398,6 +428,7 @@ export async function startDaemon(
   const scheduleHealthTick = () => {
     healthTickTimeout = resolvedDeps.setTimeout(async () => {
       try {
+        healthTicks += 1;
         const serveHealthy = await resolvedDeps.adapter.healthy();
 
         if (!serveHealthy) {
@@ -409,6 +440,7 @@ export async function startDaemon(
               workspace: controllerWorkspace,
               logDir: config.logDir,
             });
+            sharedServeRestarts += 1;
             console.log(`Shared serve restarted on port ${sharedServePort}`);
 
             const state = await resolvedDeps.readStateFile(config.stateFilePath);
@@ -444,6 +476,7 @@ export async function startDaemon(
                   sessionId: actualControllerSessionId,
                   port: sharedServePort,
                 };
+                controllerRecreates += 1;
                 await sendPromptWithRetry(
                   resolvedDeps.adapter,
                   actualControllerSessionId,
@@ -462,6 +495,7 @@ export async function startDaemon(
 
         try {
           await indexManager.incrementalUpdate();
+          indexIncrementalUpdates += 1;
         } catch (error) {
           console.error(`Failed to update codebase index incrementally: ${error}`);
         }
@@ -478,6 +512,7 @@ export async function startDaemon(
                 controllerWorkspace,
                 config.logDir
               );
+              roleServeRestarts += 1;
               console.log(`Role serve '${role}' restarted`);
               // Re-create sessions for workers on this role
               const roleAdapter = roleServeManager.getAdapterForRole(role);

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -28,6 +28,7 @@ import {
   readStateFile,
   writeStateFile,
 } from "./state-file";
+import { registerGauges } from "./telemetry";
 
 type Server = ReturnType<typeof Bun.serve>;
 
@@ -66,7 +67,10 @@ const MAX_CRASHES = 3;
 const ONE_HOUR_MS = 60 * 60 * 1000;
 
 function jsonResponse(payload: unknown, status = 200): Response {
-  return new Response(JSON.stringify(payload), { status, headers: JSON_HEADERS });
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: JSON_HEADERS,
+  });
 }
 
 function badRequest(message: string): Response {
@@ -120,12 +124,37 @@ function extractModeFromWorkerId(workerId: string): WorkerModeLiteral | null {
   return null;
 }
 
-export function startServer(opts: ServerOptions): { server: Server; stop: () => void } {
+export function startServer(opts: ServerOptions): {
+  server: Server;
+  stop: () => void;
+} {
   const hostname = opts.hostname ?? "127.0.0.1";
   const port = opts.port ?? 13370;
   const startedAt = Date.now();
   const workers = new Map<string, WorkerEntry>();
   const crashHistory = new Map<string, CrashHistoryEntry>();
+  const releaseGauges = registerGauges("daemon-server", () => {
+    let starting = 0;
+    let running = 0;
+    let stopped = 0;
+    let dead = 0;
+    for (const entry of workers.values()) {
+      if (entry.status === "starting") starting += 1;
+      if (entry.status === "running") running += 1;
+      if (entry.status === "stopped") stopped += 1;
+      if (entry.status === "dead") dead += 1;
+    }
+    return {
+      daemon_workers: workers.size,
+      daemon_workers_starting: starting,
+      daemon_workers_running: running,
+      daemon_workers_stopped: stopped,
+      daemon_workers_dead: dead,
+      daemon_crash_entries: crashHistory.size,
+      daemon_controller_present: opts.getControllerState?.() ? 1 : 0,
+      daemon_uptime_s: Math.floor((Date.now() - startedAt) / 1000),
+    };
+  });
 
   let pendingWrite: Promise<void> = Promise.resolve();
 
@@ -703,6 +732,7 @@ export function startServer(opts: ServerOptions): { server: Server; stop: () => 
   return {
     server,
     stop: () => {
+      releaseGauges();
       server.stop(true);
     },
   };

--- a/packages/daemon/src/daemon/telemetry.ts
+++ b/packages/daemon/src/daemon/telemetry.ts
@@ -1,0 +1,167 @@
+import { heapStats } from "bun:jsc";
+import * as v8 from "node:v8";
+
+type GaugeFn = () => Record<string, number>;
+
+type Snap = {
+  at: string;
+  rss: number;
+  heapTotal: number;
+  heapUsed: number;
+  objectCount: number;
+  types: Record<string, number>;
+  gauges: Record<string, number>;
+};
+
+const SAMPLE_MS = 5_000;
+const SUMMARY_EVERY = 12;
+const GROWTH_LIMIT = 50 * 1024 * 1024;
+
+const sources = new Map<string, GaugeFn>();
+
+let timer: ReturnType<typeof setInterval> | undefined;
+let prev: Snap | undefined;
+let base: Snap | undefined;
+let tick = 0;
+let takingSnapshot = false;
+let usr1: (() => void) | undefined;
+let usr2: (() => void) | undefined;
+
+function toMB(value: number) {
+  return Number((value / 1024 / 1024).toFixed(1));
+}
+
+function emit(event: string, fields: Record<string, string | number | undefined>) {
+  const body = Object.entries(fields)
+    .filter(([, value]) => value !== undefined)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(" ");
+  process.stderr.write(`[daemon-telemetry] event=${event}${body ? ` ${body}` : ""}\n`);
+}
+
+export function registerGauges(key: string, fn: GaugeFn) {
+  sources.set(key, fn);
+  return () => {
+    sources.delete(key);
+  };
+}
+
+export function readGauges(): Record<string, number> {
+  const merged: Record<string, number> = {};
+  for (const source of sources.values()) {
+    Object.assign(merged, source());
+  }
+  return merged;
+}
+
+export function takeSnapshot(): Snap {
+  const mem = process.memoryUsage();
+  const stat = heapStats();
+  const types = Object.fromEntries(
+    Object.entries(stat.objectTypeCounts).map(([k, v]) => [k, Number(v)])
+  );
+  return {
+    at: new Date().toISOString(),
+    rss: mem.rss,
+    heapTotal: mem.heapTotal,
+    heapUsed: mem.heapUsed,
+    objectCount: Number(stat.objectCount),
+    types,
+    gauges: readGauges(),
+  };
+}
+
+function sampleOnce(event: "summary" | "growth" | "signal") {
+  const next = takeSnapshot();
+  const last = prev;
+  const start = base;
+  const delta = last ? next.rss - last.rss : 0;
+  emit(`memory.${event}`, {
+    ts: next.at,
+    rss_mb: toMB(next.rss),
+    heap_mb: toMB(next.heapUsed),
+    heap_total_mb: toMB(next.heapTotal),
+    object_count: next.objectCount,
+    rss_delta_mb: last ? toMB(delta) : 0,
+    rss_since_start_mb: start ? toMB(next.rss - start.rss) : 0,
+    ...next.gauges,
+  });
+  prev = next;
+  if (!base) base = next;
+}
+
+function maybeSample() {
+  const next = takeSnapshot();
+  const last = prev;
+  const start = base;
+  const delta = last ? next.rss - last.rss : 0;
+  const summary = tick % SUMMARY_EVERY === 0;
+  const growing = tick >= SUMMARY_EVERY && delta > GROWTH_LIMIT;
+  if (summary || growing) {
+    emit(summary ? "memory.summary" : "memory.growth", {
+      ts: next.at,
+      rss_mb: toMB(next.rss),
+      heap_mb: toMB(next.heapUsed),
+      heap_total_mb: toMB(next.heapTotal),
+      object_count: next.objectCount,
+      rss_delta_mb: last ? toMB(delta) : 0,
+      rss_since_start_mb: start ? toMB(next.rss - start.rss) : 0,
+      ...next.gauges,
+    });
+  }
+  prev = next;
+  if (!base) base = next;
+  tick += 1;
+}
+
+function writeSnapshot(signal: string) {
+  if (takingSnapshot) return;
+  takingSnapshot = true;
+  try {
+    const path = `/tmp/legion-heap-${process.pid}-${Date.now()}.heapsnapshot`;
+    emit("memory.snapshot_start", {
+      signal,
+      path,
+      rss_mb: toMB(process.memoryUsage().rss),
+    });
+    const file = v8.writeHeapSnapshot(path);
+    emit("memory.snapshot_done", { signal, path: file });
+  } finally {
+    takingSnapshot = false;
+  }
+}
+
+export function registerSignals() {
+  if (usr1 && usr2) return;
+  usr1 = () => writeSnapshot("SIGUSR1");
+  usr2 = () => sampleOnce("signal");
+  process.on("SIGUSR1", usr1);
+  process.on("SIGUSR2", usr2);
+}
+
+export function start() {
+  registerSignals();
+  if (timer) return;
+  tick = 0;
+  prev = undefined;
+  base = undefined;
+  const first = takeSnapshot();
+  prev = first;
+  base = first;
+  emit("memory.baseline", {
+    ts: first.at,
+    rss_mb: toMB(first.rss),
+    heap_mb: toMB(first.heapUsed),
+    heap_total_mb: toMB(first.heapTotal),
+    object_count: first.objectCount,
+    ...first.gauges,
+  });
+  timer = setInterval(maybeSample, SAMPLE_MS);
+  timer.unref?.();
+}
+
+export function stop() {
+  if (!timer) return;
+  clearInterval(timer);
+  timer = undefined;
+}

--- a/packages/envoy-plugin/AGENTS.md
+++ b/packages/envoy-plugin/AGENTS.md
@@ -1,0 +1,33 @@
+# Envoy Plugin Package
+
+OpenCode plugin package for Legion's Envoy subsystem.
+
+## Overview
+
+This plugin exposes the Envoy tools and maintains the live session registry metadata Envoy needs for hot delivery.
+
+It is the user-facing bridge between OpenCode sessions and Envoy transport.
+
+## Where to look
+
+| Task                | Location               | Notes                                                              |
+| ------------------- | ---------------------- | ------------------------------------------------------------------ |
+| Tool definitions    | `src/index.ts`         | `envoy_subscribe`, `envoy_unsubscribe`, `envoy_list`, `envoy_send` |
+| Packaging metadata  | `package.json`         | npm identity, build scripts                                        |
+| Distribution output | `dist/index.js`        | built plugin consumed by OpenCode                                  |
+| Host rollout helper | `scripts/sync-host.sh` | sync dist + shim to remote host                                    |
+
+## Critical conventions
+
+- Tool descriptions must be self-describing enough that agents can infer correct topic formats.
+- Slack examples must use real `team_id` values, not workspace slugs.
+- This package owns the session-registry/port-backfill behavior now; do not split that back into a second plugin casually.
+- Keep the plugin source-of-truth here even if a dotfiles shim is still used for rollout convenience.
+
+## Topic reminders
+
+- Agent: `notifications.agent.<session_id>`
+- GitHub: `notifications.github.<owner>.<repo>.<kind>`
+- Slack: `notifications.slack.<team_id>.<channel_id>.<message|mention>`
+
+If you are unsure what a session is subscribed to, use `envoy_list()`.

--- a/packages/envoy-plugin/README.md
+++ b/packages/envoy-plugin/README.md
@@ -1,0 +1,27 @@
+# @sjawhar/opencode-legion-envoy
+
+OpenCode plugin for Legion's Envoy subsystem.
+
+This package exposes:
+
+- `envoy_subscribe`
+- `envoy_unsubscribe`
+- `envoy_list`
+- `envoy_send`
+
+It also maintains the live session registry metadata needed for Envoy to discover OpenCode sessions and their API ports.
+
+Slack topic examples must use the real Slack `team_id`, for example:
+
+- `notifications.slack.T09FRELLTS8.C0A0DHVU8HE.mention`
+
+Do not use workspace slugs like `trajectorylabs` in the topic path.
+
+## Sync to another machine
+
+```bash
+cd ~/legion/default/packages/envoy-plugin
+./scripts/sync-host.sh sami@sami
+```
+
+This syncs the built plugin dist and the dotfiles shim to the target host.

--- a/packages/envoy-plugin/package.json
+++ b/packages/envoy-plugin/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@sjawhar/opencode-legion-envoy",
+  "version": "0.1.0-alpha.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "bun build src/index.ts --outdir dist --target bun --format esm",
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test",
+    "lint": "bunx biome check src/"
+  },
+  "dependencies": {
+    "@opencode-ai/plugin": "^1.1.19"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.3.14",
+    "@types/bun": "latest",
+    "typescript": "^5.3.0"
+  }
+}

--- a/packages/envoy-plugin/scripts/sync-host.sh
+++ b/packages/envoy-plugin/scripts/sync-host.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+host="${1:?usage: sync-host.sh user@host}"
+root="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+rsync -az "$root/packages/envoy-plugin/dist/" "$host:~/legion/default/packages/envoy-plugin/dist/"
+rsync -az "$HOME/.dotfiles/opencode/plugins/envoy.ts" "$host:~/.dotfiles/opencode/plugins/envoy.ts"

--- a/packages/envoy-plugin/src/index.ts
+++ b/packages/envoy-plugin/src/index.ts
@@ -1,0 +1,195 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { tool } from "@opencode-ai/plugin/tool";
+
+const root = process.env.ENVOY_URL ?? "http://127.0.0.1:9020";
+
+async function call(path: string, init?: RequestInit) {
+  const res = await fetch(`${root}${path}`, init);
+  const text = await res.text();
+  if (!res.ok) throw new Error(text || `${res.status}`);
+  return text;
+}
+
+export default async (input: { serverUrl: URL }) => {
+  const shellPid = process.env.OC_SHELL_PID;
+  const registryDir = process.env.OC_REGISTRY;
+  const file = shellPid && registryDir ? `${registryDir}/${shellPid}.json` : null;
+  let activeSessionID: string | null = null;
+
+  const update = (patch: Record<string, unknown>) => {
+    if (!file) return;
+    try {
+      const data = JSON.parse(readFileSync(file, "utf-8"));
+      Object.assign(data, patch);
+      writeFileSync(file, `${JSON.stringify(data)}\n`);
+    } catch {}
+  };
+
+  const currentPort = () => {
+    const value = Number.parseInt(input.serverUrl.port, 10);
+    if (Number.isFinite(value) && value > 0) return value;
+
+    try {
+      const output = execFileSync("ss", ["-tlnp"], { encoding: "utf-8" });
+      for (const line of output.split("\n")) {
+        if (!line.includes(`pid=${process.pid}`)) continue;
+        const parts = line.trim().split(/\s+/);
+        const local = parts[3];
+        const match = local?.match(/:(\d+)$/);
+        if (!match) continue;
+        const port = Number.parseInt(match[1], 10);
+        if (Number.isFinite(port) && port > 0) return port;
+      }
+    } catch {}
+
+    return null;
+  };
+
+  const syncPort = () => {
+    const value = currentPort();
+    if (!value) return false;
+    update({ port: value });
+    return true;
+  };
+
+  const fetchSession = async (sessionID: string) => {
+    try {
+      const res = await fetch(`${input.serverUrl}/session/${sessionID}`);
+      if (!res.ok) return null;
+      const session = await res.json();
+      return { id: session.id, title: session.title || "" };
+    } catch {
+      return null;
+    }
+  };
+
+  if (file) {
+    syncPort();
+    const timer = setInterval(() => {
+      if (syncPort()) clearInterval(timer);
+    }, 1000);
+  }
+
+  return {
+    event: file
+      ? async ({ event }: { event: { type?: string; properties?: Record<string, unknown> } }) => {
+          syncPort();
+
+          if (
+            event.type === "session.status" &&
+            (event.properties?.status as { type?: string } | undefined)?.type === "busy"
+          ) {
+            const sessionID = event.properties?.sessionID as string | undefined;
+            if (sessionID && sessionID !== activeSessionID) {
+              activeSessionID = sessionID;
+              const session = await fetchSession(sessionID);
+              if (session) update({ session });
+              call("/v1/interests/subscribe", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  session_id: sessionID,
+                  dir: process.cwd(),
+                  topics: [`notifications.agent.${sessionID}`],
+                }),
+              }).catch(() => {});
+            }
+          }
+          if (event.type === "session.updated") {
+            const info = event.properties?.info as { id?: string; title?: string } | undefined;
+            if (info && info.id === activeSessionID) {
+              update({ session: { id: info.id, title: info.title || "" } });
+            }
+          }
+
+          if (event.type === "session.idle") {
+            const sessionID = event.properties?.sessionID as string | undefined;
+            if (sessionID && sessionID === activeSessionID) {
+              const session = await fetchSession(sessionID);
+              if (session) update({ session });
+            }
+          }
+        }
+      : undefined,
+    tool: {
+      envoy_subscribe: tool({
+        description:
+          "Subscribe this session to Envoy notification topics. Use exact NATS-style topic strings such as notifications.agent.<session_id>, notifications.github.<owner>.<repo>.pr, notifications.github.<owner>.<repo>.issue, notifications.github.<owner>.<repo>.comment, notifications.github.<owner>.<repo>.ci, notifications.slack.<team_id>.<channel_id>.message, or notifications.slack.<team_id>.<channel_id>.mention. Use this when a session should RECEIVE future events.",
+        args: {
+          topics: tool.schema
+            .array(tool.schema.string())
+            .describe(
+              "NATS-style topic patterns to subscribe to. Examples: notifications.agent.ses_123, notifications.github.trajectory-labs-pbc.agent-c.pr, notifications.slack.T09FRELLTS8.C0A0DHVU8HE.mention"
+            ),
+        },
+        async execute(args, ctx) {
+          ctx.metadata({ title: "Envoy subscribe" });
+          return call("/v1/interests/subscribe", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              session_id: ctx.sessionID,
+              dir: ctx.directory,
+              topics: args.topics,
+            }),
+          });
+        },
+      }),
+      envoy_unsubscribe: tool({
+        description:
+          "Unsubscribe this session from Envoy topics, or remove all current subscriptions if topics are omitted.",
+        args: {
+          topics: tool.schema
+            .array(tool.schema.string())
+            .optional()
+            .describe("Topics to remove, or omit to remove all"),
+        },
+        async execute(args, ctx) {
+          ctx.metadata({ title: "Envoy unsubscribe" });
+          return call("/v1/interests/unsubscribe", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              session_id: ctx.sessionID,
+              topics: args.topics ?? [],
+            }),
+          });
+        },
+      }),
+      envoy_list: tool({
+        description:
+          "List the current Envoy topic subscriptions for this session so you can confirm the exact topic shapes that are active.",
+        args: {},
+        async execute(_args, ctx) {
+          ctx.metadata({ title: "Envoy list" });
+          return call(`/v1/interests/${ctx.sessionID}`);
+        },
+      }),
+      envoy_send: tool({
+        description:
+          "Send an Envoy agent-to-agent message directly to another session by session ID. Use this for coordination between agents or to notify a known controller/worker session. This is for SEND, not subscription.",
+        args: {
+          target_session: tool.schema
+            .string()
+            .describe("Target OpenCode session ID, e.g. ses_2e6ca3034ffejVikSZ8mDwk0mR"),
+          message: tool.schema
+            .string()
+            .describe("Message body to deliver to that session as a new user turn/notification"),
+        },
+        async execute(args, ctx) {
+          ctx.metadata({ title: "Envoy send" });
+          return call("/v1/messages/send", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              source_session: ctx.sessionID,
+              target_session: args.target_session,
+              message: args.message,
+            }),
+          });
+        },
+      }),
+    },
+  };
+};

--- a/packages/envoy-plugin/tsconfig.json
+++ b/packages/envoy-plugin/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/envoy/.dockerignore
+++ b/packages/envoy/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.jj
+node_modules
+dist
+build
+coverage
+*.log
+.env
+.env.*
+.vscode
+.idea
+docker-data
+tmp

--- a/packages/envoy/.gitignore
+++ b/packages/envoy/.gitignore
@@ -1,0 +1,5 @@
+github
+listener
+slack
+deploy/compose/nats/nats.conf
+deploy/compose/nats/nats-*.conf

--- a/packages/envoy/AGENTS.md
+++ b/packages/envoy/AGENTS.md
@@ -1,0 +1,42 @@
+# Envoy Package
+
+Go-based cross-machine event transport and delivery subsystem.
+
+## Overview
+
+Envoy owns transport, routing, and delivery:
+
+- ingests Slack/GitHub/agent events
+- publishes and consumes via NATS/JetStream
+- resolves target OpenCode sessions
+- delivers by hot `prompt_async` or cold `opencode run --session`
+
+It does not own Legion workflow policy. The daemon/controller decides what to do; Envoy moves events to the right session.
+
+## Where to look
+
+| Task                   | Location                                  | Notes                                              |
+| ---------------------- | ----------------------------------------- | -------------------------------------------------- |
+| Receiver behavior      | `cmd/github/main.go`, `cmd/slack/main.go` | HTTP ingress, signature verification, publish path |
+| Listener behavior      | `cmd/listener/main.go`                    | subscribe/match/deliver flow                       |
+| NATS client            | `internal/bus/nats.go`                    | reconnect/self-heal logic                          |
+| Session delivery       | `internal/session/session.go`             | hot vs cold delivery                               |
+| Interest storage       | `internal/store/kv.go`                    | JetStream KV subscriptions                         |
+| Topic matching         | `internal/routing/match.go`               | wildcard matching                                  |
+| Envelope normalization | `internal/contracts/*.go`                 | generated contract + source-specific normalization |
+| Deploy/runtime         | `deploy/`                                 | compose, rollout scripts, NATS peer setup          |
+
+## Critical conventions
+
+- `packages/contracts` is the source of truth for event contract shape; regenerate Go output from there.
+- Keep Envoy API-level with OpenCode. Do not add DB introspection or OpenCode-specific hidden coupling unless there is no API path.
+- `github` / `slack` receivers must fail loudly and return 503 when publish cannot be confirmed.
+- GitHub mention routing is additive: matching comments publish to both `.comment` and `.mention` topics.
+- Slack topics must use the real Slack `team_id`, not a workspace slug.
+- NATS peer storage uses named Docker volumes, not repo-path bind mounts.
+
+## Operational notes
+
+- Health endpoints should reflect NATS health, not just process liveness.
+- If a session is not live in the registry, Envoy will cold-resume it with the configured `ENVOY_OPENCODE_BIN`.
+- Cross-machine route correctness depends on valid session registry entries with non-null ports.

--- a/packages/envoy/README.md
+++ b/packages/envoy/README.md
@@ -1,0 +1,62 @@
+# envoy
+
+Docker-first cross-machine notification routing for AI agent sessions.
+
+## Goals
+
+- Route GitHub, Slack, WhatsApp, and agent-to-agent notifications to the correct opencode session
+- Keep all envoy-owned code and infrastructure in this repo
+- Run every envoy component inside Docker containers
+- Avoid host installs except Docker on remote machines that need it
+- Inject secrets only at runtime via the `secrets` wrapper from `~/.dotfiles/shims/secrets`
+
+## Repo boundaries
+
+This repo owns:
+
+- NATS cluster config and container packaging
+- Envoy shared code
+- Envoy listener / router / webhook receivers
+- Compose files, deploy scripts, and Dockerfiles
+
+This repo does **not** silently absorb changes to other maintained software.
+
+If envoy needs changes in `opencode`, `@sjawhar/whatsapp-mcp`, or another maintained repo:
+
+- make that change in the other repo
+- keep it as a separate clear jj change/commit
+- do **not** bundle it into an existing `sami` octopus merge
+- document the dependency here under `docs/external-repos.md`
+
+## Secrets
+
+Secrets are never stored in this repo. Runtime injection uses:
+
+```bash
+secrets ENVOY_SLACK_SIGNING_SECRET ENVOY_GITHUB_WEBHOOK_SECRET -- <command>
+```
+
+Current secret names:
+
+- `ENVOY_SLACK_SIGNING_SECRET`
+- `ENVOY_GITHUB_WEBHOOK_SECRET`
+
+## Layout
+
+- `internal/contracts/generated.go` — generated Go contract output from `packages/contracts/scripts/gen-go.ts`
+- `internal/config` — env parsing
+- `internal/verify` — GitHub / Slack signature verification
+- `cmd/listener` — per-machine listener service
+- `cmd/github` — GitHub webhook receiver
+- `cmd/slack` — Slack Events receiver
+- `docker/github.Dockerfile` — GitHub receiver image
+- `docker/slack.Dockerfile` — Slack receiver image
+- `docker/listener.Dockerfile` — listener image
+- `deploy` — compose files and deploy scripts
+- `docs` — architecture, constraints, external repo touchpoints
+- `.envoy` — local execution notes and machine-readable work tracker
+
+## Contract source of truth
+
+The authoritative event contract lives in `packages/contracts/`.
+Run `bun run gen:go` in that package before validating or releasing `packages/envoy`.

--- a/packages/envoy/cmd/github/main.go
+++ b/packages/envoy/cmd/github/main.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sjawhar/envoy/internal/bus"
+	"github.com/sjawhar/envoy/internal/config"
+	"github.com/sjawhar/envoy/internal/contracts"
+	"github.com/sjawhar/envoy/internal/id"
+	"github.com/sjawhar/envoy/internal/verify"
+)
+
+func main() {
+	cfg, err := config.Load(9010)
+	if err != nil {
+		log.Fatal(err)
+	}
+	secret := getenv("ENVOY_GITHUB_WEBHOOK_SECRET")
+	trigger := getenvDefault("ENVOY_GITHUB_MENTION_TRIGGER", "@legion")
+	client, err := bus.Connect(cfg.NATSURLs)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Conn.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		if err := client.Conn.FlushTimeout(3 * time.Second); err != nil {
+			http.Error(w, "nats unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/webhook/github", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 1<<20))
+		if err != nil {
+			http.Error(w, "invalid body", http.StatusBadRequest)
+			return
+		}
+		delivery := r.Header.Get("X-GitHub-Delivery")
+		event := r.Header.Get("X-GitHub-Event")
+		signature := r.Header.Get("X-Hub-Signature-256")
+		if delivery == "" || event == "" {
+			http.Error(w, "missing github headers", http.StatusBadRequest)
+			return
+		}
+		if !verify.Github(secret, body, signature) {
+			http.Error(w, "invalid signature", http.StatusUnauthorized)
+			return
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		if githubEvent(event) && contracts.GithubIsBotSender(payload) {
+			log.Printf("github skipped bot sender delivery=%s event=%s", delivery, event)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+			return
+		}
+		if githubSkip(event) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+			return
+		}
+		items := contracts.GithubEnvelopes(contracts.GithubEnvelopeInput{
+			Event:    event,
+			Delivery: delivery,
+			Body:     payload,
+			EventID:  id.New(),
+			TraceID:  id.New(),
+		}, trigger)
+		for _, item := range items {
+			if err := item.Validate(); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if err := client.Publish(item); err != nil {
+				log.Printf("github publish failed: %v", err)
+				http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+				return
+			}
+		}
+		if len(items) > 1 {
+			log.Printf("github mention detected delivery=%s trigger=%s", delivery, trigger)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	log.Printf("envoy-github listening on %d", cfg.Port)
+	server := &http.Server{Addr: addr(cfg.Port), Handler: mux, ReadTimeout: 10 * time.Second, WriteTimeout: 10 * time.Second, IdleTimeout: 60 * time.Second}
+	log.Fatal(server.ListenAndServe())
+}
+
+func addr(port int) string {
+	return ":" + strconv.Itoa(port)
+}
+
+func getenv(key string) string {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		log.Fatalf("%s is required", key)
+	}
+	return value
+}
+
+func getenvDefault(key string, fallback string) string {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value != "" {
+		return value
+	}
+	return fallback
+}
+
+func githubEvent(event string) bool {
+	switch event {
+	case "issue_comment", "pull_request_review_comment", "pull_request_review":
+		return true
+	}
+	return false
+}
+
+func githubSkip(event string) bool {
+	switch event {
+	case "check_run", "check_suite":
+		return true
+	}
+	return false
+}

--- a/packages/envoy/cmd/listener/main.go
+++ b/packages/envoy/cmd/listener/main.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/sjawhar/envoy/internal/bus"
+	"github.com/sjawhar/envoy/internal/config"
+	"github.com/sjawhar/envoy/internal/contracts"
+	"github.com/sjawhar/envoy/internal/id"
+	"github.com/sjawhar/envoy/internal/session"
+	"github.com/sjawhar/envoy/internal/store"
+)
+
+func main() {
+	cfg, err := config.Load(9020)
+	if err != nil {
+		log.Fatal(err)
+	}
+	client, err := bus.Connect(cfg.NATSURLs)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Conn.Close()
+	registry, err := store.Open(client.Conn)
+	if err != nil {
+		log.Fatal(err)
+	}
+	deliver := session.Deliverer{
+		RegistryDir: os.Getenv("ENVOY_REGISTRY_DIR"),
+		HostBridge:  os.Getenv("ENVOY_HOST_BRIDGE"),
+		OpencodeBin: os.Getenv("ENVOY_OPENCODE_BIN"),
+		XDGConfig:   os.Getenv("ENVOY_XDG_CONFIG_HOME"),
+		XDGData:     os.Getenv("ENVOY_XDG_DATA_HOME"),
+		XDGCache:    os.Getenv("ENVOY_XDG_CACHE_HOME"),
+	}
+
+	consumer := "listener-" + strings.ReplaceAll(cfg.MachineID, " ", "-")
+	// Delete stale consumer to clear redelivery backlog from old slow Match()
+	_ = client.JS().DeleteConsumer(bus.Stream, consumer)
+	_, err = client.JS().Subscribe("notifications.>", func(msg *nats.Msg) {
+		var item contracts.Envelope
+		if err := json.Unmarshal(msg.Data, &item); err != nil {
+			log.Printf("listener decode failed: %v", err)
+			_ = msg.Ack()
+			return
+		}
+		if err := item.Validate(); err != nil {
+			log.Printf("listener invalid envelope: %v", err)
+			_ = msg.Ack()
+			return
+		}
+		log.Printf("listener received machine=%s source=%s topic=%s event_id=%s", cfg.MachineID, item.Source, item.Topic, item.EventID)
+		if item.Source == "agent" {
+			sessionID := strings.TrimPrefix(item.Topic, "notifications.agent.")
+			interest, err := registry.Get(sessionID)
+			if err == nil && interest.MachineID == cfg.MachineID {
+				if err := deliver.Deliver(item, interest); err != nil {
+					log.Printf("listener agent delivery failed: %v", err)
+				}
+				_ = msg.Ack()
+				return
+			}
+			entry, err := deliver.Find(sessionID)
+			if err != nil || entry == nil {
+				_ = msg.Ack()
+				return
+			}
+			fallback := store.Interest{SessionID: sessionID, Dir: entry.Dir, MachineID: cfg.MachineID}
+			if err := deliver.Deliver(item, fallback); err != nil {
+				log.Printf("listener agent delivery failed: %v", err)
+			}
+			_ = msg.Ack()
+			return
+		}
+		items := registry.Match(cfg.MachineID, item.Topic)
+		for _, interest := range items {
+			if err := deliver.Deliver(item, interest); err != nil {
+				log.Printf("listener delivery failed session=%s: %v", interest.SessionID, err)
+			}
+		}
+		_ = msg.Ack()
+	}, nats.Durable(consumer), nats.DeliverNew(), nats.AckExplicit(), nats.ManualAck(), nats.AckWait(60*time.Second), nats.MaxAckPending(256))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		if err := client.Conn.FlushTimeout(3 * time.Second); err != nil {
+			http.Error(w, "nats unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/v1/interests/subscribe", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var body struct {
+			SessionID string   `json:"session_id"`
+			Dir       string   `json:"dir"`
+			Topics    []string `json:"topics"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		item, err := registry.Upsert(store.Interest{
+			SessionID: body.SessionID,
+			MachineID: cfg.MachineID,
+			Dir:       body.Dir,
+		}, append(body.Topics, contracts.AgentSubject(body.SessionID)))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(item)
+	})
+	mux.HandleFunc("/v1/interests/unsubscribe", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var body struct {
+			SessionID string   `json:"session_id"`
+			Topics    []string `json:"topics"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		if err := registry.Remove(body.SessionID, body.Topics); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/v1/interests/", func(w http.ResponseWriter, r *http.Request) {
+		sessionID := strings.TrimPrefix(r.URL.Path, "/v1/interests/")
+		item, err := registry.Get(sessionID)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(item)
+	})
+	mux.HandleFunc("/v1/messages/send", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var body struct {
+			TargetSession string `json:"target_session"`
+			Message       string `json:"message"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		item := contracts.Envelope{
+			EventID:        id.New(),
+			Source:         "agent",
+			SourceEventID:  id.New(),
+			Topic:          contracts.AgentSubject(body.TargetSession),
+			DedupeKey:      "agent." + body.TargetSession + "." + id.New(),
+			IssuedAt:       contracts.NowMillis(),
+			PayloadSummary: body.Message,
+			TraceID:        id.New(),
+		}
+		if err := item.Validate(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := client.Publish(item); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(item)
+	})
+
+	log.Printf("envoy-listener listening on 127.0.0.1:%d", cfg.Port)
+	server := &http.Server{Addr: "127.0.0.1:" + strconv.Itoa(cfg.Port), Handler: mux, ReadTimeout: 10 * time.Second, WriteTimeout: 10 * time.Second, IdleTimeout: 60 * time.Second}
+	log.Fatal(server.ListenAndServe())
+}

--- a/packages/envoy/cmd/slack/main.go
+++ b/packages/envoy/cmd/slack/main.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sjawhar/envoy/internal/bus"
+	"github.com/sjawhar/envoy/internal/config"
+	"github.com/sjawhar/envoy/internal/contracts"
+	"github.com/sjawhar/envoy/internal/id"
+	"github.com/sjawhar/envoy/internal/verify"
+)
+
+func main() {
+	cfg, err := config.Load(9011)
+	if err != nil {
+		log.Fatal(err)
+	}
+	secret := getenv("ENVOY_SLACK_SIGNING_SECRET")
+	client, err := bus.Connect(cfg.NATSURLs)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Conn.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		if err := client.Conn.FlushTimeout(3 * time.Second); err != nil {
+			http.Error(w, "nats unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/webhook/slack", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 1<<20))
+		if err != nil {
+			http.Error(w, "invalid body", http.StatusBadRequest)
+			return
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		if typeName(payload["type"]) == "url_verification" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"challenge": payload["challenge"]})
+			return
+		}
+		if !verify.Slack(secret, body, r.Header.Get("X-Slack-Request-Timestamp"), r.Header.Get("X-Slack-Signature")) {
+			http.Error(w, "invalid signature", http.StatusUnauthorized)
+			return
+		}
+		if typeName(payload["type"]) == "event_callback" && stringValue(payload["event_id"]) != "" {
+			items := contracts.SlackEnvelopes(contracts.SlackEnvelopeInput{Body: payload, EventID: id.New(), TraceID: id.New()})
+			for _, item := range items {
+				if err := item.Validate(); err != nil {
+					continue
+				}
+				if err := client.Publish(item); err != nil {
+					log.Printf("slack publish failed: %v", err)
+					http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+					return
+				}
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	log.Printf("envoy-slack listening on %d", cfg.Port)
+	server := &http.Server{Addr: addr(cfg.Port), Handler: mux, ReadTimeout: 10 * time.Second, WriteTimeout: 10 * time.Second, IdleTimeout: 60 * time.Second}
+	log.Fatal(server.ListenAndServe())
+}
+
+func addr(port int) string {
+	return ":" + strconv.Itoa(port)
+}
+
+func getenv(key string) string {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		log.Fatalf("%s is required", key)
+	}
+	return value
+}
+
+func typeName(value any) string {
+	text, _ := value.(string)
+	return text
+}
+
+func stringValue(value any) string {
+	text, _ := value.(string)
+	return text
+}

--- a/packages/envoy/deploy/README.md
+++ b/packages/envoy/deploy/README.md
@@ -1,0 +1,93 @@
+# Deploy
+
+## Layout
+
+- `compose/listener.compose.yml` — host-network listener with opencode registry and host home mounts
+- `compose/github.compose.yml` — host-network GitHub receiver
+- `compose/slack.compose.yml` — host-network Slack receiver
+- `compose/nats/peer.compose.yml` — JetStream peer node (all machines run as peers via Tailscale)
+
+## Secrets
+
+Never store plaintext secrets here. Launch ingress services with the wrapper scripts:
+
+- `deploy/scripts/up-github.sh`
+- `deploy/scripts/up-slack.sh`
+
+These use `secrets ... -- docker compose ...` so the secrets exist only in the process environment at runtime.
+If the local SOPS file has a MAC mismatch, the helper falls back to a scoped `sops --ignore-mac` read for only the requested key.
+
+## GitHub mention trigger
+
+The GitHub receiver can publish a second `.mention` topic when a comment body contains a matching trigger.
+
+- `ENVOY_GITHUB_MENTION_TRIGGER` — optional, defaults to `@legion`
+
+GitHub does not provide a native `app_mention` webhook event like Slack. Mention routing is body-based and additive: matching comments still publish to `.comment`, and also publish to `.mention`.
+
+## Host sync
+
+```bash
+cd ~/legion/default
+./scripts/sync-envoy-host.sh sami@sami
+./scripts/sync-envoy-host.sh claude@sami-claude
+./scripts/sync-envoy-host.sh ghost-wispr@ghost-wispr
+```
+
+## Pi Docker install
+
+```bash
+ssh ghost-wispr@ghost-wispr 'bash -s' < ~/legion/default/packages/envoy/deploy/scripts/install-docker-debian.sh
+```
+
+## NATS peer envs
+
+For each peer host, export:
+
+- `NATS_SERVER_NAME`
+- `NATS_ROUTES`
+
+Peer nodes now store JetStream data in a Docker named volume (`nats_data`) instead of a bind-mounted repo path. This keeps cluster state independent of repo checkouts and survives source tree moves/removal.
+
+If the cluster state is corrupt and you intentionally want a clean reset, run:
+
+```bash
+cd ~/legion/default/packages/envoy/deploy/compose/nats
+docker compose -f peer.compose.yml down -v
+```
+
+Then bring the peer back with `../scripts/up-nats-peer.sh` after regenerating `nats.conf`.
+
+Example:
+
+```bash
+export NATS_SERVER_NAME=sami-agents-mx
+export NATS_ROUTES="nats://sami:6222 nats://sami-claude:6222"
+deploy/scripts/up-nats-peer.sh
+```
+
+## Listener envs
+
+- `ENVOY_MACHINE_ID`
+- `NATS_URLS`
+- `ENVOY_HOME`
+- `ENVOY_REGISTRY_DIR`
+- `ENVOY_OPENCODE_BIN`
+
+Example:
+
+```bash
+export ENVOY_MACHINE_ID=sami-agents-mx
+export NATS_URLS=nats://127.0.0.1:4222,nats://sami:4222,nats://sami-claude:4222
+export ENVOY_HOME=/home/ubuntu
+export ENVOY_REGISTRY_DIR=/tmp/opencode-1000
+export ENVOY_OPENCODE_BIN=/home/ubuntu/.mise/installs/github-sjawhar-opencode/1.3.2-sami.20260328-035401/opencode
+deploy/scripts/up-listener.sh
+```
+
+## GitHub receiver envs
+
+- `ENVOY_MACHINE_ID`
+- `NATS_URLS`
+- `ENVOY_GITHUB_WEBHOOK_SECRET`
+- `ENVOY_GITHUB_MENTION_TRIGGER` (optional, default `@legion`)

--- a/packages/envoy/deploy/compose/github.compose.yml
+++ b/packages/envoy/deploy/compose/github.compose.yml
@@ -1,0 +1,19 @@
+services:
+  github:
+    build:
+      context: ../..
+      dockerfile: docker/github.Dockerfile
+    network_mode: host
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9010/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    environment:
+      PORT: ${ENVOY_GITHUB_PORT:-9010}
+      ENVOY_MACHINE_ID: ${ENVOY_MACHINE_ID}
+      NATS_URLS: ${NATS_URLS}
+      ENVOY_GITHUB_WEBHOOK_SECRET: ${ENVOY_GITHUB_WEBHOOK_SECRET}
+      ENVOY_GITHUB_MENTION_TRIGGER: ${ENVOY_GITHUB_MENTION_TRIGGER:-@legion}

--- a/packages/envoy/deploy/compose/listener.compose.yml
+++ b/packages/envoy/deploy/compose/listener.compose.yml
@@ -1,0 +1,27 @@
+services:
+  listener:
+    build:
+      context: ../..
+      dockerfile: docker/listener.Dockerfile
+    network_mode: host
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9020/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    environment:
+      HOME: ${ENVOY_HOME}
+      PORT: ${ENVOY_LISTENER_PORT:-9020}
+      ENVOY_MACHINE_ID: ${ENVOY_MACHINE_ID}
+      NATS_URLS: ${NATS_URLS}
+      ENVOY_REGISTRY_DIR: ${ENVOY_REGISTRY_DIR}
+      ENVOY_HOST_BRIDGE: 127.0.0.1
+      ENVOY_OPENCODE_BIN: ${ENVOY_OPENCODE_BIN}
+      ENVOY_XDG_CONFIG_HOME: ${ENVOY_HOME}/.config
+      ENVOY_XDG_DATA_HOME: ${ENVOY_HOME}/.local/share
+      ENVOY_XDG_CACHE_HOME: ${ENVOY_HOME}/.cache
+    volumes:
+      - ${ENVOY_REGISTRY_DIR}:${ENVOY_REGISTRY_DIR}:ro
+      - ${ENVOY_HOME}:${ENVOY_HOME}

--- a/packages/envoy/deploy/compose/nats/compose.yml
+++ b/packages/envoy/deploy/compose/nats/compose.yml
@@ -1,0 +1,12 @@
+services:
+  nats:
+    image: nats:2.11-alpine
+    restart: unless-stopped
+    ports:
+      - "4222:4222"
+      - "6222:6222"
+      - "8222:8222"
+    volumes:
+      - ./nats.conf:/etc/nats/nats.conf:ro
+      - ../../docker-data/nats:/data
+    command: ["-c", "/etc/nats/nats.conf", "-m", "8222"]

--- a/packages/envoy/deploy/compose/nats/peer.compose.yml
+++ b/packages/envoy/deploy/compose/nats/peer.compose.yml
@@ -1,0 +1,15 @@
+services:
+  nats:
+    image: nats:2.11-alpine
+    restart: unless-stopped
+    ports:
+      - "4222:4222"
+      - "6222:6222"
+      - "8222:8222"
+    volumes:
+      - ./nats.conf:/etc/nats/nats.conf:ro
+      - nats_data:/data
+    command: ["-c", "/etc/nats/nats.conf", "-m", "8222"]
+
+volumes:
+  nats_data:

--- a/packages/envoy/deploy/compose/slack.compose.yml
+++ b/packages/envoy/deploy/compose/slack.compose.yml
@@ -1,0 +1,18 @@
+services:
+  slack:
+    build:
+      context: ../..
+      dockerfile: docker/slack.Dockerfile
+    network_mode: host
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9011/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    environment:
+      PORT: ${ENVOY_SLACK_PORT:-9011}
+      ENVOY_MACHINE_ID: ${ENVOY_MACHINE_ID}
+      NATS_URLS: ${NATS_URLS}
+      ENVOY_SLACK_SIGNING_SECRET: ${ENVOY_SLACK_SIGNING_SECRET}

--- a/packages/envoy/deploy/scripts/install-docker-debian.sh
+++ b/packages/envoy/deploy/scripts/install-docker-debian.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+sudo apt-get remove -y docker.io docker-doc docker-compose podman-docker containerd runc 2>/dev/null || true
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+. /etc/os-release
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian ${VERSION_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo systemctl enable --now docker
+docker --version

--- a/packages/envoy/deploy/scripts/read-secret.sh
+++ b/packages/envoy/deploy/scripts/read-secret.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+key="${1:?usage: read-secret.sh KEY}"
+
+if value=$(secrets get "$key" 2>/dev/null); then
+  printf '%s' "$value"
+  exit 0
+fi
+
+export SOPS_AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-$HOME/.config/sops/age/keys.txt}"
+sops -d --ignore-mac --output-type dotenv "$HOME/.dotfiles/secrets.env" | grep "^${key}=" | cut -d= -f2-

--- a/packages/envoy/deploy/scripts/render-nats-peer.sh
+++ b/packages/envoy/deploy/scripts/render-nats-peer.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+dir="${1:?usage: render-nats-peer.sh <dir>}"
+mkdir -p "$dir"
+cat > "$dir/nats.conf" <<EOF
+server_name=${NATS_SERVER_NAME:?NATS_SERVER_NAME required}
+listen=0.0.0.0:4222
+
+jetstream {
+  store_dir=/data
+}
+
+cluster {
+  name: envoy
+  listen: 0.0.0.0:6222
+  routes: [
+$(printf '    %s\n' ${NATS_ROUTES:?NATS_ROUTES required})
+  ]
+}
+EOF

--- a/packages/envoy/deploy/scripts/sync-host.sh
+++ b/packages/envoy/deploy/scripts/sync-host.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+host="${1:?usage: sync-host.sh user@host}"
+root="$(cd "$(dirname "$0")/../../../.." && pwd)"
+rsync -az --delete --exclude '.git' --exclude '.jj' --exclude 'docker-data' "$root/packages/envoy/" "$host:~/legion/default/packages/envoy/"

--- a/packages/envoy/deploy/scripts/up-github.sh
+++ b/packages/envoy/deploy/scripts/up-github.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+dir="$(cd "$(dirname "$0")" && pwd)"
+cd "$dir/.."
+export ENVOY_GITHUB_WEBHOOK_SECRET="$($dir/read-secret.sh ENVOY_GITHUB_WEBHOOK_SECRET)"
+docker compose -f compose/github.compose.yml up -d --build

--- a/packages/envoy/deploy/scripts/up-listener.sh
+++ b/packages/envoy/deploy/scripts/up-listener.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+docker compose -f compose/listener.compose.yml up -d --build

--- a/packages/envoy/deploy/scripts/up-nats-peer.sh
+++ b/packages/envoy/deploy/scripts/up-nats-peer.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+./scripts/render-nats-peer.sh compose/nats
+docker compose -f compose/nats/peer.compose.yml up -d

--- a/packages/envoy/deploy/scripts/up-slack.sh
+++ b/packages/envoy/deploy/scripts/up-slack.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+dir="$(cd "$(dirname "$0")" && pwd)"
+cd "$dir/.."
+export ENVOY_SLACK_SIGNING_SECRET="$($dir/read-secret.sh ENVOY_SLACK_SIGNING_SECRET)"
+docker compose -f compose/slack.compose.yml up -d --build

--- a/packages/envoy/docker/base/Dockerfile
+++ b/packages/envoy/docker/base/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.24-alpine AS base
+
+WORKDIR /src
+
+RUN apk add --no-cache ca-certificates curl git

--- a/packages/envoy/docker/github.Dockerfile
+++ b/packages/envoy/docker/github.Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.24-bookworm AS build
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY cmd ./cmd
+COPY internal ./internal
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build -o /out/envoy-github ./cmd/github
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /out/envoy-github /usr/local/bin/envoy-github
+
+EXPOSE 9010
+
+ENTRYPOINT ["/usr/local/bin/envoy-github"]

--- a/packages/envoy/docker/listener.Dockerfile
+++ b/packages/envoy/docker/listener.Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.24-bookworm AS build
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY cmd ./cmd
+COPY internal ./internal
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build -o /out/envoy-listener ./cmd/listener
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /out/envoy-listener /usr/local/bin/envoy-listener
+
+EXPOSE 9020
+
+ENTRYPOINT ["/usr/local/bin/envoy-listener"]

--- a/packages/envoy/docker/slack.Dockerfile
+++ b/packages/envoy/docker/slack.Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.24-bookworm AS build
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY cmd ./cmd
+COPY internal ./internal
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build -o /out/envoy-slack ./cmd/slack
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /out/envoy-slack /usr/local/bin/envoy-slack
+
+EXPOSE 9011
+
+ENTRYPOINT ["/usr/local/bin/envoy-slack"]

--- a/packages/envoy/docs/architecture.md
+++ b/packages/envoy/docs/architecture.md
@@ -1,0 +1,40 @@
+# Architecture
+
+## Phase 1
+
+```text
+GitHub webhook  --\
+Slack events    ---+--> NATS JetStream --> listener --> session wake / cold resume
+Agent messages  --/                         |
+                                            +--> per-session routing + dedupe
+```
+
+## Core pieces
+
+- `packages/contracts`
+  - envelope schema
+  - env parsing
+  - subject helpers
+  - signing / verification helpers where envoy owns them
+- `cmd/listener`
+  - machine-scoped consumer
+  - routing and dedupe
+  - hot wake vs cold resume
+- `cmd/github`
+  - webhook verification
+  - event normalization
+  - NATS publish
+- `cmd/slack`
+  - request verification
+  - challenge handling
+  - event normalization
+  - NATS publish
+
+## Runtime shape
+
+- one listener container per machine
+- one GitHub receiver container on the public EC2 host
+- one Slack receiver container on the public EC2 host
+- NATS JetStream cluster across all machines via Tailscale mesh
+- JetStream stream `ENVOY_NOTIFICATIONS` with 1h retention for replay on listener restart
+- JetStream KV bucket `envoy_interests` with 3 replicas for session subscriptions

--- a/packages/envoy/docs/constraints.md
+++ b/packages/envoy/docs/constraints.md
@@ -1,0 +1,24 @@
+# Constraints
+
+## Hard rules
+
+- No more AWS changes from envoy work without explicit approval
+- All envoy services run in Docker containers
+- Do not install anything on hosts except Docker on `ghost-wispr`
+- Do not disturb the Ghost Whisper app on the Raspberry Pi
+- Do not commit, print, or push secrets
+- Use `secrets ... -- command` for runtime secret injection
+
+## Multi-repo hygiene
+
+- Primary implementation lives in `~/legion/default/packages/envoy`
+- If opencode or another maintained repo must change, that work stays isolated in that repo
+- Never bundle those changes into an existing `sami` octopus merge
+- Track every external-repo requirement in `docs/external-repos.md`
+
+## Deployment posture
+
+- Use Tailscale IPs for inter-machine traffic
+- Use Docker on all four machines
+- Prefer Compose-managed services and explicit mounted config
+- Keep ports and public ingress limited to the already-open webhook receiver ports

--- a/packages/envoy/docs/external-repos.md
+++ b/packages/envoy/docs/external-repos.md
@@ -1,0 +1,20 @@
+# External repo touchpoints
+
+This file tracks code changes envoy may require outside this repo.
+
+## Candidate repos
+
+### opencode
+
+- Possible need: notification-oriented MCP/plugin integration or session wake helpers
+- Rule: separate jj change/commit in that repo, not folded into `sami`
+
+### whatsapp-mcp
+
+- Possible need: add daemon / publisher mode for continuous NATS publishing
+- Repo reference: `@sjawhar/whatsapp-mcp`
+- Rule: separate jj change/commit in that repo, not folded into `sami`
+
+## Status
+
+- No external repo changes executed yet

--- a/packages/envoy/go.mod
+++ b/packages/envoy/go.mod
@@ -1,0 +1,13 @@
+module github.com/sjawhar/envoy
+
+go 1.24.0
+
+require github.com/nats-io/nats.go v1.47.0
+
+require (
+	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/nats-io/nkeys v0.4.11 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
+	golang.org/x/crypto v0.37.0 // indirect
+	golang.org/x/sys v0.32.0 // indirect
+)

--- a/packages/envoy/go.sum
+++ b/packages/envoy/go.sum
@@ -1,0 +1,12 @@
+github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
+github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/nats-io/nats.go v1.47.0 h1:YQdADw6J/UfGUd2Oy6tn4Hq6YHxCaJrVKayxxFqYrgM=
+github.com/nats-io/nats.go v1.47.0/go.mod h1:iRWIPokVIFbVijxuMQq4y9ttaBTMe0SFdlZfMDd+33g=
+github.com/nats-io/nkeys v0.4.11 h1:q44qGV008kYd9W1b1nEBkNzvnWxtRSQ7A8BoqRrcfa0=
+github.com/nats-io/nkeys v0.4.11/go.mod h1:szDimtgmfOi9n25JpfIdGw12tZFYXqhGxjhVxsatHVE=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+golang.org/x/crypto v0.37.0 h1:kJNSjF/Xp7kU0iB2Z+9viTPMW4EqqsrywMXLJOOsXSE=
+golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
+golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
+golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/packages/envoy/internal/bus/nats.go
+++ b/packages/envoy/internal/bus/nats.go
@@ -1,0 +1,145 @@
+package bus
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/sjawhar/envoy/internal/contracts"
+)
+
+const Stream = "ENVOY_NOTIFICATIONS"
+
+var streamCfg = &nats.StreamConfig{
+	Name:      Stream,
+	Subjects:  []string{"notifications.>"},
+	Retention: nats.LimitsPolicy,
+	MaxAge:    time.Hour,
+	Storage:   nats.FileStorage,
+	Replicas:  3,
+}
+
+type Client struct {
+	Conn *nats.Conn
+	js   nats.JetStreamContext
+	urls []string
+	mu   sync.Mutex
+}
+
+func options(urls []string) nats.Options {
+	return nats.Options{
+		Servers:       urls,
+		Name:          "envoy",
+		MaxReconnect:  -1,
+		ReconnectWait: 2 * nats.DefaultReconnectWait,
+		DisconnectedErrCB: func(_ *nats.Conn, err error) {
+			if err != nil {
+				log.Printf("envoy nats disconnected: %v", err)
+				return
+			}
+			log.Printf("envoy nats disconnected")
+		},
+		ReconnectedCB: func(nc *nats.Conn) {
+			log.Printf("envoy nats reconnected: %s", nc.ConnectedUrl())
+		},
+		ClosedCB: func(_ *nats.Conn) {
+			log.Printf("envoy nats connection closed")
+		},
+		AsyncErrorCB: func(_ *nats.Conn, sub *nats.Subscription, err error) {
+			if sub != nil {
+				log.Printf("envoy nats async error subject=%s: %v", sub.Subject, err)
+				return
+			}
+			log.Printf("envoy nats async error: %v", err)
+		},
+	}
+}
+
+func connect(urls []string) (*nats.Conn, error) {
+	var nc *nats.Conn
+	var err error
+	for range 10 {
+		next := options(urls)
+		nc, err = next.Connect()
+		if err == nil {
+			return nc, nil
+		}
+		time.Sleep(time.Second)
+	}
+	return nil, err
+}
+
+func Connect(urls []string) (Client, error) {
+	nc, err := connect(urls)
+	if err != nil {
+		return Client{}, err
+	}
+	js, err := nc.JetStream()
+	if err != nil {
+		nc.Close()
+		return Client{}, err
+	}
+	if err := ensureStream(js); err != nil {
+		nc.Close()
+		return Client{}, err
+	}
+	return Client{Conn: nc, js: js, urls: urls}, nil
+}
+
+func ensureStream(js nats.JetStreamContext) error {
+	_, err := js.StreamInfo(Stream)
+	if err == nil {
+		_, err = js.UpdateStream(streamCfg)
+		return err
+	}
+	if !errors.Is(err, nats.ErrStreamNotFound) {
+		return err
+	}
+	_, err = js.AddStream(streamCfg)
+	return err
+}
+
+func (c *Client) JS() nats.JetStreamContext {
+	return c.js
+}
+
+func (c *Client) ensureConn() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.Conn != nil && c.Conn.Status() != nats.CLOSED {
+		return nil
+	}
+	nc, err := connect(c.urls)
+	if err != nil {
+		return err
+	}
+	js, err := nc.JetStream()
+	if err != nil {
+		nc.Close()
+		return err
+	}
+	c.Conn = nc
+	c.js = js
+	return nil
+}
+
+func (c *Client) Publish(item contracts.Envelope) error {
+	data, err := json.Marshal(item)
+	if err != nil {
+		return err
+	}
+	if err := c.ensureConn(); err != nil {
+		return err
+	}
+	_, err = c.js.Publish(item.Topic, data)
+	if err != nil && errors.Is(err, nats.ErrConnectionClosed) {
+		if err := c.ensureConn(); err != nil {
+			return err
+		}
+		_, err = c.js.Publish(item.Topic, data)
+	}
+	return err
+}

--- a/packages/envoy/internal/config/config.go
+++ b/packages/envoy/internal/config/config.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type Service struct {
+	MachineID string
+	NATSURLs  []string
+	Port      int
+}
+
+func Load(defaultPort int) (Service, error) {
+	machine := strings.TrimSpace(os.Getenv("ENVOY_MACHINE_ID"))
+	if machine == "" {
+		return Service{}, fmt.Errorf("ENVOY_MACHINE_ID is required")
+	}
+	raw := strings.TrimSpace(os.Getenv("NATS_URLS"))
+	if raw == "" {
+		return Service{}, fmt.Errorf("NATS_URLS is required")
+	}
+	urls := strings.FieldsFunc(raw, func(r rune) bool { return r == ',' })
+	for i, item := range urls {
+		urls[i] = strings.TrimSpace(item)
+	}
+	port := defaultPort
+	if value := strings.TrimSpace(os.Getenv("PORT")); value != "" {
+		next, err := strconv.Atoi(value)
+		if err != nil {
+			return Service{}, fmt.Errorf("invalid PORT: %w", err)
+		}
+		port = next
+	}
+	return Service{MachineID: machine, NATSURLs: urls, Port: port}, nil
+}

--- a/packages/envoy/internal/contracts/generated.go
+++ b/packages/envoy/internal/contracts/generated.go
@@ -1,0 +1,69 @@
+package contracts
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type Envelope struct {
+	EventID        string `json:"event_id"`
+	Source         string `json:"source"`
+	SourceEventID  string `json:"source_event_id"`
+	Topic          string `json:"topic"`
+	DedupeKey      string `json:"dedupe_key"`
+	IssuedAt       int64  `json:"issued_at"`
+	ExpiresAt      *int64 `json:"expires_at,omitempty"`
+	PayloadSummary string `json:"payload_summary"`
+	PayloadRef     string `json:"payload_ref,omitempty"`
+	TraceID        string `json:"trace_id"`
+}
+
+func (e Envelope) Validate() error {
+	if strings.TrimSpace(e.EventID) == "" {
+		return fmt.Errorf("event_id is required")
+	}
+	if strings.TrimSpace(e.Source) == "" {
+		return fmt.Errorf("source is required")
+	}
+	if strings.TrimSpace(e.SourceEventID) == "" {
+		return fmt.Errorf("source_event_id is required")
+	}
+	if strings.TrimSpace(e.Topic) == "" {
+		return fmt.Errorf("topic is required")
+	}
+	if strings.TrimSpace(e.DedupeKey) == "" {
+		return fmt.Errorf("dedupe_key is required")
+	}
+	if e.IssuedAt == 0 {
+		return fmt.Errorf("issued_at must be set")
+	}
+	if strings.TrimSpace(e.PayloadSummary) == "" {
+		return fmt.Errorf("payload_summary is required")
+	}
+	if strings.TrimSpace(e.TraceID) == "" {
+		return fmt.Errorf("trace_id is required")
+	}
+	switch e.Source {
+	case "agent", "github", "slack", "whatsapp":
+	default:
+		return fmt.Errorf("source must be one of: agent, github, slack, whatsapp")
+	}
+	return nil
+}
+
+func NowMillis() int64 {
+	return time.Now().UnixMilli()
+}
+
+func AgentSubject(session string) string {
+	return "notifications.agent." + session
+}
+
+func GithubSubject(owner string, repo string, kind string) string {
+	return "notifications.github." + owner + "." + repo + "." + kind
+}
+
+func SlackSubject(team string, channel string, kind string) string {
+	return "notifications.slack." + team + "." + channel + "." + kind
+}

--- a/packages/envoy/internal/contracts/normalize.go
+++ b/packages/envoy/internal/contracts/normalize.go
@@ -1,0 +1,360 @@
+package contracts
+
+import (
+	"fmt"
+	"strings"
+)
+
+type GithubEnvelopeInput struct {
+	Event    string
+	Delivery string
+	Body     map[string]any
+	EventID  string
+	TraceID  string
+}
+
+func GithubEnvelope(input GithubEnvelopeInput) Envelope {
+	owner := nestedString(input.Body, "repository", "owner", "login")
+	if owner == "" {
+		owner = "unknown"
+	}
+	repo := nestedString(input.Body, "repository", "name")
+	if repo == "" {
+		repo = "unknown"
+	}
+	topic := githubTopic(owner, repo, input.Event, input.Body)
+	return Envelope{
+		EventID:        input.EventID,
+		Source:         "github",
+		SourceEventID:  input.Delivery,
+		Topic:          topic,
+		DedupeKey:      "github." + input.Delivery,
+		IssuedAt:       NowMillis(),
+		PayloadSummary: githubSummary(input.Event, input.Body),
+		TraceID:        input.TraceID,
+	}
+}
+
+func GithubEnvelopes(input GithubEnvelopeInput, trigger string) []Envelope {
+	item := GithubEnvelope(input)
+	out := []Envelope{item}
+	if !githubCommentEvent(input.Event) {
+		return out
+	}
+	body := githubCommentBody(input.Event, input.Body)
+	if !ContainsMention(body, trigger) {
+		return out
+	}
+	// Publish mention topic with same structure: type.number.mention
+	owner := nestedString(input.Body, "repository", "owner", "login")
+	if owner == "" {
+		owner = "unknown"
+	}
+	repo := nestedString(input.Body, "repository", "name")
+	if repo == "" {
+		repo = "unknown"
+	}
+	num := githubNumber(input.Event, input.Body)
+	base := githubParentKind(input.Event, input.Body)
+	if num != "" {
+		// notifications.github.owner.repo.pr.7706.mention
+		mention := item
+		mention.Topic = GithubSubject(owner, repo, base+"."+num+".mention")
+		out = append(out, mention)
+	}
+	// Also publish repo-wide mention: notifications.github.owner.repo.mention
+	mention := item
+	mention.Topic = GithubSubject(owner, repo, "mention")
+	out = append(out, mention)
+	return out
+}
+
+func GithubIsBotSender(body map[string]any) bool {
+	return strings.EqualFold(nestedString(body, "sender", "type"), "Bot")
+}
+
+func ContainsMention(body string, trigger string) bool {
+	body = strings.ToLower(body)
+	trigger = strings.ToLower(strings.TrimSpace(trigger))
+	if body == "" || trigger == "" {
+		return false
+	}
+	idx := strings.Index(body, trigger)
+	for idx >= 0 {
+		if mentionEdge(body, idx, idx+len(trigger)) {
+			return true
+		}
+	next := idx + len(trigger)
+		if next >= len(body) {
+			return false
+		}
+		more := strings.Index(body[next:], trigger)
+		if more < 0 {
+			return false
+		}
+		idx = next + more
+	}
+	return false
+}
+
+type SlackEnvelopeInput struct {
+	Body    map[string]any
+	EventID string
+	TraceID string
+}
+
+func SlackEnvelope(input SlackEnvelopeInput) Envelope {
+	team := stringValue(input.Body["team_id"])
+	if team == "" {
+		team = "unknown"
+	}
+	event, _ := input.Body["event"].(map[string]any)
+	channel := stringValue(event["channel"])
+	if channel == "" {
+		channel = "unknown"
+	}
+	return Envelope{
+		EventID:        input.EventID,
+		Source:         "slack",
+		SourceEventID:  stringValue(input.Body["event_id"]),
+		Topic:          SlackSubject(team, channel, slackKind(input.Body)),
+		DedupeKey:      "slack." + stringValue(input.Body["event_id"]),
+		IssuedAt:       NowMillis(),
+		PayloadSummary: slackSummary(input.Body),
+		TraceID:        input.TraceID,
+	}
+}
+
+func SlackEnvelopes(input SlackEnvelopeInput) []Envelope {
+	item := SlackEnvelope(input)
+	out := []Envelope{item}
+	event, _ := input.Body["event"].(map[string]any)
+	thread := stringValue(event["thread_ts"])
+	if thread == "" {
+		thread = stringValue(event["ts"])
+	}
+	if thread != "" {
+		team := stringValue(input.Body["team_id"])
+		channel := stringValue(event["channel"])
+		if team != "" && channel != "" {
+			threaded := item
+			threaded.Topic = SlackSubject(team, channel, "thread."+thread)
+			out = append(out, threaded)
+		}
+	}
+	return out
+}
+
+// githubTopic builds the full topic path with number hierarchy.
+// PR #7706 opened:       pr.7706
+// Comment on PR #7706:    pr.7706.comment
+// Review on PR #7706:     pr.7706.review
+// Issue #42 opened:       issue.42
+// Comment on issue #42:   issue.42.comment
+// Push event:             push
+func githubTopic(owner string, repo string, event string, body map[string]any) string {
+	num := githubNumber(event, body)
+	parent := githubParentKind(event, body)
+	kind := githubKind(event)
+	if num != "" && kind != parent {
+		// e.g., pr.7706.comment, pr.7706.review, issue.42.comment
+		return GithubSubject(owner, repo, parent+"."+num+"."+kind)
+	}
+	if num != "" {
+		// e.g., pr.7706, issue.42
+		return GithubSubject(owner, repo, kind+"."+num)
+	}
+	// e.g., push, ci
+	return GithubSubject(owner, repo, kind)
+}
+
+// githubParentKind returns the entity type that owns the number.
+// For issue_comment, checks body["issue"]["pull_request"] to distinguish PR vs issue.
+func githubParentKind(event string, body map[string]any) string {
+	switch event {
+	case "pull_request", "pull_request_review", "pull_request_review_comment":
+		return "pr"
+	case "issues":
+		return "issue"
+	case "issue_comment":
+		if nested(body, "issue", "pull_request") != nil {
+			return "pr"
+		}
+		return "issue"
+	}
+	return ""
+}
+
+func githubKind(event string) string {
+	switch event {
+	case "pull_request":
+		return "pr"
+	case "issues":
+		return "issue"
+	case "push":
+		return "push"
+	case "check_run", "check_suite":
+		return "ci"
+	case "issue_comment":
+		return "comment"
+	case "pull_request_review":
+		return "review"
+	case "pull_request_review_comment":
+		return "comment"
+	default:
+		return "comment"
+	}
+}
+
+func githubNumber(event string, body map[string]any) string {
+	switch event {
+	case "pull_request", "pull_request_review", "pull_request_review_comment":
+		n := nested(body, "pull_request", "number")
+		if n != nil {
+			return fmt.Sprintf("%v", n)
+		}
+	case "issues":
+		n := nested(body, "issue", "number")
+		if n != nil {
+			return fmt.Sprintf("%v", n)
+		}
+	case "issue_comment":
+		n := nested(body, "issue", "number")
+		if n != nil {
+			return fmt.Sprintf("%v", n)
+		}
+	}
+	return ""
+}
+
+func githubCommentEvent(event string) bool {
+	switch event {
+	case "issue_comment", "pull_request_review_comment", "pull_request_review":
+		return true
+	}
+	return false
+}
+
+func githubCommentBody(event string, body map[string]any) string {
+	action := stringValue(body["action"])
+	if event == "pull_request_review" {
+		if action != "submitted" {
+			return ""
+		}
+		return nestedString(body, "review", "body")
+	}
+	if action != "created" {
+		return ""
+	}
+	return nestedString(body, "comment", "body")
+}
+
+func githubSummary(event string, body map[string]any) string {
+	repo := nestedString(body, "repository", "full_name")
+	switch event {
+	case "pull_request":
+		return fmt.Sprintf("PR #%v %s in %s: %s", nested(body, "pull_request", "number"), stringValue(body["action"]), repo, nestedString(body, "pull_request", "title"))
+	case "issues":
+		return fmt.Sprintf("Issue #%v %s in %s: %s", nested(body, "issue", "number"), stringValue(body["action"]), repo, nestedString(body, "issue", "title"))
+	case "push":
+		return fmt.Sprintf("Push to %s on %s", repo, stringValue(body["ref"]))
+	case "check_run", "check_suite":
+		return fmt.Sprintf("CI %s in %s", stringValue(body["action"]), repo)
+	default:
+		return fmt.Sprintf("Comment %s in %s", stringValue(body["action"]), repo)
+	}
+}
+
+func githubName(body map[string]any) string {
+	repo := nestedString(body, "repository", "name")
+	if repo != "" {
+		return repo
+	}
+	return "unknown"
+}
+
+func githubRepo(body map[string]any) string {
+	owner := nestedString(body, "repository", "owner", "login")
+	if owner != "" {
+		return owner
+	}
+	return "unknown"
+}
+
+func mentionEdge(body string, start int, end int) bool {
+	if !mentionLeft(body, start) {
+		return false
+	}
+	return mentionRight(body, end)
+}
+
+func mentionLeft(body string, idx int) bool {
+	if idx == 0 {
+		return true
+	}
+	return !mentionWord(rune(body[idx-1]))
+}
+
+func mentionRight(body string, idx int) bool {
+	if idx >= len(body) {
+		return true
+	}
+	return !mentionWord(rune(body[idx]))
+}
+
+func mentionWord(ch rune) bool {
+	if ch >= 'a' && ch <= 'z' {
+		return true
+	}
+	if ch >= '0' && ch <= '9' {
+		return true
+	}
+	if ch == '_' {
+		return true
+	}
+	if ch == '@' {
+		return true
+	}
+	if ch == '.' {
+		return true
+	}
+	return false
+}
+
+func slackKind(body map[string]any) string {
+	event, _ := body["event"].(map[string]any)
+	if stringValue(event["type"]) == "app_mention" {
+		return "mention"
+	}
+	return "message"
+}
+
+func slackSummary(body map[string]any) string {
+	event, _ := body["event"].(map[string]any)
+	text := stringValue(event["text"])
+	if len(text) > 160 {
+		text = text[:160]
+	}
+	return strings.TrimSpace(fmt.Sprintf("Slack %s from %s in %s: %s", slackKind(body), stringValue(event["user"]), stringValue(event["channel"]), text))
+}
+
+func nested(body map[string]any, keys ...string) any {
+	var cur any = body
+	for _, key := range keys {
+		item, ok := cur.(map[string]any)
+		if !ok {
+			return nil
+		}
+		cur = item[key]
+	}
+	return cur
+}
+
+func nestedString(body map[string]any, keys ...string) string {
+	return stringValue(nested(body, keys...))
+}
+
+func stringValue(value any) string {
+	text, _ := value.(string)
+	return text
+}

--- a/packages/envoy/internal/contracts/normalize_test.go
+++ b/packages/envoy/internal/contracts/normalize_test.go
@@ -1,0 +1,360 @@
+package contracts
+
+import "testing"
+
+func TestGithubEnvelope(t *testing.T) {
+	item := GithubEnvelope(GithubEnvelopeInput{
+		Event:    "pull_request",
+		Delivery: "d1",
+		EventID:  "e1",
+		TraceID:  "t1",
+		Body: map[string]any{
+			"action": "opened",
+			"repository": map[string]any{
+				"full_name": "sjawhar/envoy",
+				"name":      "envoy",
+				"owner": map[string]any{
+					"login": "sjawhar",
+				},
+			},
+			"pull_request": map[string]any{
+				"number": 7,
+				"title":  "hello",
+			},
+		},
+	})
+	if item.Topic != "notifications.github.sjawhar.envoy.pr.7" {
+		t.Fatalf("unexpected topic: %s", item.Topic)
+	}
+	if item.DedupeKey != "github.d1" {
+		t.Fatalf("unexpected dedupe key: %s", item.DedupeKey)
+	}
+	if err := item.Validate(); err != nil {
+		t.Fatalf("expected valid envelope: %v", err)
+	}
+}
+
+func TestSlackEnvelope(t *testing.T) {
+	item := SlackEnvelope(SlackEnvelopeInput{
+		EventID: "e1",
+		TraceID: "t1",
+		Body: map[string]any{
+			"team_id":  "T123",
+			"event_id": "Ev123",
+			"event": map[string]any{
+				"type":    "app_mention",
+				"user":    "U123",
+				"channel": "C123",
+				"text":    "hello envoy",
+			},
+		},
+	})
+	if item.Topic != "notifications.slack.T123.C123.mention" {
+		t.Fatalf("unexpected topic: %s", item.Topic)
+	}
+	if item.DedupeKey != "slack.Ev123" {
+		t.Fatalf("unexpected dedupe key: %s", item.DedupeKey)
+	}
+	if err := item.Validate(); err != nil {
+		t.Fatalf("expected valid envelope: %v", err)
+	}
+}
+
+func TestContainsMention(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "prefix", body: "@legion please help", want: true},
+		{name: "middle", body: "hello @legion", want: true},
+		{name: "punctuation", body: "(@legion)", want: true},
+		{name: "case", body: "@LEGION", want: true},
+		{name: "suffix word", body: "@legionnaire", want: false},
+		{name: "email", body: "user@legion.dev", want: false},
+		{name: "empty", body: "", want: false},
+	}
+	for _, item := range tests {
+		if got := ContainsMention(item.body, "@legion"); got != item.want {
+			t.Fatalf("%s: expected %v, got %v", item.name, item.want, got)
+		}
+	}
+}
+
+func TestGithubEnvelopesNoMention(t *testing.T) {
+	items := GithubEnvelopes(GithubEnvelopeInput{
+		Event:    "issue_comment",
+		Delivery: "d1",
+		EventID:  "e1",
+		TraceID:  "t1",
+		Body: map[string]any{
+			"action": "created",
+			"repository": map[string]any{
+				"full_name": "sjawhar/envoy",
+				"name":      "envoy",
+				"owner": map[string]any{
+					"login": "sjawhar",
+				},
+			},
+			"comment": map[string]any{
+				"body": "hello there",
+			},
+		},
+	}, "@legion")
+	if len(items) != 1 {
+		t.Fatalf("expected 1 envelope, got %d", len(items))
+	}
+	if items[0].Topic != "notifications.github.sjawhar.envoy.comment" {
+		t.Fatalf("unexpected topic: %s", items[0].Topic)
+	}
+}
+
+func TestGithubEnvelopesWithMention(t *testing.T) {
+	items := GithubEnvelopes(GithubEnvelopeInput{
+		Event:    "issue_comment",
+		Delivery: "d1",
+		EventID:  "e1",
+		TraceID:  "t1",
+		Body: map[string]any{
+			"action": "created",
+			"repository": map[string]any{
+				"full_name": "sjawhar/envoy",
+				"name":      "envoy",
+				"owner": map[string]any{
+					"login": "sjawhar",
+				},
+			},
+			"comment": map[string]any{
+				"body": "@legion please help",
+			},
+		},
+	}, "@legion")
+	if len(items) != 2 {
+		t.Fatalf("expected 2 envelopes, got %d", len(items))
+	}
+	if items[0].Topic != "notifications.github.sjawhar.envoy.comment" {
+		t.Fatalf("unexpected comment topic: %s", items[0].Topic)
+	}
+	if items[1].Topic != "notifications.github.sjawhar.envoy.mention" {
+		t.Fatalf("unexpected mention topic: %s", items[1].Topic)
+	}
+}
+
+func TestGithubEnvelopesReview(t *testing.T) {
+	items := GithubEnvelopes(GithubEnvelopeInput{
+		Event:    "pull_request_review",
+		Delivery: "d1",
+		EventID:  "e1",
+		TraceID:  "t1",
+		Body: map[string]any{
+			"action": "submitted",
+			"repository": map[string]any{
+				"full_name": "sjawhar/envoy",
+				"name":      "envoy",
+				"owner": map[string]any{
+					"login": "sjawhar",
+				},
+			},
+			"review": map[string]any{
+				"body": "Can @legion take a look?",
+			},
+		},
+	}, "@legion")
+	if len(items) != 2 {
+		t.Fatalf("expected 2 envelopes, got %d", len(items))
+	}
+	if items[1].Topic != "notifications.github.sjawhar.envoy.mention" {
+		t.Fatalf("unexpected mention topic: %s", items[1].Topic)
+	}
+}
+
+func TestGithubEnvelopesEmptyReview(t *testing.T) {
+	items := GithubEnvelopes(GithubEnvelopeInput{
+		Event:    "pull_request_review",
+		Delivery: "d1",
+		EventID:  "e1",
+		TraceID:  "t1",
+		Body: map[string]any{
+			"action": "submitted",
+			"repository": map[string]any{
+				"full_name": "sjawhar/envoy",
+				"name":      "envoy",
+				"owner": map[string]any{
+					"login": "sjawhar",
+				},
+			},
+			"review": map[string]any{
+				"body": "",
+			},
+		},
+	}, "@legion")
+	if len(items) != 1 {
+		t.Fatalf("expected 1 envelope, got %d", len(items))
+	}
+}
+
+func TestGithubIsBotSender(t *testing.T) {
+	if !GithubIsBotSender(map[string]any{"sender": map[string]any{"type": "Bot"}}) {
+		t.Fatal("expected bot sender to be true")
+	}
+	if GithubIsBotSender(map[string]any{"sender": map[string]any{"type": "User"}}) {
+		t.Fatal("expected user sender to be false")
+	}
+	if GithubIsBotSender(map[string]any{}) {
+		t.Fatal("expected missing sender to be false")
+	}
+}
+
+func TestGithubEnvelopesPRNumber(t *testing.T) {
+	items := GithubEnvelopes(GithubEnvelopeInput{
+		Event:    "pull_request",
+		Delivery: "d1",
+		EventID:  "e1",
+		TraceID:  "t1",
+		Body: map[string]any{
+			"action": "opened",
+			"repository": map[string]any{
+				"full_name": "sjawhar/envoy",
+				"name":      "envoy",
+				"owner": map[string]any{
+					"login": "sjawhar",
+				},
+			},
+			"pull_request": map[string]any{
+				"number": 42,
+				"title":  "test",
+			},
+		},
+	}, "@legion")
+	if len(items) != 1 {
+		t.Fatalf("expected 1 envelope, got %d", len(items))
+	}
+	if items[0].Topic != "notifications.github.sjawhar.envoy.pr.42" {
+		t.Fatalf("unexpected topic: %s", items[0].Topic)
+	}
+}
+
+func TestGithubEnvelopesIssueCommentNumber(t *testing.T) {
+	items := GithubEnvelopes(GithubEnvelopeInput{
+		Event:    "issue_comment",
+		Delivery: "d1",
+		EventID:  "e1",
+		TraceID:  "t1",
+		Body: map[string]any{
+			"action": "created",
+			"repository": map[string]any{
+				"full_name": "sjawhar/envoy",
+				"name":      "envoy",
+				"owner": map[string]any{
+					"login": "sjawhar",
+				},
+			},
+			"issue": map[string]any{
+				"number": 7,
+			},
+			"comment": map[string]any{
+				"body": "just a comment",
+			},
+		},
+	}, "@legion")
+	// issue_comment with no pull_request field → issue.7.comment
+	if len(items) != 1 {
+		t.Fatalf("expected 1 envelope, got %d", len(items))
+	}
+	if items[0].Topic != "notifications.github.sjawhar.envoy.issue.7.comment" {
+		t.Fatalf("unexpected topic: %s", items[0].Topic)
+	}
+}
+
+func TestGithubEnvelopesMentionWithNumber(t *testing.T) {
+	items := GithubEnvelopes(GithubEnvelopeInput{
+		Event:    "issue_comment",
+		Delivery: "d1",
+		EventID:  "e1",
+		TraceID:  "t1",
+		Body: map[string]any{
+			"action": "created",
+			"repository": map[string]any{
+				"full_name": "sjawhar/envoy",
+				"name":      "envoy",
+				"owner": map[string]any{
+					"login": "sjawhar",
+				},
+			},
+			"issue": map[string]any{
+				"number": 99,
+			},
+			"comment": map[string]any{
+				"body": "@legion please review",
+			},
+		},
+	}, "@legion")
+	// issue_comment with mention: issue.99.comment + issue.99.mention + repo mention
+	if len(items) != 3 {
+		t.Fatalf("expected 3 envelopes, got %d", len(items))
+	}
+	if items[0].Topic != "notifications.github.sjawhar.envoy.issue.99.comment" {
+		t.Fatalf("unexpected topic[0]: %s", items[0].Topic)
+	}
+	if items[1].Topic != "notifications.github.sjawhar.envoy.issue.99.mention" {
+		t.Fatalf("unexpected topic[1]: %s", items[1].Topic)
+	}
+	if items[2].Topic != "notifications.github.sjawhar.envoy.mention" {
+		t.Fatalf("unexpected topic[2]: %s", items[2].Topic)
+	}
+}
+
+func TestSlackEnvelopesThread(t *testing.T) {
+	items := SlackEnvelopes(SlackEnvelopeInput{
+		EventID: "e1",
+		TraceID: "t1",
+		Body: map[string]any{
+			"team_id":  "T123",
+			"event_id": "Ev123",
+			"event": map[string]any{
+				"type":      "message",
+				"user":      "U123",
+				"channel":   "C123",
+				"text":      "reply in thread",
+				"thread_ts": "1234567890.123456",
+			},
+		},
+	})
+	if len(items) != 2 {
+		t.Fatalf("expected 2 envelopes, got %d", len(items))
+	}
+	if items[0].Topic != "notifications.slack.T123.C123.message" {
+		t.Fatalf("unexpected channel topic: %s", items[0].Topic)
+	}
+	if items[1].Topic != "notifications.slack.T123.C123.thread.1234567890.123456" {
+		t.Fatalf("unexpected thread topic: %s", items[1].Topic)
+	}
+}
+
+func TestSlackEnvelopesNoThread(t *testing.T) {
+	items := SlackEnvelopes(SlackEnvelopeInput{
+		EventID: "e1",
+		TraceID: "t1",
+		Body: map[string]any{
+			"team_id":  "T123",
+			"event_id": "Ev123",
+			"event": map[string]any{
+				"type":    "app_mention",
+				"user":    "U123",
+				"channel": "C123",
+				"text":    "hello",
+				"ts":      "9999999999.000000",
+			},
+		},
+	})
+	// channel mention + thread (using ts as fallback)
+	if len(items) != 2 {
+		t.Fatalf("expected 2 envelopes, got %d", len(items))
+	}
+	if items[0].Topic != "notifications.slack.T123.C123.mention" {
+		t.Fatalf("unexpected channel topic: %s", items[0].Topic)
+	}
+	if items[1].Topic != "notifications.slack.T123.C123.thread.9999999999.000000" {
+		t.Fatalf("unexpected thread topic: %s", items[1].Topic)
+	}
+}

--- a/packages/envoy/internal/id/id.go
+++ b/packages/envoy/internal/id/id.go
@@ -1,0 +1,12 @@
+package id
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+)
+
+func New() string {
+	buf := make([]byte, 16)
+	_, _ = rand.Read(buf)
+	return hex.EncodeToString(buf)
+}

--- a/packages/envoy/internal/routing/match.go
+++ b/packages/envoy/internal/routing/match.go
@@ -1,0 +1,26 @@
+package routing
+
+import "strings"
+
+func Match(pattern string, topic string) bool {
+	pp := strings.Split(pattern, ".")
+	tp := strings.Split(topic, ".")
+
+	for len(pp) > 0 {
+		part := pp[0]
+		pp = pp[1:]
+
+		if part == ">" {
+			return true
+		}
+		if len(tp) == 0 {
+			return false
+		}
+		if part != "*" && part != tp[0] {
+			return false
+		}
+		tp = tp[1:]
+	}
+
+	return len(tp) == 0
+}

--- a/packages/envoy/internal/routing/match_test.go
+++ b/packages/envoy/internal/routing/match_test.go
@@ -1,0 +1,23 @@
+package routing
+
+import "testing"
+
+func TestMatch(t *testing.T) {
+	cases := []struct {
+		pattern string
+		topic   string
+		ok      bool
+	}{
+		{pattern: "notifications.github.sjawhar.envoy.pr", topic: "notifications.github.sjawhar.envoy.pr", ok: true},
+		{pattern: "notifications.slack.*.*.mention", topic: "notifications.slack.T123.C123.mention", ok: true},
+		{pattern: "notifications.github.>", topic: "notifications.github.sjawhar.envoy.pr", ok: true},
+		{pattern: "notifications.github.*.envoy.pr", topic: "notifications.github.sjawhar.envoy.pr", ok: true},
+		{pattern: "notifications.github.*.envoy.issue", topic: "notifications.github.sjawhar.envoy.pr", ok: false},
+	}
+	for _, item := range cases {
+		got := Match(item.pattern, item.topic)
+		if got != item.ok {
+			t.Fatalf("pattern=%s topic=%s expected=%v got=%v", item.pattern, item.topic, item.ok, got)
+		}
+	}
+}

--- a/packages/envoy/internal/session/session.go
+++ b/packages/envoy/internal/session/session.go
@@ -1,0 +1,168 @@
+package session
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sjawhar/envoy/internal/contracts"
+	"github.com/sjawhar/envoy/internal/store"
+)
+
+type RegistryEntry struct {
+	PID     int    `json:"pid"`
+	Port    int    `json:"port"`
+	Dir     string `json:"dir"`
+	Session struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+	} `json:"session"`
+}
+
+type Deliverer struct {
+	RegistryDir  string
+	HostBridge   string
+	OpencodeBin  string
+	XDGConfig    string
+	XDGData      string
+	XDGCache     string
+	RequestLimit time.Duration
+}
+
+func (d Deliverer) Deliver(item contracts.Envelope, interest store.Interest) error {
+	entry, _ := d.Find(interest.SessionID)
+	text := d.Text(item)
+	if entry != nil && entry.Port > 0 {
+		if err := d.prompt(entry.Port, interest.SessionID, text); err == nil {
+			return nil
+		}
+	}
+	return d.resume(interest.SessionID, interest.Dir, text)
+}
+
+func (d Deliverer) Find(sessionID string) (*RegistryEntry, error) {
+	files, err := filepath.Glob(filepath.Join(d.RegistryDir, "*.json"))
+	if err != nil {
+		return nil, err
+	}
+	for _, file := range files {
+		buf, err := os.ReadFile(file)
+		if err != nil {
+			continue
+		}
+		var entry RegistryEntry
+		if err := json.Unmarshal(buf, &entry); err != nil {
+			continue
+		}
+		if entry.Session.ID == sessionID {
+			return &entry, nil
+		}
+	}
+	return nil, os.ErrNotExist
+}
+
+func (d Deliverer) Text(item contracts.Envelope) string {
+	return fmt.Sprintf("[NOTIFICATION from %s]\n%s\n\nTopic: %s\nEvent ID: %s", item.Source, item.PayloadSummary, item.Topic, item.EventID)
+}
+
+func (d Deliverer) prompt(port int, sessionID string, text string) error {
+	type promptBody struct {
+		Parts []map[string]string `json:"parts"`
+		Agent string              `json:"agent,omitempty"`
+	}
+	bodyData := promptBody{
+		Parts: []map[string]string{{"type": "text", "text": text}},
+	}
+	if agent, err := d.lastAgent(port, sessionID); err == nil && agent != "" {
+		bodyData.Agent = agent
+	}
+	body, err := json.Marshal(bodyData)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s:%d/session/%s/prompt_async", d.host(), port, sessionID), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := http.Client{Timeout: d.timeout()}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("prompt_async returned %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (d Deliverer) lastAgent(port int, sessionID string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%d/session/%s/message?limit=20", d.host(), port, sessionID), nil)
+	if err != nil {
+		return "", err
+	}
+	client := http.Client{Timeout: d.timeout()}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		io.Copy(io.Discard, resp.Body)
+		return "", fmt.Errorf("message list returned %d", resp.StatusCode)
+	}
+	var items []struct {
+		Info struct {
+			Role  string `json:"role"`
+			Agent string `json:"agent"`
+		} `json:"info"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+		return "", err
+	}
+	var result string
+	for _, item := range items {
+		if item.Info.Role != "user" || item.Info.Agent == "" {
+			continue
+		}
+		result = item.Info.Agent
+	}
+	return result, nil
+}
+
+func (d Deliverer) resume(sessionID string, dir string, text string) error {
+	cmd := exec.Command(d.OpencodeBin, "run", "--session", sessionID, "--dir", dir, text)
+	cmd.Env = append(os.Environ(),
+		"XDG_CONFIG_HOME="+d.XDGConfig,
+		"XDG_DATA_HOME="+d.XDGData,
+		"XDG_CACHE_HOME="+d.XDGCache,
+	)
+	buf, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("cold resume failed: %w: %s", err, strings.TrimSpace(string(buf)))
+	}
+	return nil
+}
+
+func (d Deliverer) host() string {
+	if d.HostBridge != "" {
+		return d.HostBridge
+	}
+	return "host.docker.internal"
+}
+
+func (d Deliverer) timeout() time.Duration {
+	if d.RequestLimit > 0 {
+		return d.RequestLimit
+	}
+	return 10 * time.Second
+}

--- a/packages/envoy/internal/store/interest.go
+++ b/packages/envoy/internal/store/interest.go
@@ -1,0 +1,50 @@
+package store
+
+type Interest struct {
+	SessionID string   `json:"session_id"`
+	MachineID string   `json:"machine_id"`
+	Dir       string   `json:"dir"`
+	Topics    []string `json:"topics"`
+	UpdatedAt int64    `json:"updated_at"`
+}
+
+func Merge(item Interest, topics []string) Interest {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(item.Topics)+len(topics))
+	for _, topic := range item.Topics {
+		if seen[topic] {
+			continue
+		}
+		seen[topic] = true
+		out = append(out, topic)
+	}
+	for _, topic := range topics {
+		if seen[topic] {
+			continue
+		}
+		seen[topic] = true
+		out = append(out, topic)
+	}
+	item.Topics = out
+	return item
+}
+
+func Remove(item Interest, topics []string) Interest {
+	if len(topics) == 0 {
+		item.Topics = nil
+		return item
+	}
+	cut := map[string]bool{}
+	for _, topic := range topics {
+		cut[topic] = true
+	}
+	out := make([]string, 0, len(item.Topics))
+	for _, topic := range item.Topics {
+		if cut[topic] {
+			continue
+		}
+		out = append(out, topic)
+	}
+	item.Topics = out
+	return item
+}

--- a/packages/envoy/internal/store/interest_test.go
+++ b/packages/envoy/internal/store/interest_test.go
@@ -1,0 +1,26 @@
+package store
+
+import "testing"
+
+func TestMergeTopics(t *testing.T) {
+	item := Interest{Topics: []string{"notifications.github.>", "notifications.slack.*.*.mention"}}
+	next := Merge(item, []string{"notifications.slack.*.*.mention", "notifications.agent.s1"})
+	if len(next.Topics) != 3 {
+		t.Fatalf("expected 3 topics, got %d", len(next.Topics))
+	}
+}
+
+func TestRemoveTopics(t *testing.T) {
+	item := Interest{Topics: []string{"a", "b", "c"}}
+	next := Remove(item, []string{"b"})
+	if len(next.Topics) != 2 {
+		t.Fatalf("expected 2 topics, got %d", len(next.Topics))
+	}
+	if next.Topics[0] != "a" || next.Topics[1] != "c" {
+		t.Fatalf("unexpected topics: %#v", next.Topics)
+	}
+	clear := Remove(item, nil)
+	if len(clear.Topics) != 0 {
+		t.Fatalf("expected full removal, got %#v", clear.Topics)
+	}
+}

--- a/packages/envoy/internal/store/kv.go
+++ b/packages/envoy/internal/store/kv.go
@@ -1,0 +1,174 @@
+package store
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/sjawhar/envoy/internal/routing"
+)
+
+const Bucket = "envoy_interests"
+
+type Registry struct {
+	kv    nats.KeyValue
+	mu    sync.RWMutex
+	cache map[string]Interest
+}
+
+func Open(conn *nats.Conn) (*Registry, error) {
+	js, err := conn.JetStream()
+	if err != nil {
+		return nil, err
+	}
+	kv, err := js.KeyValue(Bucket)
+	if errors.Is(err, nats.ErrBucketNotFound) {
+		kv, err = js.CreateKeyValue(&nats.KeyValueConfig{Bucket: Bucket, Replicas: 3, Storage: nats.FileStorage})
+	}
+	if err != nil {
+		return nil, err
+	}
+	r := &Registry{kv: kv, cache: map[string]Interest{}}
+	if err := r.load(); err != nil {
+		return nil, err
+	}
+	go r.watch()
+	return r, nil
+}
+
+func (r *Registry) load() error {
+	keys, err := r.kv.Keys()
+	if errors.Is(err, nats.ErrNoKeysFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, key := range keys {
+		entry, err := r.kv.Get(key)
+		if err != nil {
+			continue
+		}
+		var item Interest
+		if err := json.Unmarshal(entry.Value(), &item); err != nil {
+			continue
+		}
+		r.cache[key] = item
+	}
+	return nil
+}
+
+func (r *Registry) watch() {
+	w, err := r.kv.WatchAll()
+	if err != nil {
+		log.Printf("registry watch failed: %v", err)
+		return
+	}
+	for entry := range w.Updates() {
+		if entry == nil {
+			continue
+		}
+		r.mu.Lock()
+		if entry.Operation() == nats.KeyValueDelete || entry.Operation() == nats.KeyValuePurge {
+			delete(r.cache, entry.Key())
+		} else {
+			var item Interest
+			if err := json.Unmarshal(entry.Value(), &item); err == nil {
+				r.cache[entry.Key()] = item
+			}
+		}
+		r.mu.Unlock()
+	}
+}
+
+func (r *Registry) Upsert(item Interest, topics []string) (Interest, error) {
+	cur, err := r.Get(item.SessionID)
+	if err == nil {
+		item = cur
+	}
+	item.MachineID = first(item.MachineID, curValue(cur.MachineID))
+	item.Dir = first(item.Dir, curValue(cur.Dir))
+	item.UpdatedAt = time.Now().UnixMilli()
+	item = Merge(item, topics)
+	sort.Strings(item.Topics)
+	buf, err := json.Marshal(item)
+	if err != nil {
+		return Interest{}, err
+	}
+	_, err = r.kv.Put(item.SessionID, buf)
+	return item, err
+}
+
+func (r *Registry) Remove(sessionID string, topics []string) error {
+	item, err := r.Get(sessionID)
+	if err != nil {
+		return err
+	}
+	item = Remove(item, topics)
+	if len(item.Topics) == 0 {
+		return r.kv.Delete(sessionID)
+	}
+	item.UpdatedAt = time.Now().UnixMilli()
+	buf, err := json.Marshal(item)
+	if err != nil {
+		return err
+	}
+	_, err = r.kv.Put(sessionID, buf)
+	return err
+}
+
+func (r *Registry) Get(sessionID string) (Interest, error) {
+	r.mu.RLock()
+	item, ok := r.cache[sessionID]
+	r.mu.RUnlock()
+	if ok {
+		return item, nil
+	}
+	entry, err := r.kv.Get(sessionID)
+	if err != nil {
+		return Interest{}, err
+	}
+	var fresh Interest
+	err = json.Unmarshal(entry.Value(), &fresh)
+	if err == nil {
+		r.mu.Lock()
+		r.cache[sessionID] = fresh
+		r.mu.Unlock()
+	}
+	return fresh, err
+}
+
+func (r *Registry) Match(machineID string, topic string) []Interest {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := []Interest{}
+	for _, item := range r.cache {
+		if item.MachineID != machineID {
+			continue
+		}
+		for _, pattern := range item.Topics {
+			if routing.Match(pattern, topic) {
+				out = append(out, item)
+				break
+			}
+		}
+	}
+	return out
+}
+
+func first(value string, fallback string) string {
+	if value != "" {
+		return value
+	}
+	return fallback
+}
+
+func curValue(value string) string {
+	return value
+}

--- a/packages/envoy/internal/verify/github.go
+++ b/packages/envoy/internal/verify/github.go
@@ -1,0 +1,22 @@
+package verify
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+func Github(secret string, body []byte, signature string) bool {
+	if !strings.HasPrefix(signature, "sha256=") {
+		return false
+	}
+	expected := sha256mac(secret, body)
+	return hmac.Equal([]byte("sha256="+expected), []byte(signature))
+}
+
+func sha256mac(secret string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
+}

--- a/packages/envoy/internal/verify/github_test.go
+++ b/packages/envoy/internal/verify/github_test.go
@@ -1,0 +1,24 @@
+package verify
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
+
+func TestGithub(t *testing.T) {
+	body := []byte(`{"hello":"world"}`)
+	mac := hmac.New(sha256.New, []byte("secret"))
+	mac.Write(body)
+	sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	if !Github("secret", body, sig) {
+		t.Fatal("expected signature to verify")
+	}
+	if Github("wrong", body, sig) {
+		t.Fatal("expected wrong secret to fail")
+	}
+	if Github("secret", body, "sha256=deadbeef") {
+		t.Fatal("expected wrong digest to fail")
+	}
+}

--- a/packages/envoy/internal/verify/slack.go
+++ b/packages/envoy/internal/verify/slack.go
@@ -1,0 +1,28 @@
+package verify
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func Slack(secret string, body []byte, timestamp string, signature string) bool {
+	if !strings.HasPrefix(signature, "v0=") || timestamp == "" {
+		return false
+	}
+	ts, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil {
+		return false
+	}
+	if delta := time.Now().Unix() - ts; delta > 300 || delta < -300 {
+		return false
+	}
+	base := fmt.Sprintf("v0:%s:%s", timestamp, string(body))
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(base))
+	return hmac.Equal([]byte("v0="+hex.EncodeToString(mac.Sum(nil))), []byte(signature))
+}

--- a/packages/envoy/internal/verify/slack_test.go
+++ b/packages/envoy/internal/verify/slack_test.go
@@ -1,0 +1,28 @@
+package verify
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestSlack(t *testing.T) {
+	body := []byte(`{"type":"event_callback"}`)
+	ts := fmt.Sprintf("%d", time.Now().Unix())
+	mac := hmac.New(sha256.New, []byte("secret"))
+	mac.Write([]byte(fmt.Sprintf("v0:%s:%s", ts, string(body))))
+	sig := "v0=" + hex.EncodeToString(mac.Sum(nil))
+	if !Slack("secret", body, ts, sig) {
+		t.Fatal("expected signature to verify")
+	}
+	if Slack("wrong", body, ts, sig) {
+		t.Fatal("expected wrong secret to fail")
+	}
+	old := fmt.Sprintf("%d", time.Now().Add(-10*time.Minute).Unix())
+	if Slack("secret", body, old, sig) {
+		t.Fatal("expected stale timestamp to fail")
+	}
+}

--- a/packages/envoy/scripts/with-envoy-secrets
+++ b/packages/envoy/scripts/with-envoy-secrets
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+exec secrets ENVOY_SLACK_SIGNING_SECRET ENVOY_GITHUB_WEBHOOK_SECRET -- "$@"

--- a/scripts/sync-envoy-host.sh
+++ b/scripts/sync-envoy-host.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+host="${1:?usage: sync-envoy-host.sh user@host}"
+root="$(cd "$(dirname "$0")/.." && pwd)"
+
+ssh "$host" 'mkdir -p ~/legion/default/packages/envoy ~/legion/default/packages/envoy-plugin/dist ~/.dotfiles/opencode/plugins'
+
+"$root/packages/envoy/deploy/scripts/sync-host.sh" "$host"
+"$root/packages/envoy-plugin/scripts/sync-host.sh" "$host"


### PR DESCRIPTION
## Summary
- add Envoy to the Legion monorepo as `packages/envoy` with Go services, Docker packaging, and deployment scripts
- add shared contracts and an `opencode-legion-envoy` plugin package for cross-runtime event handling and OpenCode integration
- add package-scoped CI and release workflows for the new Envoy, contracts, and plugin packages

## Validation
- `packages/contracts`: `bun run lint && bun run typecheck && bun run test && bun run build`
- `packages/envoy-plugin`: `bun run lint && bun run typecheck && bun run build`
- `packages/envoy`: `docker run --rm -v /home/ubuntu/legion/default:/src -w /src/packages/envoy golang:1.24-bookworm sh -lc '/usr/local/go/bin/go test ./... && /usr/local/go/bin/go build -buildvcs=false ./cmd/github && /usr/local/go/bin/go build -buildvcs=false ./cmd/slack && /usr/local/go/bin/go build -buildvcs=false ./cmd/listener'`
- plugin consumption check: OpenCode successfully loaded `https://github.com/sjawhar/legion/releases/download/legion-envoy-prerelease-20260330-220659/opencode-legion-envoy-0.10.1.tgz` and registered `envoy_subscribe`, `envoy_unsubscribe`, `envoy_list`, and `envoy_send`

## Prerelease artifact
- GitHub prerelease: `legion-envoy-prerelease-20260330-220659`
- Plugin URL:
  - `https://github.com/sjawhar/legion/releases/download/legion-envoy-prerelease-20260330-220659/opencode-legion-envoy-0.10.1.tgz`

## Pre-merge smoke checklist
- [ ] Local live-TUI delivery: start a custom OpenCode build and verify a delivered agent message appears live in the TUI
- [ ] GitHub ingress: send a signed test webhook to the deployed GitHub receiver and verify a subscribed session receives it
- [ ] Slack ingress: send a signed Slack event to the deployed Slack receiver and verify a subscribed session receives it
- [ ] Cross-machine delivery: send an agent message from one machine to a session on another machine and verify it lands
- [ ] Legion-controller path: use the Legion controller/operator workflow to exercise an Envoy delivery path, since that is how users are likely to interact with it