### PR TITLE
sjawhar-legion-229: fix cross-machine delivery fallback to filter by machine_id

### DIFF
--- a/packages/envoy/cmd/listener/main.go
+++ b/packages/envoy/cmd/listener/main.go
@@ -40,6 +40,7 @@ func main() {
 		sessions = reg
 	}
 	deliver := session.Deliverer{
+		MachineID:   cfg.MachineID,
 		RegistryDir: os.Getenv("ENVOY_REGISTRY_DIR"),
 		HostBridge:  os.Getenv("ENVOY_HOST_BRIDGE"),
 		Sessions:    sessions,

--- a/packages/envoy/internal/integration/delivery_test.go
+++ b/packages/envoy/internal/integration/delivery_test.go
@@ -84,6 +84,7 @@ func setupTestEnv(t *testing.T, options ...testEnvOption) *testEnv {
 	registryDir := t.TempDir()
 
 	deliverer := session.Deliverer{
+		MachineID:    "test-machine",
 		RegistryDir:  registryDir,
 		HostBridge:   "127.0.0.1",
 		RequestLimit: 5 * time.Second,
@@ -900,5 +901,104 @@ func TestE2E_ResumeDeliveryAfterReRegistration(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	if c := deliveriesB.Load(); c != 1 {
 		t.Fatalf("expected 1 delivery to resumed port B, got %d", c)
+	}
+}
+
+// TestE2E_CrossMachineAgentMessageACKsWithoutDelivery verifies that when an agent
+// message targets a session on machine-B, machine-A's listener ACKs (does not deliver
+// or NAK). This prevents wasting MaxDeliver budget on wrong-machine retries.
+func TestE2E_CrossMachineAgentMessageACKsWithoutDelivery(t *testing.T) {
+	env := setupTestEnv(t)
+	// Override deliverer machine ID to match the consumer's machine-A
+	env.deliverer.MachineID = "machine-A"
+	// Create a mock session server (simulates the target)
+	port, deliveries, _, _ := mockSession(t)
+
+	// Register the session in KV as belonging to machine-B
+	if err := env.sessions.Put("ses_on_b", session.SessionEntry{
+		Port:      port,
+		MachineID: "machine-B",
+		Dir:       "/test",
+	}); err != nil {
+		t.Fatalf("failed to put session entry: %v", err)
+	}
+
+	// Register interest (any machine can see interests)
+	env.registry.Upsert(store.Interest{
+		SessionID: "ses_on_b",
+		MachineID: "machine-B",
+		Dir:       "/test",
+	}, []string{contracts.AgentSubject("ses_on_b")})
+
+	// Also create a stale file registry entry on machine-A (simulates the problem)
+	env.registerFileSession("ses_on_b", port)
+
+	// Start consumer as machine-A (not the session's machine)
+	env.startConsumer("machine-A")
+
+	publishEnvelope(env, newEnvelope("agent", "notifications.agent.ses_on_b", "cross-machine test", "dedupe-cross-1"))
+
+	// Wait long enough for delivery + potential retries
+	time.Sleep(3 * time.Second)
+
+	// Machine-A should NOT have delivered (session belongs to machine-B)
+	if count := deliveries.Load(); count != 0 {
+		t.Fatalf("machine-A should not deliver to machine-B's session, got %d deliveries", count)
+	}
+}
+
+// TestE2E_CrossMachineBroadcastFilteredByMatch verifies that broadcast messages
+// are only delivered to sessions on the local machine (registry.Match filters by machine_id).
+func TestE2E_CrossMachineBroadcastFilteredByMatch(t *testing.T) {
+	env := setupTestEnv(t)
+	// Override deliverer machine ID to match the consumer's machine-A
+	env.deliverer.MachineID = "machine-A"
+	portLocal, deliveriesLocal, _, _ := mockSession(t)
+	portRemote, deliveriesRemote, _, _ := mockSession(t)
+
+	// Register local session (machine-A)
+	env.registry.Upsert(store.Interest{
+		SessionID: "ses_local",
+		MachineID: "machine-A",
+		Dir:       "/test",
+	}, []string{"notifications.slack.*.*.mention"})
+	env.registerFileSession("ses_local", portLocal)
+	if err := env.sessions.Put("ses_local", session.SessionEntry{
+		Port:      portLocal,
+		MachineID: "machine-A",
+		Dir:       "/test",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Register remote session (machine-B)
+	env.registry.Upsert(store.Interest{
+		SessionID: "ses_remote",
+		MachineID: "machine-B",
+		Dir:       "/test",
+	}, []string{"notifications.slack.*.*.mention"})
+	env.registerFileSession("ses_remote", portRemote)
+	if err := env.sessions.Put("ses_remote", session.SessionEntry{
+		Port:      portRemote,
+		MachineID: "machine-B",
+		Dir:       "/test",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Consumer is machine-A
+	env.startConsumer("machine-A")
+
+	publishEnvelope(env, newEnvelope("slack", "notifications.slack.T1.C1.mention", "broadcast", "dedupe-cross-bcast"))
+
+	time.Sleep(3 * time.Second)
+
+	// Local session should receive the broadcast
+	if c := deliveriesLocal.Load(); c != 1 {
+		t.Fatalf("local session expected 1 delivery, got %d", c)
+	}
+	// Remote session should NOT receive (Match filters by machine_id)
+	if c := deliveriesRemote.Load(); c != 0 {
+		t.Fatalf("remote session should not receive broadcast on machine-A, got %d", c)
 	}
 }

--- a/packages/envoy/internal/session/handler.go
+++ b/packages/envoy/internal/session/handler.go
@@ -1,6 +1,8 @@
 package session
 
 import (
+	"errors"
+
 	"github.com/sjawhar/envoy/internal/contracts"
 	"github.com/sjawhar/envoy/internal/store"
 )
@@ -25,6 +27,9 @@ func HandleAgentMessage(
 	// Interest path: direct delivery if interest matches this machine
 	if interest != nil && interest.MachineID == machineID {
 		if err := deliverer.Deliver(item, *interest); err != nil {
+			if errors.Is(err, ErrWrongMachine) {
+				return HandleAgentResult{Delivered: false}
+			}
 			return HandleAgentResult{ShouldNAK: true, Err: err}
 		}
 		return HandleAgentResult{Delivered: true}
@@ -38,6 +43,9 @@ func HandleAgentMessage(
 
 	fallback := store.Interest{SessionID: sessionID, Dir: entry.Dir, MachineID: machineID}
 	if err := deliverer.Deliver(item, fallback); err != nil {
+		if errors.Is(err, ErrWrongMachine) {
+			return HandleAgentResult{Delivered: false}
+		}
 		return HandleAgentResult{ShouldNAK: true, Err: err}
 	}
 	return HandleAgentResult{Delivered: true}

--- a/packages/envoy/internal/session/handler_test.go
+++ b/packages/envoy/internal/session/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/sjawhar/envoy/internal/store"
 )
@@ -137,6 +138,111 @@ func TestHandleAgentMessage_WrongMachine(t *testing.T) {
 	}
 	if count := deliveryCount.Load(); count != 1 {
 		t.Fatalf("expected 1 delivery via fallback, got %d", count)
+	}
+}
+
+// TestHandleAgentMessage_WrongMachineKVAcks tests that when the KV session
+// registry says a session is on another machine, the handler returns no-delivery
+// (ACK) rather than NAK, even when the file registry has a stale entry.
+func TestHandleAgentMessage_WrongMachineKVAcks(t *testing.T) {
+	var deliveryCount atomic.Int32
+
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deliveryCount.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer mock.Close()
+
+	port := mockPort(mock.URL)
+	dir := t.TempDir()
+	writeRegistryEntry(t, dir, 1, port, "ses_target")
+
+	client := setupNATS(t)
+	sessions, err := OpenSessionRegistry(client.Conn, WithSessionReplicas(1), WithSessionTTL(10*time.Second))
+	if err != nil {
+		t.Fatalf("failed to open session registry: %v", err)
+	}
+	// KV says session is on machine-B
+	sessions.Put("ses_target", SessionEntry{Port: port, MachineID: "machine-B", Dir: "/test"})
+
+	deliverer := Deliverer{
+		MachineID:    "machine-A",
+		RegistryDir:  dir,
+		HostBridge:   "127.0.0.1",
+		RequestLimit: 5 * time.Second,
+		Sessions:     sessions,
+	}
+
+	// No interest or wrong-machine interest — handler falls to fallback path
+	result := HandleAgentMessage(
+		newTestEnvelope("agent", "notifications.agent.ses_target", "test"),
+		"ses_target", "machine-A", nil, &deliverer,
+	)
+
+	// Should ACK (not NAK) — another listener owns this session
+	if result.Delivered {
+		t.Fatal("expected no delivery (session on different machine)")
+	}
+	if result.ShouldNAK {
+		t.Fatal("wrong machine should ACK, not NAK")
+	}
+	if count := deliveryCount.Load(); count != 0 {
+		t.Fatalf("expected 0 deliveries, got %d", count)
+	}
+}
+
+// TestHandleAgentMessage_InterestPathWrongMachineKVAcks tests that even when
+// the interest path matches this machine, if the KV session registry says the
+// session moved to another machine, the handler returns no-delivery (ACK).
+func TestHandleAgentMessage_InterestPathWrongMachineKVAcks(t *testing.T) {
+	var deliveryCount atomic.Int32
+
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deliveryCount.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer mock.Close()
+
+	port := mockPort(mock.URL)
+	dir := t.TempDir()
+	writeRegistryEntry(t, dir, 1, port, "ses_target")
+
+	client := setupNATS(t)
+	sessions, err := OpenSessionRegistry(client.Conn, WithSessionReplicas(1), WithSessionTTL(10*time.Second))
+	if err != nil {
+		t.Fatalf("failed to open session registry: %v", err)
+	}
+	// KV says session moved to machine-B
+	sessions.Put("ses_target", SessionEntry{Port: port, MachineID: "machine-B", Dir: "/test"})
+
+	deliverer := Deliverer{
+		MachineID:    "machine-A",
+		RegistryDir:  dir,
+		HostBridge:   "127.0.0.1",
+		RequestLimit: 5 * time.Second,
+		Sessions:     sessions,
+	}
+
+	// Interest says machine-A (stale interest), but KV says machine-B
+	interest := &store.Interest{
+		SessionID: "ses_target",
+		Dir:       "/test",
+		MachineID: "machine-A",
+	}
+
+	result := HandleAgentMessage(
+		newTestEnvelope("agent", "notifications.agent.ses_target", "test"),
+		"ses_target", "machine-A", interest, &deliverer,
+	)
+
+	if result.Delivered {
+		t.Fatal("expected no delivery (KV says session moved to machine-B)")
+	}
+	if result.ShouldNAK {
+		t.Fatal("wrong machine should ACK, not NAK")
+	}
+	if count := deliveryCount.Load(); count != 0 {
+		t.Fatalf("expected 0 deliveries, got %d", count)
 	}
 }
 

--- a/packages/envoy/internal/session/session.go
+++ b/packages/envoy/internal/session/session.go
@@ -3,6 +3,7 @@ package session
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -24,7 +25,12 @@ type RegistryEntry struct {
 	} `json:"session"`
 }
 
+// ErrWrongMachine is returned when a session belongs to a different machine.
+// Callers should ACK the message (another listener owns this session).
+var ErrWrongMachine = errors.New("session belongs to a different machine")
+
 type Deliverer struct {
+	MachineID    string
 	RegistryDir  string
 	HostBridge   string
 	RequestLimit time.Duration
@@ -36,8 +42,13 @@ func (d Deliverer) Deliver(item contracts.Envelope, interest store.Interest) err
 
 	// KV-first: try SessionRegistry for port
 	if d.Sessions != nil {
-		if entry, err := d.Sessions.Get(interest.SessionID); err == nil && entry.Port > 0 {
-			return d.prompt(entry.Port, interest.SessionID, text)
+		if entry, err := d.Sessions.Get(interest.SessionID); err == nil {
+			if d.MachineID != "" && entry.MachineID != "" && entry.MachineID != d.MachineID {
+				return ErrWrongMachine
+			}
+			if entry.Port > 0 {
+				return d.prompt(entry.Port, interest.SessionID, text)
+			}
 		}
 	}
 

--- a/packages/envoy/internal/session/session_test.go
+++ b/packages/envoy/internal/session/session_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -251,6 +252,7 @@ func TestDeliver_KVFirstOverFile(t *testing.T) {
 	sessions.Put("ses_target", SessionEntry{Port: kvPort, MachineID: "test", Dir: "/test"})
 
 	deliverer := Deliverer{
+		MachineID:    "test",
 		RegistryDir:  dir,
 		HostBridge:   "127.0.0.1",
 		RequestLimit: 5 * time.Second,
@@ -301,5 +303,87 @@ func TestDeliver_NilSessionsFallsBackToFile(t *testing.T) {
 	}
 	if count := deliveryCount.Load(); count != 1 {
 		t.Fatalf("expected exactly 1 delivery via file fallback, got %d", count)
+	}
+}
+
+func TestDeliver_WrongMachineReturnsError(t *testing.T) {
+	var deliveryCount atomic.Int32
+
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deliveryCount.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer mock.Close()
+
+	port := mockPort(mock.URL)
+	dir := t.TempDir()
+	writeRegistryEntry(t, dir, 1, port, "ses_target")
+
+	client := setupNATS(t)
+	sessions, err := OpenSessionRegistry(client.Conn, WithSessionReplicas(1), WithSessionTTL(10*time.Second))
+	if err != nil {
+		t.Fatalf("failed to open session registry: %v", err)
+	}
+	// Register session on machine-B
+	sessions.Put("ses_target", SessionEntry{Port: port, MachineID: "machine-B", Dir: "/test"})
+
+	// Deliverer is on machine-A
+	deliverer := Deliverer{
+		MachineID:    "machine-A",
+		RegistryDir:  dir,
+		HostBridge:   "127.0.0.1",
+		RequestLimit: 5 * time.Second,
+		Sessions:     sessions,
+	}
+	item := newTestEnvelope("agent", "notifications.agent.ses_target", "test message")
+	interest := store.Interest{SessionID: "ses_target", Dir: "/test", MachineID: "machine-A"}
+
+	err = deliverer.Deliver(item, interest)
+	if !errors.Is(err, ErrWrongMachine) {
+		t.Fatalf("expected ErrWrongMachine, got: %v", err)
+	}
+	if count := deliveryCount.Load(); count != 0 {
+		t.Fatalf("expected 0 deliveries (wrong machine), got %d", count)
+	}
+}
+
+func TestDeliver_WrongMachineSkipsFileFallback(t *testing.T) {
+	var fileDeliveries atomic.Int32
+
+	fileMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fileDeliveries.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer fileMock.Close()
+
+	filePort := mockPort(fileMock.URL)
+	dir := t.TempDir()
+	writeRegistryEntry(t, dir, 1, filePort, "ses_target")
+
+	client := setupNATS(t)
+	sessions, err := OpenSessionRegistry(client.Conn, WithSessionReplicas(1), WithSessionTTL(10*time.Second))
+	if err != nil {
+		t.Fatalf("failed to open session registry: %v", err)
+	}
+	// KV says session is on machine-B
+	sessions.Put("ses_target", SessionEntry{Port: 9999, MachineID: "machine-B", Dir: "/test"})
+
+	deliverer := Deliverer{
+		MachineID:    "machine-A",
+		RegistryDir:  dir,
+		HostBridge:   "127.0.0.1",
+		RequestLimit: 5 * time.Second,
+		Sessions:     sessions,
+	}
+	item := newTestEnvelope("agent", "notifications.agent.ses_target", "test message")
+	interest := store.Interest{SessionID: "ses_target", Dir: "/test", MachineID: "machine-A"}
+
+	err = deliverer.Deliver(item, interest)
+	if !errors.Is(err, ErrWrongMachine) {
+		t.Fatalf("expected ErrWrongMachine, got: %v", err)
+	}
+	// File fallback must NOT have been tried
+	if count := fileDeliveries.Load(); count != 0 {
+		t.Fatalf("expected 0 file deliveries (KV says wrong machine), got %d", count)
 	}
 }


### PR DESCRIPTION
Closes #229

## Summary

- Add `MachineID` field to `Deliverer` and `ErrWrongMachine` sentinel error
- In `Deliver()`, check KV session registry `entry.MachineID` against the deliverer's machine ID before attempting `prompt_async` — if mismatch, return `ErrWrongMachine` (short-circuits file registry fallback too)
- In `HandleAgentMessage`, handle `ErrWrongMachine` by returning `Delivered: false` (ACK, not NAK) on both interest and fallback paths
- Set `MachineID` on the listener's `Deliverer` from config
- Verified `registry.Match()` in the broadcast path already correctly filters by `machine_id`

## Impact

Previously, with 4 machines and `MaxDeliver:20`, 3 listeners NAK'd every agent-targeted message when hitting the fallback paths — wasting 15 retries per message. Now wrong-machine listeners ACK immediately, preserving retry budget for genuine delivery failures.

## Tests

- Unit: `TestDeliver_WrongMachineReturnsError`, `TestDeliver_WrongMachineSkipsFileFallback`
- Unit: `TestHandleAgentMessage_WrongMachineKVAcks`, `TestHandleAgentMessage_InterestPathWrongMachineKVAcks`  
- Integration: `TestE2E_CrossMachineAgentMessageACKsWithoutDelivery`, `TestE2E_CrossMachineBroadcastFilteredByMatch`
- All existing tests continue to pass