### PR TITLE
sjawhar-legion-215: bind listener to all interfaces for bridge networking

### DIFF
--- a/packages/envoy/cmd/listener/main.go
+++ b/packages/envoy/cmd/listener/main.go
@@ -287,7 +287,7 @@ func main() {
 		_ = json.NewEncoder(w).Encode(item)
 	})
 
-	log.Printf("envoy-listener listening on 127.0.0.1:%d", cfg.Port)
-	server := &http.Server{Addr: "127.0.0.1:" + strconv.Itoa(cfg.Port), Handler: mux, ReadTimeout: 10 * time.Second, WriteTimeout: 10 * time.Second, IdleTimeout: 60 * time.Second}
+	log.Printf("envoy-listener listening on :%d", cfg.Port)
+	server := &http.Server{Addr: ":" + strconv.Itoa(cfg.Port), Handler: mux, ReadTimeout: 10 * time.Second, WriteTimeout: 10 * time.Second, IdleTimeout: 60 * time.Second}
 	log.Fatal(server.ListenAndServe())
 }


### PR DESCRIPTION
Closes #215

## Summary

The envoy listener HTTP server was hardcoded to bind to `127.0.0.1:PORT`, which is unreachable from the host when Docker uses bridge networking. The github and slack receivers already bind to `:PORT` (all interfaces). This change makes the listener consistent with them.

### Change
- `cmd/listener/main.go`: Changed server bind address from `127.0.0.1:PORT` to `:PORT`
- Works in both host and bridge networking modes
- No regression on existing deployments (`:PORT` is a superset of `127.0.0.1:PORT`)