### PR TITLE
sjawhar-legion-221: fix default stream replicas from 3 to 1

### DIFF
--- a/packages/envoy/internal/bus/nats.go
+++ b/packages/envoy/internal/bus/nats.go
@@ -19,7 +19,7 @@ var streamCfg = &nats.StreamConfig{
 	Retention: nats.LimitsPolicy,
 	MaxAge:    time.Hour,
 	Storage:   nats.FileStorage,
-	Replicas:  3,
+	Replicas:  1,
 }
 
 // ConnectOption configures the bus client.
@@ -29,7 +29,7 @@ type connectOpts struct {
 	replicas int
 }
 
-// WithReplicas overrides the stream replica count (default 3). Use 1 for single-node test NATS.
+// WithReplicas overrides the stream replica count (default 1).
 func WithReplicas(n int) ConnectOption {
 	return func(o *connectOpts) { o.replicas = n }
 }
@@ -95,7 +95,7 @@ func connect(urls []string, reconnectCB func(*nats.Conn)) (*nats.Conn, error) {
 }
 
 func Connect(urls []string, options ...ConnectOption) (*Client, error) {
-	opts := connectOpts{replicas: 3}
+	opts := connectOpts{replicas: 1}
 	for _, o := range options {
 		o(&opts)
 	}


### PR DESCRIPTION
Closes #221

## Summary

- Change default JetStream stream replicas from 3 to 1 in `packages/envoy/internal/bus/nats.go`
- Fixes listener startup block when NATS cluster can't achieve 3-replica quorum (e.g. only 1-2 peers reachable)
- `WithReplicas` option preserved for callers that need higher replication
- Same fix pattern as #206 (which fixed `registry.go` but missed `bus.go`)

## Changes

- `streamCfg.Replicas`: 3 → 1
- `connectOpts.replicas` default: 3 → 1
- Updated `WithReplicas` doc comment to reflect new default