### PR TITLE
feat: make NATS replicas configurable via ENVOY_NATS_REPLICAS env var (#224)

### DIFF
--- a/packages/envoy/cmd/github/main.go
+++ b/packages/envoy/cmd/github/main.go
@@ -24,7 +24,7 @@ func main() {
 	}
 	secret := getenv("ENVOY_GITHUB_WEBHOOK_SECRET")
 	trigger := getenvDefault("ENVOY_GITHUB_MENTION_TRIGGER", "@legion")
-	client, err := bus.Connect(cfg.NATSURLs)
+	client, err := bus.Connect(cfg.NATSURLs, bus.WithReplicas(cfg.NATSReplicas))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/packages/envoy/cmd/listener/main.go
+++ b/packages/envoy/cmd/listener/main.go
@@ -24,17 +24,17 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	client, err := bus.Connect(cfg.NATSURLs)
+	client, err := bus.Connect(cfg.NATSURLs, bus.WithReplicas(cfg.NATSReplicas))
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer client.Conn.Close()
-	registry, err := store.Open(client.Conn)
+	registry, err := store.Open(client.Conn, store.WithReplicas(cfg.NATSReplicas))
 	if err != nil {
 		log.Fatal(err)
 	}
 	var sessions *session.SessionRegistry
-	if reg, err := session.OpenSessionRegistry(client.Conn); err != nil {
+	if reg, err := session.OpenSessionRegistry(client.Conn, session.WithSessionReplicas(cfg.NATSReplicas)); err != nil {
 		log.Printf("WARN: KV registry unavailable, using file-only delivery: %v", err)
 	} else {
 		sessions = reg

--- a/packages/envoy/cmd/slack/main.go
+++ b/packages/envoy/cmd/slack/main.go
@@ -23,7 +23,7 @@ func main() {
 		log.Fatal(err)
 	}
 	secret := getenv("ENVOY_SLACK_SIGNING_SECRET")
-	client, err := bus.Connect(cfg.NATSURLs)
+	client, err := bus.Connect(cfg.NATSURLs, bus.WithReplicas(cfg.NATSReplicas))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/packages/envoy/internal/config/config.go
+++ b/packages/envoy/internal/config/config.go
@@ -8,9 +8,10 @@ import (
 )
 
 type Service struct {
-	MachineID string
-	NATSURLs  []string
-	Port      int
+	MachineID    string
+	NATSURLs     []string
+	NATSReplicas int
+	Port         int
 }
 
 func Load(defaultPort int) (Service, error) {
@@ -34,5 +35,13 @@ func Load(defaultPort int) (Service, error) {
 		}
 		port = next
 	}
-	return Service{MachineID: machine, NATSURLs: urls, Port: port}, nil
+	replicas := 1
+	if value := strings.TrimSpace(os.Getenv("ENVOY_NATS_REPLICAS")); value != "" {
+		next, err := strconv.Atoi(value)
+		if err != nil {
+			return Service{}, fmt.Errorf("invalid ENVOY_NATS_REPLICAS: %w", err)
+		}
+		replicas = next
+	}
+	return Service{MachineID: machine, NATSURLs: urls, NATSReplicas: replicas, Port: port}, nil
 }

--- a/packages/envoy/internal/store/kv.go
+++ b/packages/envoy/internal/store/kv.go
@@ -31,7 +31,7 @@ func WithReplicas(n int) OpenOption {
 }
 
 func Open(conn *nats.Conn, options ...OpenOption) (*Registry, error) {
-	opts := openOpts{replicas: 3}
+	opts := openOpts{replicas: 1}
 	for _, o := range options {
 		o(&opts)
 	}


### PR DESCRIPTION
## Summary

- Add `ENVOY_NATS_REPLICAS` env var (default: `1`) to `config.Load()`, propagated as `cfg.NATSReplicas` to all three replica-setting call sites: `bus.Connect`, `store.Open`, `session.OpenSessionRegistry`
- Fix the last hardcoded `Replicas: 3` default in `store/kv.go` → `1` (safe for single-peer NATS)
- All cmd binaries (`listener`, `github`, `slack`) now pass the config value through their existing `WithReplicas` / `WithSessionReplicas` option functions

Closes #224