### PR TITLE
sjawhar-legion-191: add CI status gates at In Progress and Testing transitions

### DIFF
--- a/.opencode/skills/legion-controller/SKILL.md
+++ b/.opencode/skills/legion-controller/SKILL.md
@@ -281,31 +281,30 @@ The controller MUST NOT:
 
 The controller dispatches workers. Workers do the work. If you are about to touch code, branches, or PRs directly — stop and dispatch the appropriate worker instead.
 
-### Quality Gate (Controller Policy)
+### CI Gates (Enforced by Decision Engine)
 
-Before dispatching a tester, the controller independently verifies code quality. This is a controller-level policy, not signaled by the state machine.
+CI status is now checked by the decision engine at all code-producing phase transitions:
+- **In Progress → Testing** (implementer done)
+- **Testing → Needs Review** (tester done)
+- **Needs Review → Retro** (reviewer done)
 
-**When to run:** Whenever about to execute a `dispatch_tester` action.
+The decision engine emits `resume_implementer_for_ci_failure`, `retry_ci_check`, or
+`investigate_no_pr` when appropriate. The controller does NOT need to independently
+verify CI before dispatching — the state machine handles it.
 
-**Before dispatching tester, verify CI is passing:**
-```bash
-gh pr checks "$LEGION_ISSUE_ID"
-```
+**Controller remediation for CI-related actions:**
 
-If any checks are failing, do NOT dispatch the tester. Instead:
-1. Move issue back to In Progress
-2. Re-dispatch an implementer with the CI failure output:
-```bash
-legion dispatch "$ISSUE_IDENTIFIER" implement \
-  --repo "$OWNER/$REPO" \
-  --prompt "Invoke the /legion-worker skill for implement mode. CI is failing: [paste failure summary]. Fix and push. ($BACKEND_SUFFIX)"
-```
+| Action | From Status | Controller Response |
+|--------|-------------|---------------------|
+| `resume_implementer_for_ci_failure` | In Progress | Remove `worker-done` label, resume implementer with CI failure output. Status stays In Progress. |
+| `resume_implementer_for_ci_failure` | Testing | Remove `worker-done` and `test-passed` labels, move issue back to In Progress, resume implementer with CI failure output. |
+| `resume_implementer_for_ci_failure` | Needs Review | Same as existing behavior — resume implementer with CI failure output. |
+| `retry_ci_check` | In Progress / Testing | Wait and re-check (same as existing Needs Review behavior). |
+| `investigate_no_pr` | In Progress / Testing | Same handling as Needs Review — investigate missing PR. |
 
 **CI is the implementer's responsibility.** The implement workflow requires passing CI before
-signaling completion. If CI is failing when the controller sees a PR, the implementer didn't
-finish — re-dispatch an implementer with the CI failure output. The tester should also check
-CI status and include it in the review.
-
+signaling completion. If CI is failing when the decision engine evaluates an issue, the
+implementer didn't finish — the engine emits the appropriate resume action.
 
 ### Pre-Merge Gate
 

--- a/packages/daemon/src/state/AGENTS.md
+++ b/packages/daemon/src/state/AGENTS.md
@@ -28,9 +28,15 @@ The core of the controller's decision-making. Key transitions:
 |--------|-------------|-------------|----------|-----------|----------|
 | Backlog | yes | — | — | — | `transition_to_todo` |
 | Todo | no | no | — | — | `dispatch_planner` |
-| In Progress | yes | — | — | — | `transition_to_testing` |
+| In Progress | yes | — | no PR | — | `investigate_no_pr` |
+| In Progress | yes | — | has PR | failing | `resume_implementer_for_ci_failure` |
+| In Progress | yes | — | has PR | pending | `retry_ci_check` |
+| In Progress | yes | — | has PR | passing/null | `transition_to_testing` |
 | Testing | no | no | — | — | `dispatch_tester` |
-| Testing | yes | — | — | test-passed | `transition_to_needs_review` |
+| Testing | yes | — | has PR | test-passed + passing/null | `transition_to_needs_review` |
+| Testing | yes | — | no PR | test-passed | `investigate_no_pr` |
+| Testing | yes | — | has PR | test-passed + failing | `resume_implementer_for_ci_failure` |
+| Testing | yes | — | has PR | test-passed + pending | `retry_ci_check` |
 | Testing | yes | — | — | !test-passed | `resume_implementer_for_test_failure` |
 | Needs Review | yes | — | ready | passing/null | `transition_to_retro` |
 | Needs Review | yes | — | ready | failing | `resume_implementer_for_ci_failure` |
@@ -51,6 +57,7 @@ The core of the controller's decision-making. Key transitions:
 - In Progress no longer returns `skip` when `hasPr && !hasLiveWorker` — this caused a deadlock when workers died after creating a PR.
 - `skip` action uses the actual `workerMode` from the daemon (when available) for sessionId computation, instead of defaulting to `implement`.
 - `transition_to_done` action exists for explicit Done transitions (mapped to `merge` mode).
+- `needsCiStatus` now returns `true` for In Progress, Testing, and Needs Review (all require PR). CI gates are enforced at all code-producing transitions.
 
 ## Anti-Patterns
 

--- a/packages/daemon/src/state/__tests__/decision.test.ts
+++ b/packages/daemon/src/state/__tests__/decision.test.ts
@@ -32,14 +32,59 @@ describe("suggestAction", () => {
     expect(action).toBe("dispatch_implementer");
   });
 
-  it("in_progress_worker_done transitions to testing", () => {
-    const action = suggestAction(IssueStatus.IN_PROGRESS, true, false, null, false, false);
+  it("in_progress_worker_done_ci_null_transitions_to_testing", () => {
+    const action = suggestAction(IssueStatus.IN_PROGRESS, true, false, null, true, false);
     expect(action).toBe("transition_to_testing");
   });
 
   it("in_progress_with_live_worker skips", () => {
     const action = suggestAction(IssueStatus.IN_PROGRESS, false, true, null, false, false);
     expect(action).toBe("skip");
+  });
+
+  // In Progress + CI gate tests
+  it("in_progress_worker_done_no_pr_investigates", () => {
+    const action = suggestAction(IssueStatus.IN_PROGRESS, true, false, null, false, false);
+    expect(action).toBe("investigate_no_pr");
+  });
+
+  it("in_progress_worker_done_ci_failing_resumes_implementer", () => {
+    const action = suggestAction(
+      IssueStatus.IN_PROGRESS,
+      true,
+      false,
+      null,
+      true,
+      false,
+      "failing"
+    );
+    expect(action).toBe("resume_implementer_for_ci_failure");
+  });
+
+  it("in_progress_worker_done_ci_pending_retries", () => {
+    const action = suggestAction(
+      IssueStatus.IN_PROGRESS,
+      true,
+      false,
+      null,
+      true,
+      false,
+      "pending"
+    );
+    expect(action).toBe("retry_ci_check");
+  });
+
+  it("in_progress_worker_done_ci_passing_transitions_to_testing", () => {
+    const action = suggestAction(
+      IssueStatus.IN_PROGRESS,
+      true,
+      false,
+      null,
+      true,
+      false,
+      "passing"
+    );
+    expect(action).toBe("transition_to_testing");
   });
 
   it("needs_review_approved transitions to retro", () => {
@@ -156,6 +201,32 @@ describe("suggestAction", () => {
   it("testing_with_live_worker_skips", () => {
     const action = suggestAction(IssueStatus.TESTING, false, true, null, false, false);
     expect(action).toBe("skip");
+  });
+
+  // Testing + CI gate tests
+  it("testing_worker_done_test_passed_no_pr_investigates", () => {
+    const action = suggestAction(IssueStatus.TESTING, true, false, null, false, true);
+    expect(action).toBe("investigate_no_pr");
+  });
+
+  it("testing_worker_done_test_passed_ci_failing_resumes_implementer", () => {
+    const action = suggestAction(IssueStatus.TESTING, true, false, null, true, true, "failing");
+    expect(action).toBe("resume_implementer_for_ci_failure");
+  });
+
+  it("testing_worker_done_test_passed_ci_pending_retries", () => {
+    const action = suggestAction(IssueStatus.TESTING, true, false, null, true, true, "pending");
+    expect(action).toBe("retry_ci_check");
+  });
+
+  it("testing_worker_done_test_passed_ci_passing_transitions_to_needs_review", () => {
+    const action = suggestAction(IssueStatus.TESTING, true, false, null, true, true, "passing");
+    expect(action).toBe("transition_to_needs_review");
+  });
+
+  it("testing_worker_done_test_passed_ci_null_transitions_to_needs_review", () => {
+    const action = suggestAction(IssueStatus.TESTING, true, false, null, true, true, null);
+    expect(action).toBe("transition_to_needs_review");
   });
 
   it("unknown_status_skips", () => {
@@ -482,7 +553,7 @@ describe("buildIssueState", () => {
       issueId: "ENG-21",
       status: "In Progress",
       labels: ["user-feedback-given", "worker-done"],
-      hasPr: false,
+      hasPr: true,
       prIsDraft: null,
       ciStatus: null,
       mergeableStatus: null,
@@ -846,7 +917,7 @@ describe("buildCollectedState", () => {
         issueId: "ENG-22",
         status: "In Progress",
         labels: ["worker-done"],
-        hasPr: false,
+        hasPr: true,
         prIsDraft: null,
         ciStatus: null,
         mergeableStatus: null,

--- a/packages/daemon/src/state/__tests__/types.test.ts
+++ b/packages/daemon/src/state/__tests__/types.test.ts
@@ -297,8 +297,8 @@ describe("ParsedIssue properties", () => {
     expect(issue.needsPrStatus).toBe(true);
   });
 
-  it("needs_pr_status returns false when status not Needs Review", () => {
-    const issue = createParsedIssue("ENG-21", "In Progress", ["worker-done"], {
+  it("needs_pr_status returns false when status not Needs Review or In Progress", () => {
+    const issue = createParsedIssue("ENG-21", "Testing", ["worker-done"], {
       owner: "owner",
       repo: "repo",
       number: 123,
@@ -318,6 +318,39 @@ describe("ParsedIssue properties", () => {
   it("needs_pr_status returns false when no pr_ref", () => {
     const issue = createParsedIssue("ENG-21", "Needs Review", ["worker-done"], null);
     expect(issue.needsPrStatus).toBe(false);
+  });
+
+  it("needs_pr_status returns true for In Progress with worker-done and PR", () => {
+    const issue = createParsedIssue("ENG-21", "In Progress", ["worker-done"], {
+      owner: "owner",
+      repo: "repo",
+      number: 123,
+    });
+    expect(issue.needsPrStatus).toBe(true);
+  });
+
+  // needsCiStatus enrichment tests
+  it("needsCiStatus returns true for In Progress with PR", () => {
+    const issue = createParsedIssue("ENG-21", "In Progress", [], {
+      owner: "owner",
+      repo: "repo",
+      number: 123,
+    });
+    expect(issue.needsCiStatus).toBe(true);
+  });
+
+  it("needsCiStatus returns true for Testing with PR", () => {
+    const issue = createParsedIssue("ENG-21", "Testing", [], {
+      owner: "owner",
+      repo: "repo",
+      number: 123,
+    });
+    expect(issue.needsCiStatus).toBe(true);
+  });
+
+  it("needsCiStatus returns false for In Progress without PR", () => {
+    const issue = createParsedIssue("ENG-21", "In Progress", [], null);
+    expect(issue.needsCiStatus).toBe(false);
   });
 });
 

--- a/packages/daemon/src/state/decision.ts
+++ b/packages/daemon/src/state/decision.ts
@@ -59,6 +59,15 @@ export function suggestAction(
 
     case IssueStatus.IN_PROGRESS:
       if (hasWorkerDone) {
+        if (!hasPr) {
+          return "investigate_no_pr";
+        }
+        if (ciStatus === CiStatus.FAILING) {
+          return "resume_implementer_for_ci_failure";
+        }
+        if (ciStatus === CiStatus.PENDING) {
+          return "retry_ci_check";
+        }
         return "transition_to_testing";
       }
       if (hasLiveWorker) {
@@ -69,6 +78,15 @@ export function suggestAction(
     case IssueStatus.TESTING:
       if (hasWorkerDone) {
         if (hasTestPassed) {
+          if (!hasPr) {
+            return "investigate_no_pr";
+          }
+          if (ciStatus === CiStatus.FAILING) {
+            return "resume_implementer_for_ci_failure";
+          }
+          if (ciStatus === CiStatus.PENDING) {
+            return "retry_ci_check";
+          }
           return "transition_to_needs_review";
         }
         return "resume_implementer_for_test_failure";

--- a/packages/daemon/src/state/types.ts
+++ b/packages/daemon/src/state/types.ts
@@ -367,14 +367,19 @@ export function createParsedIssue(
 
     get needsPrStatus() {
       return (
-        this.status === IssueStatus.NEEDS_REVIEW &&
-        this.labels.includes("worker-done") &&
+        ((this.status === IssueStatus.NEEDS_REVIEW && this.labels.includes("worker-done")) ||
+          (this.status === IssueStatus.IN_PROGRESS && this.labels.includes("worker-done"))) &&
         this.prRef !== null
       );
     },
 
     get needsCiStatus() {
-      return this.status === IssueStatus.NEEDS_REVIEW && this.prRef !== null;
+      return (
+        (this.status === IssueStatus.NEEDS_REVIEW ||
+          this.status === IssueStatus.IN_PROGRESS ||
+          this.status === IssueStatus.TESTING) &&
+        this.prRef !== null
+      );
     },
   };
 }


### PR DESCRIPTION
Closes #191

## Summary

Adds CI status gates to the decision engine at **In Progress → Testing** and **Testing → Needs Review** transitions, preventing broken code from advancing through the pipeline.

### Changes
- **types.ts**: Expanded `needsCiStatus` to cover In Progress/Testing (with PR). Expanded `needsPrStatus` for In Progress (future-proofing per spec).
- **decision.ts**: After `worker-done` at In Progress and after `worker-done + test-passed` at Testing, the engine now checks: no PR → `investigate_no_pr`, CI failing → `resume_implementer_for_ci_failure`, CI pending → `retry_ci_check`, CI passing/null → allow transition (backward-compatible).
- **Controller SKILL.md**: Replaced ad-hoc "Quality Gate" section with "CI Gates (Enforced by Decision Engine)" — decision policy now lives in the state machine, remediation instructions stay in the controller.
- **AGENTS.md**: Updated state machine table with new gate rows.
- **Tests**: 14 new tests (10 decision + 4 types enrichment), 4 updated existing tests. All 216 state tests pass.