### PR TITLE
sjawhar-legion-235: bind HTTP server before NATS connection (async health startup)

### DIFF
--- a/docs/solutions/envoy/async-health-startup-pattern.md
+++ b/docs/solutions/envoy/async-health-startup-pattern.md
@@ -1,0 +1,162 @@
+---
+title: "Go async health startup: bind HTTP before slow dependencies"
+category: envoy
+tags:
+  - go
+  - health-check
+  - startup
+  - atomic-pointer
+  - readiness-gate
+  - nats
+  - pulumi
+  - net-listen
+  - servemux
+  - gitignore
+date: 2026-04-05
+status: active
+module: envoy
+related_issues:
+  - "#235"
+symptoms:
+  - "Pulumi deploy timeout waiting for health check"
+  - "health endpoint unreachable during NATS connection"
+  - "503 from /healthz during startup"
+  - "container appears down while connecting to NATS"
+  - "new test files in cmd/listener/ not tracked by git"
+---
+
+# Go Async Health Startup: Bind HTTP Before Slow Dependencies
+
+When a Go service depends on slow external resources (NATS, databases, remote APIs), the
+health check endpoint must be reachable before those dependencies initialize. Otherwise
+orchestrators (Pulumi, Kubernetes) time out and kill the container.
+
+## The Pattern: 7-Phase Startup
+
+```
+1. config.Load()           — synchronous, fast
+2. net.Listen("tcp", addr) — bind port in main goroutine (deterministic)
+3. Build HTTP mux           — /healthz always available, /v1/* behind readiness gate
+4. go server.Serve(ln)      — HTTP live immediately, /healthz returns {"status":"starting"}
+5. Slow init in main()      — NATS connect, store open, consumer subscribe
+6. deps.Store(...)           — atomic publish, readiness gate opens for /v1/*
+7. log.Fatal(<-fatal)        — block on HTTP server error channel
+```
+
+**Why `net.Listen` + `server.Serve(ln)` instead of `ListenAndServe`**: `ListenAndServe`
+binds and accepts atomically — you cannot separate them. `net.Listen` in the main goroutine
+guarantees the port is bound before any slow I/O begins. `server.Serve(ln)` in a goroutine
+starts accepting connections on the already-bound listener.
+
+## `atomic.Pointer[T]` for Dependency Publication
+
+```go
+type listenerDeps struct {
+    client   *bus.Client
+    registry *store.Registry
+    sessions *session.SessionRegistry  // may be nil (graceful degradation)
+}
+
+var deps atomic.Pointer[listenerDeps]
+```
+
+**Why not a mutex**: Single writer (main goroutine stores after init), many concurrent readers
+(HTTP handlers load on each request). Lock-free reads, no contention. Nil pointer is a natural
+"not ready" sentinel.
+
+**Key subtlety — two access patterns for the same dependencies:**
+- **HTTP handlers**: access via `deps.Load()` — created before deps exist, gated by readiness
+  middleware. Must use atomic pointer.
+- **NATS consumer callback**: captures local variables directly from the init scope — created
+  after all deps are initialized. Does NOT use the atomic pointer. This is correct and
+  intentional; adding an atomic read on every NATS message would be unnecessary overhead.
+
+**`sessions` can be nil even after init.** `session.OpenSessionRegistry` failure is non-fatal
+(graceful degradation to file-only delivery). The atomic pointer being non-nil does not
+guarantee all fields are non-nil. The `SessionRegistry` type uses nil-receiver methods that
+return `ErrNoKV`, so nil dereference is safe — but callers should handle the error.
+
+## Readiness Gate Middleware
+
+```go
+func readinessGate(ready func() bool, next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        if !ready() {
+            http.Error(w, "service starting", http.StatusServiceUnavailable)
+            return
+        }
+        next.ServeHTTP(w, r)
+    })
+}
+```
+
+Applied to a **sub-mux** wrapping all `/v1/*` routes — one gate, no per-handler nil checks:
+```go
+v1 := http.NewServeMux()
+v1.HandleFunc("/v1/interests/subscribe", ...)
+mux.Handle("/v1/", readinessGate(func() bool { return deps.Load() != nil }, v1))
+```
+
+## Three-State Health Check
+
+| Phase | `/healthz` | Body | Meaning |
+|-------|-----------|------|---------|
+| Starting | 200 | `{"status":"starting"}` | Alive, init in progress — don't restart |
+| Healthy | 200 | `{"status":"healthy"}` | NATS connected, fully operational |
+| Unhealthy | 503 | `{"status":"unhealthy","error":"..."}` | Was connected, NATS dropped |
+
+Returning **200 during startup** is deliberate — it tells the orchestrator "I'm alive, keep
+waiting" without triggering a container restart. This is bounded by the NATS connection timeout
+(~10s with retries).
+
+## Fatal Error Routing
+
+`log.Fatal` calls `os.Exit(1)`, skipping all defers. Safe from `main()` (process is dying
+anyway), dangerous from goroutines (defers in other goroutines won't run).
+
+**Rule**: Keep fatal-error paths in the main goroutine. Background goroutines send errors to
+a buffered channel:
+
+```go
+fatal := make(chan error, 1)  // buffered: goroutine won't block if main is in slow init
+go func() {
+    if err := server.Serve(ln); err != http.ErrServerClosed {
+        fatal <- err
+    }
+}()
+// ... slow init in main ...
+log.Fatal(<-fatal)
+```
+
+The buffer size of 1 is important: if the HTTP server dies while main is still in NATS init,
+the send must not block or the goroutine leaks.
+
+## Gotchas
+
+### Go `ServeMux` Sub-Mux Routing
+
+When `mux.Handle("/v1/", submux)` delegates to a sub-mux, Go does **NOT** strip the `/v1/`
+prefix. The inner mux must register full paths:
+
+```go
+v1.HandleFunc("/v1/interests/subscribe", ...)  // ✓ full path
+v1.HandleFunc("/interests/subscribe", ...)     // ✗ won't match
+```
+
+The trailing slash on `/v1/` is required for prefix matching in `net/http`.
+
+### `.gitignore` Bare-Name Pattern Trap
+
+A bare pattern like `listener` in `.gitignore` matches any file or directory named `listener`
+at any depth. This meant `cmd/listener/` was gitignored — new files (like `main_test.go`)
+were silently invisible to `git`/`jj`.
+
+**Fix**: Root-anchor binary names with `/listener`. For Go projects, always anchor compiled
+binary ignores: `/github`, `/listener`, `/slack` — never bare names.
+
+## Applicability to Other Receivers
+
+The `github` and `slack` receivers (`cmd/github/main.go`, `cmd/slack/main.go`) have the same
+NATS-before-HTTP pattern but are simpler (publish-only, no JetStream consumer). The same
+7-phase startup, `atomic.Pointer`, and readiness gate apply directly. The `readinessGate`
+function is generic (`func() bool` + `http.Handler`) and can be copied verbatim.

--- a/docs/solutions/index.json
+++ b/docs/solutions/index.json
@@ -466,7 +466,8 @@
     "packages/envoy/cmd/listener": [
       "architecture-patterns/nats-kv-dual-bucket-lifecycle.md",
       "architecture-patterns/nats-kv-graceful-degradation.md",
-      "envoy/listener-routing-by-topic-prefix.md"
+      "envoy/listener-routing-by-topic-prefix.md",
+      "envoy/async-health-startup-pattern.md"
     ],
     "packages/envoy-plugin": [
       "architecture-patterns/nats-kv-dual-bucket-lifecycle.md"

--- a/packages/envoy/.gitignore
+++ b/packages/envoy/.gitignore
@@ -1,5 +1,5 @@
-github
-listener
-slack
+/github
+/listener
+/slack
 deploy/compose/nats/nats.conf
 deploy/compose/nats/nats-*.conf

--- a/packages/envoy/cmd/listener/main.go
+++ b/packages/envoy/cmd/listener/main.go
@@ -3,10 +3,12 @@ package main
 import (
 	"encoding/json"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/nats-io/nats.go"
@@ -19,26 +21,271 @@ import (
 	"github.com/sjawhar/envoy/internal/store"
 )
 
+// listenerDeps holds NATS-dependent resources published atomically after
+// initialization completes. HTTP handlers read these via atomic.Pointer to
+// avoid data races during the startup window.
+type listenerDeps struct {
+	client   *bus.Client
+	registry *store.Registry
+	sessions *session.SessionRegistry
+}
+
+// readinessGate returns 503 until ready returns true, providing a single
+// gate for all /v1/* endpoints during NATS initialization.
+func readinessGate(ready func() bool, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !ready() {
+			http.Error(w, "service starting", http.StatusServiceUnavailable)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 func main() {
+	// Phase 1: Load config (synchronous, fast).
 	cfg, err := config.Load(9020)
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Phase 2: Bind HTTP port deterministically in main goroutine before
+	// any NATS work begins. This guarantees /healthz is reachable as soon
+	// as Serve starts, regardless of NATS connection latency.
+	addr := ":" + strconv.Itoa(cfg.Port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Shared state: nil until NATS initialization completes.
+	var deps atomic.Pointer[listenerDeps]
+
+	// Phase 3: Build HTTP mux.
+	mux := http.NewServeMux()
+
+	// /healthz is always reachable — returns 200 "starting" before NATS init,
+	// 200 "healthy" after init with live NATS, 503 "unhealthy" if NATS drops.
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		d := deps.Load()
+		if d == nil {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "starting"})
+			return
+		}
+		if err := d.client.Conn.FlushTimeout(3 * time.Second); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "unhealthy", "error": "nats unavailable"})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "healthy"})
+	})
+
+	// /v1/* routes on a sub-mux, gated by a single readiness middleware.
+	v1 := http.NewServeMux()
+
+	v1.HandleFunc("/v1/interests/subscribe", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var body struct {
+			SessionID string   `json:"session_id"`
+			Dir       string   `json:"dir"`
+			Topics    []string `json:"topics"`
+			Port      int      `json:"port"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		d := deps.Load()
+		item, err := d.registry.Upsert(store.Interest{
+			SessionID: body.SessionID,
+			MachineID: cfg.MachineID,
+			Dir:       body.Dir,
+		}, append(body.Topics, contracts.AgentSubject(body.SessionID)))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if body.Port > 0 {
+			if err := d.sessions.Put(body.SessionID, session.SessionEntry{
+				Port:      body.Port,
+				MachineID: cfg.MachineID,
+				Dir:       body.Dir,
+			}); err != nil {
+				log.Printf("listener session registry put failed session=%s: %v", body.SessionID, err)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(item)
+	})
+	v1.HandleFunc("/v1/interests/unsubscribe", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var body struct {
+			SessionID string   `json:"session_id"`
+			Topics    []string `json:"topics"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		d := deps.Load()
+		if err := d.registry.Remove(body.SessionID, body.Topics); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	v1.HandleFunc("/v1/registry/", func(w http.ResponseWriter, r *http.Request) {
+		sessionID := strings.TrimPrefix(r.URL.Path, "/v1/registry/")
+		if sessionID == "" {
+			http.Error(w, "session_id required", http.StatusBadRequest)
+			return
+		}
+		d := deps.Load()
+		entry, err := d.sessions.Get(sessionID)
+		if err != nil {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(entry)
+	})
+
+	v1.HandleFunc("/v1/interests/", func(w http.ResponseWriter, r *http.Request) {
+		sessionID := strings.TrimPrefix(r.URL.Path, "/v1/interests/")
+		d := deps.Load()
+		item, err := d.registry.Get(sessionID)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(item)
+	})
+	v1.HandleFunc("/v1/messages/send", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var body struct {
+			SourceSession string `json:"source_session"`
+			TargetSession string `json:"target_session"`
+			Message       string `json:"message"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		item := contracts.Envelope{
+			EventID:        id.New(),
+			Source:         "agent",
+			SourceSession:  body.SourceSession,
+			SourceEventID:  id.New(),
+			Topic:          contracts.AgentSubject(body.TargetSession),
+			DedupeKey:      "agent." + body.TargetSession + "." + id.New(),
+			IssuedAt:       contracts.NowMillis(),
+			PayloadSummary: body.Message,
+			TraceID:        id.New(),
+		}
+		if err := item.Validate(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		d := deps.Load()
+		if err := d.client.Publish(item); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(item)
+	})
+	v1.HandleFunc("/v1/messages/publish", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var body struct {
+			SourceSession string `json:"source_session"`
+			Topic         string `json:"topic"`
+			Message       string `json:"message"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		if body.Topic == "" || body.Message == "" {
+			http.Error(w, "topic and message are required", http.StatusBadRequest)
+			return
+		}
+		item := contracts.Envelope{
+			EventID:        id.New(),
+			Source:         "agent",
+			SourceSession:  body.SourceSession,
+			SourceEventID:  id.New(),
+			Topic:          body.Topic,
+			DedupeKey:      "publish." + id.New(),
+			IssuedAt:       contracts.NowMillis(),
+			PayloadSummary: body.Message,
+			TraceID:        id.New(),
+		}
+		if err := item.Validate(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		d := deps.Load()
+		if err := d.client.Publish(item); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(item)
+	})
+
+	mux.Handle("/v1/", readinessGate(func() bool { return deps.Load() != nil }, v1))
+
+	// Phase 4: Start HTTP server (port already bound via net.Listen).
+	server := &http.Server{
+		Handler:      mux,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+	fatal := make(chan error, 1)
+	go func() {
+		if err := server.Serve(ln); err != http.ErrServerClosed {
+			fatal <- err
+		}
+	}()
+	log.Printf("envoy-listener listening on %s", addr)
+
+	// Phase 5: Connect to NATS (main goroutine — log.Fatal is safe here).
 	client, err := bus.Connect(cfg.NATSURLs, bus.WithReplicas(cfg.NATSReplicas))
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer client.Conn.Close()
+
 	registry, err := store.Open(client.Conn, store.WithReplicas(cfg.NATSReplicas))
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	var sessions *session.SessionRegistry
 	if reg, err := session.OpenSessionRegistry(client.Conn, session.WithSessionReplicas(cfg.NATSReplicas)); err != nil {
 		log.Printf("WARN: KV registry unavailable, using file-only delivery: %v", err)
 	} else {
 		sessions = reg
 	}
+
 	deliver := session.Deliverer{
 		MachineID:   cfg.MachineID,
 		RegistryDir: os.Getenv("ENVOY_REGISTRY_DIR"),
@@ -125,174 +372,14 @@ func main() {
 		log.Fatal(err)
 	}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		if err := client.Conn.FlushTimeout(3 * time.Second); err != nil {
-			http.Error(w, "nats unavailable", http.StatusServiceUnavailable)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("ok"))
+	// Phase 6: Publish initialized state — readiness gate opens for /v1/*.
+	deps.Store(&listenerDeps{
+		client:   client,
+		registry: registry,
+		sessions: sessions,
 	})
-	mux.HandleFunc("/v1/interests/subscribe", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		var body struct {
-			SessionID string   `json:"session_id"`
-			Dir       string   `json:"dir"`
-			Topics    []string `json:"topics"`
-			Port      int      `json:"port"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			http.Error(w, "invalid json", http.StatusBadRequest)
-			return
-		}
-		item, err := registry.Upsert(store.Interest{
-			SessionID: body.SessionID,
-			MachineID: cfg.MachineID,
-			Dir:       body.Dir,
-		}, append(body.Topics, contracts.AgentSubject(body.SessionID)))
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		if body.Port > 0 {
-			if err := sessions.Put(body.SessionID, session.SessionEntry{
-				Port:      body.Port,
-				MachineID: cfg.MachineID,
-				Dir:       body.Dir,
-			}); err != nil {
-				log.Printf("listener session registry put failed session=%s: %v", body.SessionID, err)
-			}
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(item)
-	})
-	mux.HandleFunc("/v1/interests/unsubscribe", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		var body struct {
-			SessionID string   `json:"session_id"`
-			Topics    []string `json:"topics"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			http.Error(w, "invalid json", http.StatusBadRequest)
-			return
-		}
-		if err := registry.Remove(body.SessionID, body.Topics); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("ok"))
-	})
-	mux.HandleFunc("/v1/registry/", func(w http.ResponseWriter, r *http.Request) {
-		sessionID := strings.TrimPrefix(r.URL.Path, "/v1/registry/")
-		if sessionID == "" {
-			http.Error(w, "session_id required", http.StatusBadRequest)
-			return
-		}
-		entry, err := sessions.Get(sessionID)
-		if err != nil {
-			http.Error(w, "not found", http.StatusNotFound)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(entry)
-	})
+	log.Printf("envoy-listener ready (NATS connected)")
 
-	mux.HandleFunc("/v1/interests/", func(w http.ResponseWriter, r *http.Request) {
-		sessionID := strings.TrimPrefix(r.URL.Path, "/v1/interests/")
-		item, err := registry.Get(sessionID)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusNotFound)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(item)
-	})
-	mux.HandleFunc("/v1/messages/send", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		var body struct {
-			SourceSession string `json:"source_session"`
-			TargetSession string `json:"target_session"`
-			Message       string `json:"message"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			http.Error(w, "invalid json", http.StatusBadRequest)
-			return
-		}
-		item := contracts.Envelope{
-			EventID:        id.New(),
-			Source:         "agent",
-			SourceSession:  body.SourceSession,
-			SourceEventID:  id.New(),
-			Topic:          contracts.AgentSubject(body.TargetSession),
-			DedupeKey:      "agent." + body.TargetSession + "." + id.New(),
-			IssuedAt:       contracts.NowMillis(),
-			PayloadSummary: body.Message,
-			TraceID:        id.New(),
-		}
-		if err := item.Validate(); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if err := client.Publish(item); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(item)
-	})
-	mux.HandleFunc("/v1/messages/publish", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		var body struct {
-			SourceSession string `json:"source_session"`
-			Topic         string `json:"topic"`
-			Message       string `json:"message"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			http.Error(w, "invalid json", http.StatusBadRequest)
-			return
-		}
-		if body.Topic == "" || body.Message == "" {
-			http.Error(w, "topic and message are required", http.StatusBadRequest)
-			return
-		}
-		item := contracts.Envelope{
-			EventID:        id.New(),
-			Source:         "agent",
-			SourceSession:  body.SourceSession,
-			SourceEventID:  id.New(),
-			Topic:          body.Topic,
-			DedupeKey:      "publish." + id.New(),
-			IssuedAt:       contracts.NowMillis(),
-			PayloadSummary: body.Message,
-			TraceID:        id.New(),
-		}
-		if err := item.Validate(); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if err := client.Publish(item); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(item)
-	})
-
-	log.Printf("envoy-listener listening on :%d", cfg.Port)
-	server := &http.Server{Addr: ":" + strconv.Itoa(cfg.Port), Handler: mux, ReadTimeout: 10 * time.Second, WriteTimeout: 10 * time.Second, IdleTimeout: 60 * time.Second}
-	log.Fatal(server.ListenAndServe())
+	// Phase 7: Block until fatal error from HTTP server.
+	log.Fatal(<-fatal)
 }

--- a/packages/envoy/cmd/listener/main_test.go
+++ b/packages/envoy/cmd/listener/main_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestReadinessGate_NotReady_Returns503(t *testing.T) {
+	handler := readinessGate(func() bool { return false }, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be called when not ready")
+	}))
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest("GET", "/v1/interests/subscribe", nil))
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rr.Code)
+	}
+	if body := rr.Body.String(); body != "service starting\n" {
+		t.Fatalf("unexpected body: %q", body)
+	}
+}
+
+func TestReadinessGate_Ready_PassesThrough(t *testing.T) {
+	var called bool
+	handler := readinessGate(func() bool { return true }, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest("GET", "/v1/interests/subscribe", nil))
+
+	if !called {
+		t.Fatal("handler should be called when ready")
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+}
+
+// healthzHandler builds the same /healthz handler used in main(), parameterized
+// by the shared state pointer so we can control readiness in tests.
+func healthzHandler(state *atomic.Pointer[listenerDeps]) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		d := state.Load()
+		if d == nil {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "starting"})
+			return
+		}
+		// Post-init path would check NATS health, but requires a live
+		// bus.Client which needs NATS. Only the starting state is
+		// testable without NATS.
+	}
+}
+
+func TestHealthz_Starting_Returns200WithJSON(t *testing.T) {
+	var state atomic.Pointer[listenerDeps]
+	handler := healthzHandler(&state)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest("GET", "/healthz", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	ct := rr.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Fatalf("expected Content-Type application/json, got %q", ct)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+	if body["status"] != "starting" {
+		t.Fatalf("expected status 'starting', got %q", body["status"])
+	}
+}
+
+func TestFullMux_StartingState(t *testing.T) {
+	// Simulate the full mux with no deps published (starting state).
+	var state atomic.Pointer[listenerDeps]
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", healthzHandler(&state))
+
+	v1 := http.NewServeMux()
+	v1.HandleFunc("/v1/interests/subscribe", func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("v1 handler should not be called during starting state")
+	})
+	mux.Handle("/v1/", readinessGate(func() bool { return state.Load() != nil }, v1))
+
+	t.Run("healthz returns 200 starting", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest("GET", "/healthz", nil))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rr.Code)
+		}
+	})
+
+	t.Run("v1 endpoint returns 503", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest("POST", "/v1/interests/subscribe", nil))
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Fatalf("expected 503, got %d", rr.Code)
+		}
+	})
+
+	t.Run("v1 messages returns 503", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest("POST", "/v1/messages/send", nil))
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Fatalf("expected 503, got %d", rr.Code)
+		}
+	})
+
+	t.Run("v1 registry returns 503", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest("GET", "/v1/registry/some-id", nil))
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Fatalf("expected 503, got %d", rr.Code)
+		}
+	})
+}


### PR DESCRIPTION
Closes #235

## Summary

Restructures Envoy listener startup to bind the HTTP port **before** NATS initialization, fixing Pulumi deploy timeouts caused by slow NATS connections making the health endpoint unreachable.

### Changes

- **`packages/envoy/cmd/listener/main.go`**: Reordered startup phases — `net.Listen` binds the port in the main goroutine before any NATS work begins. HTTP server starts in a goroutine via `server.Serve(ln)`, then NATS init runs in the main goroutine. Dependencies published via `atomic.Pointer[listenerDeps]` for safe concurrent access by HTTP handlers.

- **Health check states**: `/healthz` returns JSON with three states:
  | Phase | Status | Body |
  |-------|--------|------|
  | Starting (NATS not connected) | 200 | `{"status":"starting"}` |
  | Healthy (NATS live) | 200 | `{"status":"healthy"}` |
  | Unhealthy (NATS dropped) | 503 | `{"status":"unhealthy","error":"nats unavailable"}` |

- **Readiness gate**: Single `readinessGate` middleware wraps all `/v1/*` routes on a sub-mux, returning 503 until NATS init completes. No per-handler nil checks needed.

- **`packages/envoy/cmd/listener/main_test.go`** (new): 7 tests covering readiness gate behavior and startup health states.

- **`packages/envoy/.gitignore`**: Root-anchored binary ignore patterns (`/listener` → was `listener`) — the bare pattern was accidentally ignoring `cmd/listener/` for new files.

### Design decisions

- NATS init in main goroutine (not background goroutine) — `log.Fatal` is safe from main, avoiding the `os.Exit(1)` / skipped-defers issue
- `atomic.Pointer[listenerDeps]` over mutex — lock-free reads for HTTP handlers, single atomic Store after init
- Consumer callback captures local variables directly (set during NATS init in main), not through the atomic pointer
- `session.OpenSessionRegistry` failure still does NOT block readiness (preserves graceful degradation)