### PR TITLE
sjawhar-legion-169: fix workspace creation to target main and auto-create .opencode symlink

### DIFF
--- a/packages/daemon/src/daemon/__tests__/repo-manager.test.ts
+++ b/packages/daemon/src/daemon/__tests__/repo-manager.test.ts
@@ -46,6 +46,7 @@ describe("ensureRepoClone", () => {
       },
       exists: async () => false,
       rmDir: async () => {},
+      symlink: async () => {},
     };
 
     const paths = resolveLegionPaths({}, "/home/test");
@@ -65,6 +66,7 @@ describe("ensureRepoClone", () => {
       },
       exists: async () => true,
       rmDir: async () => {},
+      symlink: async () => {},
     };
     const paths = resolveLegionPaths({}, "/home/test");
     await ensureRepoClone(paths, { host: "github.com", owner: "acme", repo: "widgets" }, deps);
@@ -83,6 +85,7 @@ describe("ensureRepoClone", () => {
         },
         exists: async () => true,
         rmDir: async () => {},
+        symlink: async () => {},
       };
       const paths = resolveLegionPaths({}, "/home/test");
 
@@ -107,6 +110,7 @@ describe("ensureRepoClone", () => {
         },
         exists: async () => false,
         rmDir: async () => {},
+        symlink: async () => {},
       };
       const paths = resolveLegionPaths({}, "/home/test");
 
@@ -138,6 +142,7 @@ describe("ensureRepoClone", () => {
         }),
         exists: async () => true,
         rmDir: async () => {},
+        symlink: async () => {},
       };
       const paths = resolveLegionPaths({}, "/home/test");
 
@@ -151,6 +156,7 @@ describe("ensureRepoClone", () => {
         runJj: async () => ({ exitCode: 128, stdout: "", stderr: "Permission denied (publickey)" }),
         exists: async () => true,
         rmDir: async () => {},
+        symlink: async () => {},
       };
       const paths = resolveLegionPaths({}, "/home/test");
 
@@ -171,6 +177,7 @@ describe("ensureWorkspace", () => {
       },
       exists: async (p) => p.includes("repos/"),
       rmDir: async () => {},
+      symlink: async () => {},
     };
     const paths = resolveLegionPaths({}, "/home/test");
     const repo = { host: "github.com", owner: "acme", repo: "widgets" };
@@ -180,6 +187,8 @@ describe("ensureWorkspace", () => {
     const wsCmd = commands.find((c) => c.includes("workspace"));
     expect(wsCmd).toBeDefined();
     expect(wsCmd).toContain("add");
+    expect(wsCmd).toContain("--revision");
+    expect(wsCmd).toContain("main");
   });
 
   it("skips workspace creation when it already exists", async () => {
@@ -191,6 +200,7 @@ describe("ensureWorkspace", () => {
       },
       exists: async () => true,
       rmDir: async () => {},
+      symlink: async () => {},
     };
     const paths = resolveLegionPaths({}, "/home/test");
     const repo = { host: "github.com", owner: "acme", repo: "widgets" };
@@ -198,6 +208,93 @@ describe("ensureWorkspace", () => {
 
     const wsCmd = commands.find((c) => c.includes("workspace"));
     expect(wsCmd).toBeUndefined();
+  });
+
+  it("creates .opencode symlink when .claude exists", async () => {
+    const symlinkCalls: { target: string; linkPath: string }[] = [];
+    const deps: RepoManagerDeps = {
+      runJj: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+      exists: async (p) => {
+        if (p.includes("repos/")) return true;
+        if (p.endsWith(".claude")) return true;
+        if (p.endsWith(".opencode")) return false;
+        return false;
+      },
+      rmDir: async () => {},
+      symlink: async (target, linkPath) => {
+        symlinkCalls.push({ target, linkPath });
+      },
+    };
+    const paths = resolveLegionPaths({}, "/home/test");
+    const repo = { host: "github.com", owner: "acme", repo: "widgets" };
+    await ensureWorkspace(paths, "sjawhar/42", "acme-widgets-7", repo, deps);
+
+    expect(symlinkCalls).toHaveLength(1);
+    expect(symlinkCalls[0].target).toBe(".claude");
+    expect(symlinkCalls[0].linkPath).toEndWith(".opencode");
+  });
+
+  it("skips .opencode symlink when .claude does not exist", async () => {
+    const symlinkCalls: { target: string; linkPath: string }[] = [];
+    const deps: RepoManagerDeps = {
+      runJj: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+      exists: async (p) => {
+        if (p.includes("repos/")) return true;
+        return false;
+      },
+      rmDir: async () => {},
+      symlink: async (target, linkPath) => {
+        symlinkCalls.push({ target, linkPath });
+      },
+    };
+    const paths = resolveLegionPaths({}, "/home/test");
+    const repo = { host: "github.com", owner: "acme", repo: "widgets" };
+    await ensureWorkspace(paths, "sjawhar/42", "acme-widgets-7", repo, deps);
+
+    expect(symlinkCalls).toHaveLength(0);
+  });
+
+  it("skips .opencode symlink when .opencode already exists", async () => {
+    const symlinkCalls: { target: string; linkPath: string }[] = [];
+    const deps: RepoManagerDeps = {
+      runJj: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+      exists: async (p) => {
+        if (p.includes("repos/")) return true;
+        if (p.endsWith(".claude")) return true;
+        if (p.endsWith(".opencode")) return true;
+        return false;
+      },
+      rmDir: async () => {},
+      symlink: async (target, linkPath) => {
+        symlinkCalls.push({ target, linkPath });
+      },
+    };
+    const paths = resolveLegionPaths({}, "/home/test");
+    const repo = { host: "github.com", owner: "acme", repo: "widgets" };
+    await ensureWorkspace(paths, "sjawhar/42", "acme-widgets-7", repo, deps);
+
+    expect(symlinkCalls).toHaveLength(0);
+  });
+
+  it("does not fail when symlink creation throws", async () => {
+    const deps: RepoManagerDeps = {
+      runJj: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+      exists: async (p) => {
+        if (p.includes("repos/")) return true;
+        if (p.endsWith(".claude")) return true;
+        if (p.endsWith(".opencode")) return false;
+        return false;
+      },
+      rmDir: async () => {},
+      symlink: async () => {
+        throw new Error("EACCES: permission denied");
+      },
+    };
+    const paths = resolveLegionPaths({}, "/home/test");
+    const repo = { host: "github.com", owner: "acme", repo: "widgets" };
+    // Should not throw despite symlink failure
+    const wsPath = await ensureWorkspace(paths, "sjawhar/42", "acme-widgets-7", repo, deps);
+    expect(wsPath).toBe("/home/test/.local/share/legion/workspaces/sjawhar/42/acme-widgets-7");
   });
 });
 
@@ -214,8 +311,8 @@ describe("cleanupWorkspace", () => {
       rmDir: async (p) => {
         removedPaths.push(p);
       },
+      symlink: async () => {},
     };
-
     const paths = resolveLegionPaths({}, "/home/test");
     const repo = { host: "github.com", owner: "acme", repo: "widgets" };
     await cleanupWorkspace(paths, "sjawhar/42", "acme-widgets-7", repo, deps);

--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -232,6 +232,7 @@ describe("daemon server", () => {
       },
       exists: async () => false,
       rmDir: async () => {},
+      symlink: async () => {},
     };
     await startTestServer({ paths, repoManagerDeps });
 
@@ -262,6 +263,8 @@ describe("daemon server", () => {
         "/tmp/legion-data/workspaces/123e4567-e89b-12d3-a456-426614174000/acme-widgets-77",
         "--name",
         "acme-widgets-77",
+        "--revision",
+        "main",
         "-R",
         "/tmp/legion-data/repos/github.com/acme/widgets",
       ],
@@ -305,6 +308,7 @@ describe("daemon server", () => {
         runJj: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
         exists: async () => false,
         rmDir: async () => {},
+        symlink: async () => {},
       };
       await startTestServer({ paths, repoManagerDeps });
 
@@ -374,6 +378,7 @@ describe("daemon server", () => {
       runJj: async () => ({ exitCode: 128, stdout: "", stderr: "Permission denied (publickey)" }),
       exists: async () => true,
       rmDir: async () => {},
+      symlink: async () => {},
     };
     await startTestServer({ paths, repoManagerDeps });
 
@@ -605,6 +610,7 @@ describe("daemon server", () => {
       rmDir: async (workspacePath: string) => {
         rmDirCalls.push(workspacePath);
       },
+      symlink: async () => {},
     };
     await startTestServer({ paths, repoManagerDeps });
 

--- a/packages/daemon/src/daemon/repo-manager.ts
+++ b/packages/daemon/src/daemon/repo-manager.ts
@@ -17,6 +17,7 @@ export interface RepoManagerDeps {
   runJj: (args: string[]) => Promise<JjResult>;
   exists: (path: string) => Promise<boolean>;
   rmDir: (path: string) => Promise<void>;
+  symlink: (target: string, linkPath: string) => Promise<void>;
 }
 
 const defaultDeps: RepoManagerDeps = {
@@ -38,6 +39,10 @@ const defaultDeps: RepoManagerDeps = {
   rmDir: async (p) => {
     const { rm } = await import("node:fs/promises");
     await rm(p, { recursive: true, force: true });
+  },
+  symlink: async (target, linkPath) => {
+    const { symlink } = await import("node:fs/promises");
+    await symlink(target, linkPath);
   },
 };
 
@@ -113,11 +118,24 @@ export async function ensureWorkspace(
       workspacePath,
       "--name",
       issueId.toLowerCase(),
+      "--revision",
+      "main",
       "-R",
       clonePath,
     ]);
     if (result.exitCode !== 0) {
       throw new Error(`Failed to create workspace ${workspacePath}: ${result.stderr}`);
+    }
+  }
+
+  // Create .opencode symlink if .claude exists and .opencode doesn't
+  const claudeDir = path.join(workspacePath, ".claude");
+  const opencodePath = path.join(workspacePath, ".opencode");
+  if ((await deps.exists(claudeDir)) && !(await deps.exists(opencodePath))) {
+    try {
+      await deps.symlink(".claude", opencodePath);
+    } catch {
+      // Non-fatal: symlink creation failure shouldn't block workspace setup
     }
   }
 


### PR DESCRIPTION
Closes #169

## Summary

Fixes two bugs in `ensureWorkspace` (repo-manager.ts):

1. **Workspace created on root commit instead of main** — `jj workspace add` was called without `--revision main`, causing new workspaces to land on the root commit (`zzzzzzzz` parent). Workers in these workspaces see an empty repo with no files and produce zero output.

2. **Missing `.opencode` symlink** — When a repo contains a `.claude` directory, the `.opencode` symlink wasn't being created automatically. Workers using OpenCode couldn't find skills/config without manual intervention.

### Changes

- Added `--revision main` to the `jj workspace add` command in `ensureWorkspace`
- Added `symlink` to `RepoManagerDeps` interface for testability
- After workspace creation, automatically creates `.opencode → .claude` symlink if `.claude` exists and `.opencode` doesn't
- Symlink creation is non-fatal — failures are silently caught to avoid blocking workspace setup
- Updated all existing test mocks to include the new `symlink` dep
- Added 4 new tests: revision flag presence, symlink creation, symlink skip conditions, error resilience