### PR TITLE
feat: workers notify controller via Envoy on completion

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,0 +1,45 @@
+{
+  "name": ".opencode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@opencode-ai/plugin": "latest"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.3.13.tgz",
+      "integrity": "sha512-zHgtWfdDz8Wu8srE8f8HUtPT9i6c3jTmgQKoFZUZ+RR5CMQF1kAlb1cxeEe9Xm2DRNFVJog9Cv/G1iUHYgXSUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.3.13",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.1.95",
+        "@opentui/solid": ">=0.1.95"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.3.13",
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/.opencode/skills/envoy/SKILL.md
+++ b/.opencode/skills/envoy/SKILL.md
@@ -83,7 +83,15 @@ Examples:
 1. Get the target session ID
 2. Call `envoy_send(target_session, message)`
 
-You do NOT need to subscribe in order to send.
+You do NOT need to subscribe in order to send or publish.
+
+### Tools
+
+- `envoy_subscribe(topics)` — receive future events on those topics
+- `envoy_unsubscribe(topics?)` — stop receiving some or all topics
+- `envoy_list()` — show current subscriptions
+- `envoy_send(target_session, message)` — send directly to a specific session (point-to-point)
+- `envoy_publish(topic, message)` — broadcast to any topic (all matching subscribers receive it)
 
 ## Patterns
 

--- a/.opencode/skills/legion-controller/SKILL.md
+++ b/.opencode/skills/legion-controller/SKILL.md
@@ -85,6 +85,10 @@ The controller MUST NOT ask "should I continue?" for routine operations. Act on 
 2. There is genuine stakeholder disagreement
 3. The situation is not covered by existing rules
 
+## Envoy Notifications
+
+The daemon automatically subscribes the controller to `notifications.legion.controller` and `notifications.agent.<session_id>` at startup. Workers broadcast to `notifications.legion.controller` when they finish a phase, giving you instant notification instead of waiting for the next polling cycle. The `worker-done` label remains the source of truth — Envoy is a speed optimization.
+
 ## Algorithm
 
 ```dot

--- a/.opencode/skills/legion-retro/SKILL.md
+++ b/.opencode/skills/legion-retro/SKILL.md
@@ -273,3 +273,9 @@ Add `worker-done` label to the issue, then exit:
 Then remove `worker-active`:
 - **GitHub:** `gh issue edit $ISSUE_NUMBER --remove-label "worker-active" -R $OWNER/$REPO`
 - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current labels without "worker-active"])`
+
+Then notify the controller via Envoy (best-effort):
+```
+envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER retro completed. Ready for merge.")
+```
+If `envoy_publish` fails, continue — the label is the source of truth.

--- a/.opencode/skills/legion-worker/SKILL.md
+++ b/.opencode/skills/legion-worker/SKILL.md
@@ -35,6 +35,7 @@ Use the **backend** from your prompt to choose GitHub CLI or Linear MCP commands
 4. **Signal completion (MOST IMPORTANT)** — before you stop for ANY reason, you MUST: push your work, add `worker-done` label, remove `worker-active` label. If you skip this, the issue silently stalls. Create a todo for this at session start (see Required Startup Todos below).
 4.5. **Write handoff data before signaling.** Each workflow has a handoff write step — you MUST attempt it before adding `worker-done`. The `|| true` means CLI failures don't block you, but skipping the attempt is not acceptable. If the write fails, note it in your exit comment.
 5. **Clean up on exit** - remove `worker-active` label when exiting (done or blocked)
+6. **Notify the controller via Envoy** — after adding `worker-done`, broadcast a completion notification so the controller doesn't have to wait for its next polling cycle. Use `envoy_publish(topic="notifications.legion.controller", message="Worker done: <issue> <mode> <outcome>")`. If `envoy_publish` fails, that's fine — the label is the source of truth.
 
 ## Skill Discipline
 
@@ -108,7 +109,7 @@ If you're resuming after user feedback, also read the issue comments for the ans
 
 1. Your workflow-specific work items (from the workflow file)
 2. A **signal completion** todo as the LAST item:
-   - `Signal completion: push changes, add worker-done label, remove worker-active label`
+   - `Signal completion: push changes, add worker-done label, remove worker-active label, notify controller via Envoy`
    - Keep this todo `pending` until you have actually run the label commands and verified they succeeded
    - **Do not mark this complete early** — it is your contract with the controller
 
@@ -179,6 +180,12 @@ jj git push
 Then update labels:
 - Add `worker-done` if your mode requires it (see routing table)
 - Remove `worker-active` (the controller added this when dispatching you)
+
+Then notify the controller via Envoy (best-effort, non-blocking):
+```
+envoy_publish(topic="notifications.legion.controller", message="Worker done: <issue-id> <mode> completed")
+```
+If `envoy_publish` fails, continue — the label is the source of truth.
 
 ## Mode Routing
 

--- a/.opencode/skills/legion-worker/workflows/architect.md
+++ b/.opencode/skills/legion-worker/workflows/architect.md
@@ -240,6 +240,12 @@ linear_linear(action="update",
 - **GitHub:** `gh issue edit $ISSUE_NUMBER --remove-label "worker-active" -R $OWNER/$REPO`
 - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current labels without "worker-active"])`
 
+Then notify the controller via Envoy (best-effort):
+```
+envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER architect completed. Sub-issues ready for planning.")
+```
+If `envoy_publish` fails, continue — the label is the source of truth.
+
 ## Common Mistakes
 
 | Mistake | Correction |

--- a/.opencode/skills/legion-worker/workflows/implement.md
+++ b/.opencode/skills/legion-worker/workflows/implement.md
@@ -363,6 +363,12 @@ current_labels = [l.name for l in issue.labels if l.name != "worker-active"]
 linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "worker-done"])
 ```
 
+Then notify the controller via Envoy (best-effort):
+```
+envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER implement completed. PR ready for testing.")
+```
+If `envoy_publish` fails, continue — the label is the source of truth.
+
 ---
 
 ## Mode 2: Address Comments
@@ -491,3 +497,9 @@ issue = linear_linear(action="get", id=$LEGION_ISSUE_ID)
 current_labels = [l.name for l in issue.labels if l.name != "worker-active"]
 linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "worker-done"])
 ```
+
+Then notify the controller via Envoy (best-effort):
+```
+envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER implement completed after changes. PR ready for re-testing.")
+```
+If `envoy_publish` fails, continue — the label is the source of truth.

--- a/.opencode/skills/legion-worker/workflows/plan.md
+++ b/.opencode/skills/legion-worker/workflows/plan.md
@@ -408,6 +408,12 @@ Then remove `worker-active`:
 - **GitHub:** `gh issue edit $ISSUE_NUMBER --remove-label "worker-active" -R $OWNER/$REPO`
 - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current labels without "worker-active"])`
 
+Then notify the controller via Envoy (best-effort):
+```
+envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER plan completed. Ready for implementation.")
+```
+If `envoy_publish` fails, continue — the label is the source of truth.
+
 **CRITICAL:** Only add `worker-done` after successfully posting the plan. Never add this label if:
 - Requirements were unclear and could not be resolved (use `user-input-needed` instead)
 - Plan review failed and was not resolved

--- a/.opencode/skills/legion-worker/workflows/review.md
+++ b/.opencode/skills/legion-worker/workflows/review.md
@@ -240,6 +240,12 @@ current_labels = [l.name for l in issue.labels if l.name != "worker-active"]
 linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "worker-done"])
 ```
 
+Then notify the controller via Envoy (best-effort):
+```
+envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER review completed. See PR for review outcome.")
+```
+If `envoy_publish` fails, continue — the label is the source of truth.
+
 ## Common Mistakes
 
 | Mistake | Correction |

--- a/.opencode/skills/legion-worker/workflows/test.md
+++ b/.opencode/skills/legion-worker/workflows/test.md
@@ -332,6 +332,11 @@ current_labels = [l.name for l in issue.labels if l.name != "worker-active"]
 linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "worker-done", "test-passed"])
 ```
 
+Then notify the controller via Envoy (best-effort):
+```
+envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER test passed.")
+```
+
 **If any criterion fails:**
 
 **GitHub:**
@@ -350,6 +355,13 @@ issue = linear_linear(action="get", id=$LEGION_ISSUE_ID)
 current_labels = [l.name for l in issue.labels if l.name != "worker-active"]
 linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "worker-done", "test-failed"])
 ```
+
+Then notify the controller via Envoy (best-effort):
+```
+envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER test failed. See PR comments for details.")
+```
+
+If `envoy_publish` fails, continue — the label is the source of truth.
 
 ## Blocking on User Input
 

--- a/packages/contracts/schemas/envelope.schema.json
+++ b/packages/contracts/schemas/envelope.schema.json
@@ -19,6 +19,7 @@
       "enum": ["agent", "github", "slack", "whatsapp"]
     },
     "source_event_id": { "type": "string", "minLength": 1 },
+    "source_session": { "type": "string" },
     "topic": { "type": "string", "minLength": 1 },
     "dedupe_key": { "type": "string", "minLength": 1 },
     "issued_at": { "type": "integer" },

--- a/packages/contracts/src/envelope.ts
+++ b/packages/contracts/src/envelope.ts
@@ -4,6 +4,7 @@ export const EnvelopeSchema = z.object({
   event_id: z.string().min(1),
   source: z.enum(["agent", "github", "slack", "whatsapp"]),
   source_event_id: z.string().min(1),
+  source_session: z.string().optional(),
   topic: z.string().min(1),
   dedupe_key: z.string().min(1),
   issued_at: z.number().int(),

--- a/packages/daemon/src/daemon/__tests__/index.test.ts
+++ b/packages/daemon/src/daemon/__tests__/index.test.ts
@@ -927,7 +927,7 @@ describe("daemon entry", () => {
         controllerSessionId: "ses_test",
       },
       {
-        readStateFile: async () => ({ workers: {}, crashHistory: {} }),
+        readStateFile: async () => ({ workers: { "test-implement": { id: "test-implement", port: 13381, sessionId: "ses_worker", workspace: "/test", startedAt: new Date().toISOString(), status: "running" as const, crashCount: 0, lastCrashAt: null } }, crashHistory: {} }),
         writeStateFile: async () => {},
         adapter: {
           ...makeAdapter({

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -134,16 +134,38 @@ async function sendPromptWithRetry(
   throw lastError;
 }
 
+function subscribeControllerToEnvoy(sessionId: string) {
+  const envoyUrl = process.env.ENVOY_URL ?? "http://127.0.0.1:9020";
+  fetch(`${envoyUrl}/v1/interests/subscribe`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      session_id: sessionId,
+      topics: ["notifications.legion.controller", "notifications.slack.*.*.mention"],
+    }),
+  })
+    .then(() => {
+      console.log(`Controller subscribed to Envoy: session=${sessionId}`);
+    })
+    .catch((err) => {
+      console.warn(`Envoy subscribe failed (non-fatal): ${err}`);
+    });
+}
+
 function buildControllerEnv(config: DaemonConfig): Record<string, string> {
   // config.legionId is guaranteed non-empty by the startDaemon guard at line 107-109.
   // The "" fallback is unreachable dead code — kept to satisfy the type checker.
   const legionId = config.legionId ?? "";
-  return {
+  const env: Record<string, string> = {
     LEGION_ID: legionId,
     LEGION_ISSUE_BACKEND: config.issueBackend,
     LEGION_SHORT_ID: legionId.slice(0, 8),
     LEGION_DAEMON_PORT: String(config.daemonPort),
   };
+  if (config.controllerSessionId) {
+    env.LEGION_CONTROLLER_SESSION_ID = config.controllerSessionId;
+  }
+  return env;
 }
 
 export async function startDaemon(
@@ -200,6 +222,8 @@ export async function startDaemon(
   let indexInitializations = 0;
   let indexIncrementalUpdates = 0;
 
+  let controllerState: ControllerState | undefined;
+
   registerSignals();
   startMemoryTelemetry();
   const releaseDaemonGauges = registerGauges("daemon-index", () => ({
@@ -239,6 +263,16 @@ export async function startDaemon(
     console.log(`Shared serve started on port ${sharedServePort}`);
   }
 
+  // Log when shared serve exits but don't auto-restart — it idles out with 0 sessions.
+  // The serve will be restarted on-demand when workers are created.
+  const adapterAny = resolvedDeps.adapter as { onServeExit?: ((code: number | null) => void) | null };
+  if (adapterAny.onServeExit !== undefined) {
+    adapterAny.onServeExit = (code) => {
+      if (shuttingDown) return;
+      console.log(`Shared serve exited (code=${code}), will restart on next worker creation`);
+    };
+  }
+
   // Initialize per-role serves for credential isolation (when GitHub Apps configured)
   let roleServeManager: RoleServeManager | undefined;
   let tokenManager: TokenManager | undefined;
@@ -264,16 +298,45 @@ export async function startDaemon(
   }
 
   const preState = await resolvedDeps.readStateFile(config.stateFilePath);
-  let controllerState: ControllerState | undefined = preState.controller;
+  controllerState = preState.controller;
 
-  for (const entry of Object.values(preState.workers)) {
-    try {
-      const actualId = await resolvedDeps.adapter.createSession(entry.sessionId, entry.workspace);
-      if (actualId !== entry.sessionId) {
-        console.warn(`Worker ${entry.id}: session ID changed ${entry.sessionId} -> ${actualId}`);
-      }
-    } catch (error) {
-      console.error(`Failed to re-create session for ${entry.id}: ${error}`);
+  // Prune dead/stopped workers from state file on startup
+  const activeWorkers: Record<string, typeof preState.workers[string]> = {};
+  let pruned = 0;
+  for (const [id, entry] of Object.entries(preState.workers)) {
+    if (entry.status === "dead" || entry.status === "stopped") {
+      pruned++;
+      continue;
+    }
+    activeWorkers[id] = entry;
+  }
+  if (pruned > 0) {
+    console.log(`Pruned ${pruned} dead/stopped workers from state file`);
+    await resolvedDeps.writeStateFile(config.stateFilePath, {
+      ...preState,
+      workers: activeWorkers,
+    });
+  }
+
+  // Recreate sessions for active workers in parallel (batched)
+  const workerEntries = Object.values(activeWorkers);
+  if (workerEntries.length > 0) {
+    console.log(`Recreating ${workerEntries.length} active worker sessions...`);
+    const BATCH_SIZE = 10;
+    for (let i = 0; i < workerEntries.length; i += BATCH_SIZE) {
+      const batch = workerEntries.slice(i, i + BATCH_SIZE);
+      await Promise.allSettled(
+        batch.map(async (entry) => {
+          try {
+            const actualId = await resolvedDeps.adapter.createSession(entry.sessionId, entry.workspace);
+            if (actualId !== entry.sessionId) {
+              console.warn(`Worker ${entry.id}: session ID changed ${entry.sessionId} -> ${actualId}`);
+            }
+          } catch (error) {
+            console.error(`Failed to re-create session for ${entry.id}: ${error}`);
+          }
+        })
+      );
     }
   }
 
@@ -317,6 +380,7 @@ export async function startDaemon(
     });
     releaseDaemonGauges();
     stopMemoryTelemetry();
+    clearInterval(keepalive);
     stopServer();
     if (exitAfter) {
       process.exit(0);
@@ -393,6 +457,7 @@ export async function startDaemon(
     }
     console.log(`External controller: session=${config.controllerSessionId}`);
     controllerState = { sessionId: config.controllerSessionId };
+    subscribeControllerToEnvoy(config.controllerSessionId);
   } else {
     const requestedSessionId = computeControllerSessionId(legionId);
     let actualSessionId: string | undefined;
@@ -418,6 +483,7 @@ export async function startDaemon(
           resolvedDeps
         );
         console.log(`Controller started: session=${actualSessionId} port=${sharedServePort}`);
+        subscribeControllerToEnvoy(actualSessionId);
       } catch (error) {
         console.error(`Controller session created but prompt failed: ${error}`);
         console.error("Health loop will retry on next tick.");
@@ -444,19 +510,31 @@ export async function startDaemon(
             console.log(`Shared serve restarted on port ${sharedServePort}`);
 
             const state = await resolvedDeps.readStateFile(config.stateFilePath);
-            for (const entry of Object.values(state.workers)) {
-              try {
-                const actualId = await resolvedDeps.adapter.createSession(
-                  entry.sessionId,
-                  entry.workspace
+            const liveWorkers = Object.values(state.workers).filter(
+              (e) => e.status !== "dead" && e.status !== "stopped"
+            );
+            if (liveWorkers.length > 0) {
+              console.log(`Recreating ${liveWorkers.length} active worker sessions after serve restart...`);
+              const BATCH_SIZE = 10;
+              for (let i = 0; i < liveWorkers.length; i += BATCH_SIZE) {
+                const batch = liveWorkers.slice(i, i + BATCH_SIZE);
+                await Promise.allSettled(
+                  batch.map(async (entry) => {
+                    try {
+                      const actualId = await resolvedDeps.adapter.createSession(
+                        entry.sessionId,
+                        entry.workspace
+                      );
+                      if (actualId !== entry.sessionId) {
+                        console.warn(
+                          `Worker ${entry.id}: session ID changed ${entry.sessionId} -> ${actualId}`
+                        );
+                      }
+                    } catch {
+                      // Best-effort session re-creation
+                    }
+                  })
                 );
-                if (actualId !== entry.sessionId) {
-                  console.warn(
-                    `Worker ${entry.id}: session ID changed ${entry.sessionId} -> ${actualId}`
-                  );
-                }
-              } catch {
-                // Best-effort session re-creation
               }
             }
 
@@ -539,6 +617,10 @@ export async function startDaemon(
       }
     }, config.checkIntervalMs);
   };
+  // Keepalive: prevent Bun's event loop from draining when the shared serve child exits.
+  // Bun.spawn links child lifecycle to parent — without this, the daemon exits when the serve does.
+  const keepalive = setInterval(() => {}, 2_147_483_647); // max 32-bit int
+
   scheduleHealthTick();
 
   const handleSignal = async () => {
@@ -556,5 +638,11 @@ export async function startDaemon(
 }
 
 if (import.meta.main) {
+  process.on("uncaughtException", (error) => {
+    console.error("[daemon] uncaught exception:", error);
+  });
+  process.on("unhandledRejection", (reason) => {
+    console.error("[daemon] unhandled rejection:", reason);
+  });
   void startDaemon();
 }

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -18,7 +18,7 @@ import {
 import { RoleServeManager } from "./multi-serve";
 import { isPortFree } from "./ports";
 import { createAdapter } from "./runtime";
-import type { RuntimeAdapter } from "./runtime/types";
+import type { RuntimeAdapter, RuntimeStartOptions } from "./runtime/types";
 import { startServer } from "./server";
 import { type ControllerState, readStateFile, writeStateFile } from "./state-file";
 import {
@@ -144,7 +144,11 @@ function subscribeControllerToEnvoy(sessionId: string) {
       topics: ["notifications.legion.controller", "notifications.slack.*.*.mention"],
     }),
   })
-    .then(() => {
+    .then((res) => {
+      if (!res.ok) {
+        console.warn(`Envoy subscribe returned ${res.status} (non-fatal)`);
+        return;
+      }
       console.log(`Controller subscribed to Envoy: session=${sessionId}`);
     })
     .catch((err) => {
@@ -251,27 +255,14 @@ export async function startDaemon(
         })
       : createNoopIndexManager();
 
-  const existingHealthy = await resolvedDeps.adapter.healthy();
-  if (existingHealthy) {
-    console.log(`Adopted existing shared serve on port ${sharedServePort}`);
-  } else {
-    await resolvedDeps.adapter.start({
-      env: buildControllerEnv(config),
-      workspace: controllerWorkspace,
-      logDir: config.logDir,
-    });
-    console.log(`Shared serve started on port ${sharedServePort}`);
-  }
-
-  // Log when shared serve exits but don't auto-restart — it idles out with 0 sessions.
-  // The serve will be restarted on-demand when workers are created.
-  const adapterAny = resolvedDeps.adapter as { onServeExit?: ((code: number | null) => void) | null };
-  if (adapterAny.onServeExit !== undefined) {
-    adapterAny.onServeExit = (code) => {
-      if (shuttingDown) return;
-      console.log(`Shared serve exited (code=${code}), will restart on next worker creation`);
-    };
-  }
+  // Configure the adapter with start opts for lazy serve startup.
+  const serveStartOpts: RuntimeStartOptions = {
+    env: buildControllerEnv(config),
+    workspace: controllerWorkspace,
+    logDir: config.logDir,
+  };
+  const adapterConfigure = resolvedDeps.adapter as { configure?: (opts: RuntimeStartOptions) => void };
+  adapterConfigure.configure?.(serveStartOpts);
 
   // Initialize per-role serves for credential isolation (when GitHub Apps configured)
   let roleServeManager: RoleServeManager | undefined;
@@ -318,8 +309,22 @@ export async function startDaemon(
     });
   }
 
-  // Recreate sessions for active workers in parallel (batched)
+  // Start serve eagerly if there are active workers or an internal controller that needs it.
+  // Otherwise, defer — ensureRunning() in the adapter starts it on first POST /workers.
   const workerEntries = Object.values(activeWorkers);
+  const hasInternalController = !config.controllerSessionId;
+  const needsServeNow = workerEntries.length > 0 || hasInternalController;
+
+  if (needsServeNow) {
+    const existingHealthy = await resolvedDeps.adapter.healthy();
+    if (!existingHealthy) {
+      await resolvedDeps.adapter.start(serveStartOpts);
+    }
+    console.log(`Shared serve running on port ${sharedServePort}`);
+  } else {
+    console.log(`Shared serve deferred — will start on first worker creation`);
+  }
+
   if (workerEntries.length > 0) {
     console.log(`Recreating ${workerEntries.length} active worker sessions...`);
     const BATCH_SIZE = 10;
@@ -498,22 +503,21 @@ export async function startDaemon(
         const serveHealthy = await resolvedDeps.adapter.healthy();
 
         if (!serveHealthy) {
-          console.error("Shared serve is unhealthy, attempting restart...");
+          // Only restart the serve if something needs it (active workers or internal controller).
+          // With external controller + 0 workers, let the serve stay down — ensureRunning() starts it on demand.
+          const state = await resolvedDeps.readStateFile(config.stateFilePath);
+          const liveWorkers = Object.values(state.workers).filter(
+            (e) => e.status !== "dead" && e.status !== "stopped"
+          );
+          const needsRestart = liveWorkers.length > 0 || hasInternalController;
 
-          try {
-            await resolvedDeps.adapter.start({
-              env: buildControllerEnv(config),
-              workspace: controllerWorkspace,
-              logDir: config.logDir,
-            });
-            sharedServeRestarts += 1;
-            console.log(`Shared serve restarted on port ${sharedServePort}`);
+          if (needsRestart) {
+            console.error("Shared serve is unhealthy, attempting restart...");
+            try {
+              await resolvedDeps.adapter.start(serveStartOpts);
+              sharedServeRestarts += 1;
+              console.log(`Shared serve restarted on port ${sharedServePort}`);
 
-            const state = await resolvedDeps.readStateFile(config.stateFilePath);
-            const liveWorkers = Object.values(state.workers).filter(
-              (e) => e.status !== "dead" && e.status !== "stopped"
-            );
-            if (liveWorkers.length > 0) {
               console.log(`Recreating ${liveWorkers.length} active worker sessions after serve restart...`);
               const BATCH_SIZE = 10;
               for (let i = 0; i < liveWorkers.length; i += BATCH_SIZE) {
@@ -536,38 +540,38 @@ export async function startDaemon(
                   })
                 );
               }
-            }
 
-            if (controllerState?.port) {
-              try {
-                const actualControllerSessionId = await resolvedDeps.adapter.createSession(
-                  controllerState.sessionId,
-                  controllerWorkspace
-                );
-                if (actualControllerSessionId !== controllerState.sessionId) {
-                  console.warn(
-                    `Controller: session ID changed ${controllerState.sessionId} -> ${actualControllerSessionId}`
+              if (controllerState?.port) {
+                try {
+                  const actualControllerSessionId = await resolvedDeps.adapter.createSession(
+                    controllerState.sessionId,
+                    controllerWorkspace
                   );
+                  if (actualControllerSessionId !== controllerState.sessionId) {
+                    console.warn(
+                      `Controller: session ID changed ${controllerState.sessionId} -> ${actualControllerSessionId}`
+                    );
+                  }
+                  controllerState = {
+                    ...controllerState,
+                    sessionId: actualControllerSessionId,
+                    port: sharedServePort,
+                  };
+                  controllerRecreates += 1;
+                  await sendPromptWithRetry(
+                    resolvedDeps.adapter,
+                    actualControllerSessionId,
+                    "/legion-controller",
+                    resolvedDeps
+                  );
+                  console.log(`Controller re-created: session=${actualControllerSessionId}`);
+                } catch (error) {
+                  console.error(`Failed to re-create controller session: ${error}`);
                 }
-                controllerState = {
-                  ...controllerState,
-                  sessionId: actualControllerSessionId,
-                  port: sharedServePort,
-                };
-                controllerRecreates += 1;
-                await sendPromptWithRetry(
-                  resolvedDeps.adapter,
-                  actualControllerSessionId,
-                  "/legion-controller",
-                  resolvedDeps
-                );
-                console.log(`Controller re-created: session=${actualControllerSessionId}`);
-              } catch (error) {
-                console.error(`Failed to re-create controller session: ${error}`);
               }
+            } catch (error) {
+              console.error(`Failed to restart shared serve: ${error}`);
             }
-          } catch (error) {
-            console.error(`Failed to restart shared serve: ${error}`);
           }
         }
 

--- a/packages/daemon/src/daemon/runtime/opencode.ts
+++ b/packages/daemon/src/daemon/runtime/opencode.ts
@@ -10,17 +10,23 @@ import type { RuntimeAdapter, RuntimeStartOptions } from "./types";
 
 export class OpenCodeAdapter implements RuntimeAdapter {
   private pid = 0;
-  private subprocess: ReturnType<typeof Bun.spawn> | null = null;
   private readonly workspaces = new Map<string, string>();
-  private lastStartOpts: RuntimeStartOptions | null = null;
-  onServeExit: ((code: number | null) => void) | null = null;
+  private startOpts: RuntimeStartOptions | null = null;
+  private startingPromise: Promise<void> | null = null;
 
   constructor(private readonly port: number) {}
+
   getPort(): number {
     return this.port;
   }
+
+  /** Store start opts for lazy serve startup via ensureRunning(). */
+  configure(opts: RuntimeStartOptions): void {
+    this.startOpts = opts;
+  }
+
   async start(opts: RuntimeStartOptions): Promise<void> {
-    this.lastStartOpts = opts;
+    this.startOpts = opts;
     const serve = await spawnSharedServe({
       port: this.port,
       workspace: opts.workspace,
@@ -28,32 +34,26 @@ export class OpenCodeAdapter implements RuntimeAdapter {
       env: opts.env,
     });
     this.pid = serve.pid;
-    this.subprocess = serve.subprocess;
-    serve.subprocess.exited.then((code) => {
-      console.error(`[daemon] shared serve exited unexpectedly: pid=${this.pid} code=${code}`);
-      this.pid = 0;
-      this.subprocess = null;
-      this.onServeExit?.(code);
-    });
     await waitForHealthy(this.port);
   }
 
-  private async ensureRunning(): Promise<void> {
+  /** Start the serve on demand if it's not running. Coalesces concurrent calls. */
+  async ensureRunning(): Promise<void> {
     if (await healthCheck(this.port)) return;
-    if (!this.lastStartOpts) throw new Error("Shared serve not initialized");
-    console.log("Shared serve not running, starting on demand...");
-    await this.start(this.lastStartOpts);
+    if (!this.startOpts)
+      throw new Error("Shared serve not configured \u2014 call configure() or start() first");
+    if (!this.startingPromise) {
+      this.startingPromise = this.start(this.startOpts).finally(() => {
+        this.startingPromise = null;
+      });
+    }
+    await this.startingPromise;
   }
 
   async stop(): Promise<void> {
-    if (this.subprocess) {
-      this.subprocess.kill();
-      await this.subprocess.exited;
-      this.subprocess = null;
-    } else if (this.pid > 0) {
+    if (this.pid > 0) {
       await stopServe(this.port, this.pid);
     }
-    this.pid = 0;
   }
 
   async healthy(): Promise<boolean> {

--- a/packages/daemon/src/daemon/runtime/opencode.ts
+++ b/packages/daemon/src/daemon/runtime/opencode.ts
@@ -10,14 +10,17 @@ import type { RuntimeAdapter, RuntimeStartOptions } from "./types";
 
 export class OpenCodeAdapter implements RuntimeAdapter {
   private pid = 0;
+  private subprocess: ReturnType<typeof Bun.spawn> | null = null;
   private readonly workspaces = new Map<string, string>();
+  private lastStartOpts: RuntimeStartOptions | null = null;
+  onServeExit: ((code: number | null) => void) | null = null;
 
   constructor(private readonly port: number) {}
-
   getPort(): number {
     return this.port;
   }
   async start(opts: RuntimeStartOptions): Promise<void> {
+    this.lastStartOpts = opts;
     const serve = await spawnSharedServe({
       port: this.port,
       workspace: opts.workspace,
@@ -25,13 +28,32 @@ export class OpenCodeAdapter implements RuntimeAdapter {
       env: opts.env,
     });
     this.pid = serve.pid;
+    this.subprocess = serve.subprocess;
+    serve.subprocess.exited.then((code) => {
+      console.error(`[daemon] shared serve exited unexpectedly: pid=${this.pid} code=${code}`);
+      this.pid = 0;
+      this.subprocess = null;
+      this.onServeExit?.(code);
+    });
     await waitForHealthy(this.port);
   }
 
+  private async ensureRunning(): Promise<void> {
+    if (await healthCheck(this.port)) return;
+    if (!this.lastStartOpts) throw new Error("Shared serve not initialized");
+    console.log("Shared serve not running, starting on demand...");
+    await this.start(this.lastStartOpts);
+  }
+
   async stop(): Promise<void> {
-    if (this.pid > 0) {
+    if (this.subprocess) {
+      this.subprocess.kill();
+      await this.subprocess.exited;
+      this.subprocess = null;
+    } else if (this.pid > 0) {
       await stopServe(this.port, this.pid);
     }
+    this.pid = 0;
   }
 
   async healthy(): Promise<boolean> {
@@ -39,12 +61,14 @@ export class OpenCodeAdapter implements RuntimeAdapter {
   }
 
   async createSession(sessionId: string, workspace: string): Promise<string> {
+    await this.ensureRunning();
     const actualId = await createSession(this.port, sessionId, workspace);
     this.workspaces.set(actualId, workspace);
     return actualId;
   }
 
   async sendPrompt(sessionId: string, text: string): Promise<void> {
+    await this.ensureRunning();
     const client = createWorkerClient(this.port, this.workspaces.get(sessionId) ?? "");
     await client.session.promptAsync({
       sessionID: sessionId,

--- a/packages/daemon/src/daemon/serve-manager.ts
+++ b/packages/daemon/src/daemon/serve-manager.ts
@@ -3,10 +3,11 @@ import { join } from "node:path";
 import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk/v2";
 import { HealthCheckResponseSchema, SessionCreateResponseSchema } from "./schemas";
 
-interface SharedServeState {
+export interface SharedServeState {
   port: number;
   pid: number;
   status: "starting" | "running" | "dead";
+  subprocess: ReturnType<typeof Bun.spawn>;
 }
 
 interface SharedServeOptions {
@@ -60,7 +61,7 @@ export async function spawnSharedServe(opts: SharedServeOptions): Promise<Shared
     throw new Error("Failed to spawn shared opencode serve process");
   }
 
-  return { port: opts.port, pid, status: "starting" };
+  return { port: opts.port, pid, status: "starting", subprocess };
 }
 
 export async function waitForHealthy(port: number, maxRetries = 30, delayMs = 500): Promise<void> {

--- a/packages/daemon/src/daemon/serve-manager.ts
+++ b/packages/daemon/src/daemon/serve-manager.ts
@@ -3,11 +3,10 @@ import { join } from "node:path";
 import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk/v2";
 import { HealthCheckResponseSchema, SessionCreateResponseSchema } from "./schemas";
 
-export interface SharedServeState {
+interface SharedServeState {
   port: number;
   pid: number;
   status: "starting" | "running" | "dead";
-  subprocess: ReturnType<typeof Bun.spawn>;
 }
 
 interface SharedServeOptions {
@@ -45,7 +44,7 @@ export async function spawnSharedServe(opts: SharedServeOptions): Promise<Shared
     stderr = openSync(logFile, "a");
   }
 
-  const { OPENCODE_PERMISSION: _, ...baseEnv } = process.env;
+  const { OPENCODE_PERMISSION: _, OC_SHELL_PID: _pid, OC_REGISTRY: _reg, ...baseEnv } = process.env;
   const subprocess = Bun.spawn(["opencode", "serve", "--port", String(opts.port)], {
     cwd: opts.workspace,
     env: {
@@ -61,7 +60,7 @@ export async function spawnSharedServe(opts: SharedServeOptions): Promise<Shared
     throw new Error("Failed to spawn shared opencode serve process");
   }
 
-  return { port: opts.port, pid, status: "starting", subprocess };
+  return { port: opts.port, pid, status: "starting" };
 }
 
 export async function waitForHealthy(port: number, maxRetries = 30, delayMs = 500): Promise<void> {

--- a/packages/envoy-plugin/src/index.ts
+++ b/packages/envoy-plugin/src/index.ts
@@ -20,7 +20,12 @@ export default async (input: { serverUrl: URL }) => {
   const update = (patch: Record<string, unknown>) => {
     if (!file) return;
     try {
-      const data = JSON.parse(readFileSync(file, "utf-8"));
+      let data: Record<string, unknown> = {};
+      try {
+        data = JSON.parse(readFileSync(file, "utf-8"));
+      } catch {
+        data = { pid: Number(shellPid), dir: process.cwd(), started: new Date().toISOString() };
+      }
       Object.assign(data, patch);
       writeFileSync(file, `${JSON.stringify(data)}\n`);
     } catch {}
@@ -185,6 +190,28 @@ export default async (input: { serverUrl: URL }) => {
             body: JSON.stringify({
               source_session: ctx.sessionID,
               target_session: args.target_session,
+              message: args.message,
+            }),
+          });
+        },
+      }),
+      envoy_publish: tool({
+        description:
+          "Publish an Envoy message to any topic. Use for broadcast to named topics like notifications.legion.controller, team channels, or custom routing. Subscribers matching the topic will receive the message. This is for BROADCAST, not session-targeted delivery (use envoy_send for that).",
+        args: {
+          topic: tool.schema
+            .string()
+            .describe("NATS-style topic to publish to, e.g. notifications.legion.controller"),
+          message: tool.schema.string().describe("Message body to broadcast"),
+        },
+        async execute(args, ctx) {
+          ctx.metadata({ title: "Envoy publish" });
+          return call("/v1/messages/publish", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              source_session: ctx.sessionID,
+              topic: args.topic,
               message: args.message,
             }),
           });

--- a/packages/envoy/AGENTS.md
+++ b/packages/envoy/AGENTS.md
@@ -9,7 +9,7 @@ Envoy owns transport, routing, and delivery:
 - ingests Slack/GitHub/agent events
 - publishes and consumes via NATS/JetStream
 - resolves target OpenCode sessions
-- delivers by hot `prompt_async` or cold `opencode run --session`
+- delivers by hot `prompt_async` (messages stay in JetStream for retry if session is unavailable)
 
 It does not own Legion workflow policy. The daemon/controller decides what to do; Envoy moves events to the right session.
 
@@ -20,7 +20,7 @@ It does not own Legion workflow policy. The daemon/controller decides what to do
 | Receiver behavior      | `cmd/github/main.go`, `cmd/slack/main.go` | HTTP ingress, signature verification, publish path |
 | Listener behavior      | `cmd/listener/main.go`                    | subscribe/match/deliver flow                       |
 | NATS client            | `internal/bus/nats.go`                    | reconnect/self-heal logic                          |
-| Session delivery       | `internal/session/session.go`             | hot vs cold delivery                               |
+| Session delivery       | `internal/session/session.go`             | hot delivery via prompt_async                      |
 | Interest storage       | `internal/store/kv.go`                    | JetStream KV subscriptions                         |
 | Topic matching         | `internal/routing/match.go`               | wildcard matching                                  |
 | Envelope normalization | `internal/contracts/*.go`                 | generated contract + source-specific normalization |
@@ -38,5 +38,5 @@ It does not own Legion workflow policy. The daemon/controller decides what to do
 ## Operational notes
 
 - Health endpoints should reflect NATS health, not just process liveness.
-- If a session is not live in the registry, Envoy will cold-resume it with the configured `ENVOY_OPENCODE_BIN`.
+- If a session is not live in the registry, delivery fails and the message is NAK'd for retry (up to MaxDeliver attempts over the stream's MaxAge window).
 - Cross-machine route correctness depends on valid session registry entries with non-null ports.

--- a/packages/envoy/cmd/listener/main.go
+++ b/packages/envoy/cmd/listener/main.go
@@ -84,6 +84,8 @@ func main() {
 			_ = msg.Ack()
 			return
 		}
+		// NAK on any failure retries ALL recipients, causing duplicates for already-delivered ones.
+		// Acceptable: notifications are advisory and idempotent.
 		var failed bool
 		for _, interest := range items {
 			if err := deliver.Deliver(item, interest); err != nil {
@@ -96,7 +98,7 @@ func main() {
 		} else {
 			_ = msg.Ack()
 		}
-	}, nats.Durable(consumer), nats.DeliverNew(), nats.AckExplicit(), nats.ManualAck(), nats.AckWait(60*time.Second), nats.MaxAckPending(256))
+	}, nats.Durable(consumer), nats.DeliverNew(), nats.AckExplicit(), nats.ManualAck(), nats.AckWait(60*time.Second), nats.MaxAckPending(256), nats.MaxDeliver(20))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/packages/envoy/cmd/listener/main.go
+++ b/packages/envoy/cmd/listener/main.go
@@ -35,16 +35,11 @@ func main() {
 	deliver := session.Deliverer{
 		RegistryDir: os.Getenv("ENVOY_REGISTRY_DIR"),
 		HostBridge:  os.Getenv("ENVOY_HOST_BRIDGE"),
-		OpencodeBin: os.Getenv("ENVOY_OPENCODE_BIN"),
-		XDGConfig:   os.Getenv("ENVOY_XDG_CONFIG_HOME"),
-		XDGData:     os.Getenv("ENVOY_XDG_DATA_HOME"),
-		XDGCache:    os.Getenv("ENVOY_XDG_CACHE_HOME"),
 	}
 
 	consumer := "listener-" + strings.ReplaceAll(cfg.MachineID, " ", "-")
-	// Delete stale consumer to clear redelivery backlog from old slow Match()
 	_ = client.JS().DeleteConsumer(bus.Stream, consumer)
-	_, err = client.JS().Subscribe("notifications.>", func(msg *nats.Msg) {
+	_, err = client.Subscribe("notifications.>", func(msg *nats.Msg) {
 		var item contracts.Envelope
 		if err := json.Unmarshal(msg.Data, &item); err != nil {
 			log.Printf("listener decode failed: %v", err)
@@ -63,6 +58,8 @@ func main() {
 			if err == nil && interest.MachineID == cfg.MachineID {
 				if err := deliver.Deliver(item, interest); err != nil {
 					log.Printf("listener agent delivery failed: %v", err)
+					_ = msg.NakWithDelay(30 * time.Second)
+					return
 				}
 				_ = msg.Ack()
 				return
@@ -75,17 +72,30 @@ func main() {
 			fallback := store.Interest{SessionID: sessionID, Dir: entry.Dir, MachineID: cfg.MachineID}
 			if err := deliver.Deliver(item, fallback); err != nil {
 				log.Printf("listener agent delivery failed: %v", err)
+				_ = msg.NakWithDelay(30 * time.Second)
+				return
 			}
 			_ = msg.Ack()
 			return
 		}
 		items := registry.Match(cfg.MachineID, item.Topic)
+		if len(items) == 0 {
+			log.Printf("listener no matching interests for topic=%s", item.Topic)
+			_ = msg.Ack()
+			return
+		}
+		var failed bool
 		for _, interest := range items {
 			if err := deliver.Deliver(item, interest); err != nil {
 				log.Printf("listener delivery failed session=%s: %v", interest.SessionID, err)
+				failed = true
 			}
 		}
-		_ = msg.Ack()
+		if failed {
+			_ = msg.NakWithDelay(30 * time.Second)
+		} else {
+			_ = msg.Ack()
+		}
 	}, nats.Durable(consumer), nats.DeliverNew(), nats.AckExplicit(), nats.ManualAck(), nats.AckWait(60*time.Second), nats.MaxAckPending(256))
 	if err != nil {
 		log.Fatal(err)
@@ -162,6 +172,7 @@ func main() {
 			return
 		}
 		var body struct {
+			SourceSession string `json:"source_session"`
 			TargetSession string `json:"target_session"`
 			Message       string `json:"message"`
 		}
@@ -172,9 +183,50 @@ func main() {
 		item := contracts.Envelope{
 			EventID:        id.New(),
 			Source:         "agent",
+			SourceSession:  body.SourceSession,
 			SourceEventID:  id.New(),
 			Topic:          contracts.AgentSubject(body.TargetSession),
 			DedupeKey:      "agent." + body.TargetSession + "." + id.New(),
+			IssuedAt:       contracts.NowMillis(),
+			PayloadSummary: body.Message,
+			TraceID:        id.New(),
+		}
+		if err := item.Validate(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := client.Publish(item); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(item)
+	})
+	mux.HandleFunc("/v1/messages/publish", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var body struct {
+			SourceSession string `json:"source_session"`
+			Topic         string `json:"topic"`
+			Message       string `json:"message"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		if body.Topic == "" || body.Message == "" {
+			http.Error(w, "topic and message are required", http.StatusBadRequest)
+			return
+		}
+		item := contracts.Envelope{
+			EventID:        id.New(),
+			Source:         "agent",
+			SourceSession:  body.SourceSession,
+			SourceEventID:  id.New(),
+			Topic:          body.Topic,
+			DedupeKey:      "publish." + id.New(),
 			IssuedAt:       contracts.NowMillis(),
 			PayloadSummary: body.Message,
 			TraceID:        id.New(),

--- a/packages/envoy/deploy/compose/listener.compose.yml
+++ b/packages/envoy/deploy/compose/listener.compose.yml
@@ -12,16 +12,10 @@ services:
       retries: 3
       start_period: 5s
     environment:
-      HOME: ${ENVOY_HOME}
       PORT: ${ENVOY_LISTENER_PORT:-9020}
       ENVOY_MACHINE_ID: ${ENVOY_MACHINE_ID}
       NATS_URLS: ${NATS_URLS}
       ENVOY_REGISTRY_DIR: ${ENVOY_REGISTRY_DIR}
       ENVOY_HOST_BRIDGE: 127.0.0.1
-      ENVOY_OPENCODE_BIN: ${ENVOY_OPENCODE_BIN}
-      ENVOY_XDG_CONFIG_HOME: ${ENVOY_HOME}/.config
-      ENVOY_XDG_DATA_HOME: ${ENVOY_HOME}/.local/share
-      ENVOY_XDG_CACHE_HOME: ${ENVOY_HOME}/.cache
     volumes:
       - ${ENVOY_REGISTRY_DIR}:${ENVOY_REGISTRY_DIR}:ro
-      - ${ENVOY_HOME}:${ENVOY_HOME}

--- a/packages/envoy/docker/github.Dockerfile
+++ b/packages/envoy/docker/github.Dockerfile
@@ -12,9 +12,12 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build -o /out/envoy-gith
 
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/* \
+    && groupadd -r envoy && useradd -r -g envoy envoy
 
 COPY --from=build /out/envoy-github /usr/local/bin/envoy-github
+
+USER envoy
 
 EXPOSE 9010
 

--- a/packages/envoy/docker/listener.Dockerfile
+++ b/packages/envoy/docker/listener.Dockerfile
@@ -12,9 +12,12 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build -o /out/envoy-list
 
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/* \
+    && groupadd -r envoy && useradd -r -g envoy envoy
 
 COPY --from=build /out/envoy-listener /usr/local/bin/envoy-listener
+
+USER envoy
 
 EXPOSE 9020
 

--- a/packages/envoy/docker/slack.Dockerfile
+++ b/packages/envoy/docker/slack.Dockerfile
@@ -12,9 +12,12 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build -o /out/envoy-slac
 
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/* \
+    && groupadd -r envoy && useradd -r -g envoy envoy
 
 COPY --from=build /out/envoy-slack /usr/local/bin/envoy-slack
+
+USER envoy
 
 EXPOSE 9011
 

--- a/packages/envoy/internal/bus/nats.go
+++ b/packages/envoy/internal/bus/nats.go
@@ -27,9 +27,16 @@ type Client struct {
 	js   nats.JetStreamContext
 	urls []string
 	mu   sync.Mutex
+
+	// subscriber state for auto-resubscribe
+	subMu       sync.Mutex
+	subSubject  string
+	subHandler  nats.MsgHandler
+	subOpts     []nats.SubOpt
+	subActive   *nats.Subscription
 }
 
-func options(urls []string) nats.Options {
+func options(urls []string, reconnectCB func(*nats.Conn)) nats.Options {
 	return nats.Options{
 		Servers:       urls,
 		Name:          "envoy",
@@ -44,6 +51,9 @@ func options(urls []string) nats.Options {
 		},
 		ReconnectedCB: func(nc *nats.Conn) {
 			log.Printf("envoy nats reconnected: %s", nc.ConnectedUrl())
+			if reconnectCB != nil {
+				reconnectCB(nc)
+			}
 		},
 		ClosedCB: func(_ *nats.Conn) {
 			log.Printf("envoy nats connection closed")
@@ -58,11 +68,11 @@ func options(urls []string) nats.Options {
 	}
 }
 
-func connect(urls []string) (*nats.Conn, error) {
+func connect(urls []string, reconnectCB func(*nats.Conn)) (*nats.Conn, error) {
 	var nc *nats.Conn
 	var err error
 	for range 10 {
-		next := options(urls)
+		next := options(urls, reconnectCB)
 		nc, err = next.Connect()
 		if err == nil {
 			return nc, nil
@@ -72,21 +82,24 @@ func connect(urls []string) (*nats.Conn, error) {
 	return nil, err
 }
 
-func Connect(urls []string) (Client, error) {
-	nc, err := connect(urls)
+func Connect(urls []string) (*Client, error) {
+	c := &Client{urls: urls}
+	nc, err := connect(urls, c.onReconnect)
 	if err != nil {
-		return Client{}, err
+		return nil, err
 	}
 	js, err := nc.JetStream()
 	if err != nil {
 		nc.Close()
-		return Client{}, err
+		return nil, err
 	}
 	if err := ensureStream(js); err != nil {
 		nc.Close()
-		return Client{}, err
+		return nil, err
 	}
-	return Client{Conn: nc, js: js, urls: urls}, nil
+	c.Conn = nc
+	c.js = js
+	return c, nil
 }
 
 func ensureStream(js nats.JetStreamContext) error {
@@ -106,13 +119,56 @@ func (c *Client) JS() nats.JetStreamContext {
 	return c.js
 }
 
+func (c *Client) onReconnect(nc *nats.Conn) {
+	c.mu.Lock()
+	c.Conn = nc
+	js, err := nc.JetStream()
+	if err != nil {
+		c.mu.Unlock()
+		log.Printf("envoy nats resubscribe failed (jetstream): %v", err)
+		return
+	}
+	c.js = js
+	c.mu.Unlock()
+
+	c.subMu.Lock()
+	defer c.subMu.Unlock()
+	if c.subSubject == "" || c.subHandler == nil {
+		return
+	}
+	log.Printf("envoy nats resubscribing to %s", c.subSubject)
+	sub, err := c.js.Subscribe(c.subSubject, c.subHandler, c.subOpts...)
+	if err != nil {
+		log.Printf("envoy nats resubscribe failed: %v", err)
+		return
+	}
+	c.subActive = sub
+	log.Printf("envoy nats resubscribed to %s", c.subSubject)
+}
+
+// Subscribe creates a JetStream subscription that auto-resubscribes on reconnect.
+// Only one subscription per client is supported (the listener's main consumer).
+func (c *Client) Subscribe(subject string, handler nats.MsgHandler, opts ...nats.SubOpt) (*nats.Subscription, error) {
+	c.subMu.Lock()
+	defer c.subMu.Unlock()
+	sub, err := c.js.Subscribe(subject, handler, opts...)
+	if err != nil {
+		return nil, err
+	}
+	c.subSubject = subject
+	c.subHandler = handler
+	c.subOpts = opts
+	c.subActive = sub
+	return sub, nil
+}
+
 func (c *Client) ensureConn() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.Conn != nil && c.Conn.Status() != nats.CLOSED {
 		return nil
 	}
-	nc, err := connect(c.urls)
+	nc, err := connect(c.urls, c.onReconnect)
 	if err != nil {
 		return err
 	}

--- a/packages/envoy/internal/contracts/generated.go
+++ b/packages/envoy/internal/contracts/generated.go
@@ -9,8 +9,8 @@ import (
 type Envelope struct {
 	EventID        string `json:"event_id"`
 	Source         string `json:"source"`
-	SourceSession  string `json:"source_session,omitempty"`
 	SourceEventID  string `json:"source_event_id"`
+	SourceSession  string `json:"source_session,omitempty"`
 	Topic          string `json:"topic"`
 	DedupeKey      string `json:"dedupe_key"`
 	IssuedAt       int64  `json:"issued_at"`

--- a/packages/envoy/internal/contracts/generated.go
+++ b/packages/envoy/internal/contracts/generated.go
@@ -9,6 +9,7 @@ import (
 type Envelope struct {
 	EventID        string `json:"event_id"`
 	Source         string `json:"source"`
+	SourceSession  string `json:"source_session,omitempty"`
 	SourceEventID  string `json:"source_event_id"`
 	Topic          string `json:"topic"`
 	DedupeKey      string `json:"dedupe_key"`

--- a/packages/envoy/internal/contracts/normalize.go
+++ b/packages/envoy/internal/contracts/normalize.go
@@ -1,6 +1,7 @@
 package contracts
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -331,11 +332,20 @@ func slackKind(body map[string]any) string {
 
 func slackSummary(body map[string]any) string {
 	event, _ := body["event"].(map[string]any)
-	text := stringValue(event["text"])
-	if len(text) > 160 {
-		text = text[:160]
+	data := map[string]string{
+		"kind":    slackKind(body),
+		"user":    stringValue(event["user"]),
+		"channel": stringValue(event["channel"]),
+		"text":    stringValue(event["text"]),
 	}
-	return strings.TrimSpace(fmt.Sprintf("Slack %s from %s in %s: %s", slackKind(body), stringValue(event["user"]), stringValue(event["channel"]), text))
+	if ts := stringValue(event["ts"]); ts != "" {
+		data["ts"] = ts
+	}
+	if thread := stringValue(event["thread_ts"]); thread != "" {
+		data["thread_ts"] = thread
+	}
+	out, _ := json.Marshal(data)
+	return string(out)
 }
 
 func nested(body map[string]any, keys ...string) any {

--- a/packages/envoy/internal/session/session.go
+++ b/packages/envoy/internal/session/session.go
@@ -7,9 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/sjawhar/envoy/internal/contracts"
@@ -29,10 +27,6 @@ type RegistryEntry struct {
 type Deliverer struct {
 	RegistryDir  string
 	HostBridge   string
-	OpencodeBin  string
-	XDGConfig    string
-	XDGData      string
-	XDGCache     string
 	RequestLimit time.Duration
 }
 
@@ -40,11 +34,9 @@ func (d Deliverer) Deliver(item contracts.Envelope, interest store.Interest) err
 	entry, _ := d.Find(interest.SessionID)
 	text := d.Text(item)
 	if entry != nil && entry.Port > 0 {
-		if err := d.prompt(entry.Port, interest.SessionID, text); err == nil {
-			return nil
-		}
+		return d.prompt(entry.Port, interest.SessionID, text)
 	}
-	return d.resume(interest.SessionID, interest.Dir, text)
+	return fmt.Errorf("no live serve port for session %s", interest.SessionID)
 }
 
 func (d Deliverer) Find(sessionID string) (*RegistryEntry, error) {
@@ -69,19 +61,19 @@ func (d Deliverer) Find(sessionID string) (*RegistryEntry, error) {
 }
 
 func (d Deliverer) Text(item contracts.Envelope) string {
-	return fmt.Sprintf("[NOTIFICATION from %s]\n%s\n\nTopic: %s\nEvent ID: %s", item.Source, item.PayloadSummary, item.Topic, item.EventID)
+	header := fmt.Sprintf("[NOTIFICATION from %s]", item.Source)
+	if item.SourceSession != "" {
+		header = fmt.Sprintf("[NOTIFICATION from %s (reply-to: %s)]", item.Source, item.SourceSession)
+	}
+	return fmt.Sprintf("%s\n%s\n\nTopic: %s\nEvent ID: %s", header, item.PayloadSummary, item.Topic, item.EventID)
 }
 
 func (d Deliverer) prompt(port int, sessionID string, text string) error {
 	type promptBody struct {
 		Parts []map[string]string `json:"parts"`
-		Agent string              `json:"agent,omitempty"`
 	}
 	bodyData := promptBody{
 		Parts: []map[string]string{{"type": "text", "text": text}},
-	}
-	if agent, err := d.lastAgent(port, sessionID); err == nil && agent != "" {
-		bodyData.Agent = agent
 	}
 	body, err := json.Marshal(bodyData)
 	if err != nil {
@@ -105,53 +97,8 @@ func (d Deliverer) prompt(port int, sessionID string, text string) error {
 	return nil
 }
 
-func (d Deliverer) lastAgent(port int, sessionID string) (string, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%d/session/%s/message?limit=20", d.host(), port, sessionID), nil)
-	if err != nil {
-		return "", err
-	}
-	client := http.Client{Timeout: d.timeout()}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		io.Copy(io.Discard, resp.Body)
-		return "", fmt.Errorf("message list returned %d", resp.StatusCode)
-	}
-	var items []struct {
-		Info struct {
-			Role  string `json:"role"`
-			Agent string `json:"agent"`
-		} `json:"info"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
-		return "", err
-	}
-	var result string
-	for _, item := range items {
-		if item.Info.Role != "user" || item.Info.Agent == "" {
-			continue
-		}
-		result = item.Info.Agent
-	}
-	return result, nil
-}
-
-func (d Deliverer) resume(sessionID string, dir string, text string) error {
-	cmd := exec.Command(d.OpencodeBin, "run", "--session", sessionID, "--dir", dir, text)
-	cmd.Env = append(os.Environ(),
-		"XDG_CONFIG_HOME="+d.XDGConfig,
-		"XDG_DATA_HOME="+d.XDGData,
-		"XDG_CACHE_HOME="+d.XDGCache,
-	)
-	buf, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("cold resume failed: %w: %s", err, strings.TrimSpace(string(buf)))
-	}
-	return nil
-}
+// resume was removed — cold-starting host processes from inside a container
+// runs as root and is a security risk. Messages stay in JetStream for retry.
 
 func (d Deliverer) host() string {
 	if d.HostBridge != "" {


### PR DESCRIPTION
Closes #179, closes #184

## Summary

- Workers broadcast completion notifications to `notifications.legion.controller` via `envoy_publish`
- New `envoy_publish(topic, message)` tool for broadcasting to any topic
- New `/v1/messages/publish` listener endpoint for arbitrary topic publishing
- Controller subscribes to `notifications.legion.controller` at startup
- Daemon propagates `LEGION_CONTROLLER_SESSION_ID` in shared serve env (kept for edge cases)

## Design

- **Named topic, not session-targeted**: Workers publish to `notifications.legion.controller` instead of needing the controller's session ID. The controller subscribes to this topic at startup.
- **Best-effort, non-blocking**: If `envoy_publish` fails, the worker continues normally. The `worker-done` label remains the source of truth.
- **Speed optimization**: Envoy wakes the controller immediately. The label-based state machine still drives all transitions.
- **Generic tool**: `envoy_publish` works for any topic — team channels, custom routing, not just controller notifications.

## Changes

- `packages/envoy/cmd/listener/main.go` — new `/v1/messages/publish` endpoint
- `packages/envoy-plugin/src/index.ts` — new `envoy_publish` tool
- `packages/daemon/src/daemon/index.ts` — propagate `LEGION_CONTROLLER_SESSION_ID` in serve env
- `.opencode/skills/legion-controller/SKILL.md` — subscribe to controller topic at startup
- `.opencode/skills/legion-worker/SKILL.md` — use `envoy_publish` in completion checklist
- `.opencode/skills/legion-worker/workflows/*.md` — all 5 workflows use `envoy_publish`
- `.opencode/skills/legion-retro/SKILL.md` — retro uses `envoy_publish`
- `.opencode/skills/envoy/SKILL.md` — document `envoy_publish` tool