### PR TITLE
CRITICAL hotfix: skip UpdateStream to prevent blocking on existing 3-replica stream

### DIFF
--- a/packages/envoy/internal/bus/nats.go
+++ b/packages/envoy/internal/bus/nats.go
@@ -123,8 +123,7 @@ func Connect(urls []string, options ...ConnectOption) (*Client, error) {
 func ensureStreamWithConfig(js nats.JetStreamContext, cfg *nats.StreamConfig) error {
 	_, err := js.StreamInfo(Stream)
 	if err == nil {
-		_, err = js.UpdateStream(cfg)
-		return err
+		return nil
 	}
 	if !errors.Is(err, nats.ErrStreamNotFound) {
 		return err


### PR DESCRIPTION
Closes #221

## Summary

- When a NATS stream already exists with Replicas:3, `js.UpdateStream` blocks trying to achieve quorum — same root cause as the startup hang
- PR #222 changed the *default* from 3→1, but existing clusters still have the old 3-replica stream
- Fix: if stream already exists (`StreamInfo` succeeds), skip `UpdateStream` entirely and return nil
- New streams still get created with the configured replica count

**sami-claude is down — this unblocks startup against existing clusters.**