### PR TITLE
fix(infra): Pulumi POC fixes — registryAuth, optional sshHost, health check timing

### DIFF
--- a/packages/envoy/infra/Pulumi.prod.yaml
+++ b/packages/envoy/infra/Pulumi.prod.yaml
@@ -1,12 +1,11 @@
 config:
   envoy:registry: ghcr.io/sjawhar/legion
-  envoy:imageTag: PLACEHOLDER_SET_BEFORE_DEPLOY
+  envoy:imageTag: 78afd36b3ea3
   envoy:natsImage: "nats:2.11-alpine"
   envoy:machines:
     - name: sami-agents-mx
-      sshHost: "ssh://ubuntu@sami-agents-mx"
       machineId: sami-agents-mx
-      tailscaleIp: PLACEHOLDER_SET_BEFORE_DEPLOY
+      tailscaleIp: "100.117.175.119"
       nats:
         serverName: sami-agents-mx
       listener:
@@ -17,7 +16,7 @@ config:
     - name: sami
       sshHost: "ssh://sami@sami"
       machineId: sami
-      tailscaleIp: PLACEHOLDER_SET_BEFORE_DEPLOY
+      tailscaleIp: "100.100.92.97"
       nats:
         serverName: sami
       listener:
@@ -25,7 +24,7 @@ config:
     - name: sami-claude
       sshHost: "ssh://claude@sami-claude"
       machineId: sami-claude
-      tailscaleIp: PLACEHOLDER_SET_BEFORE_DEPLOY
+      tailscaleIp: "100.85.18.68"
       nats:
         serverName: sami-claude
       listener:
@@ -33,6 +32,13 @@ config:
     - name: ghost-wispr
       sshHost: "ssh://ghost-wispr@ghost-wispr"
       machineId: ghost-wispr
-      tailscaleIp: PLACEHOLDER_SET_BEFORE_DEPLOY
+      tailscaleIp: "100.103.243.89"
       listener:
         registryDir: /home/ghost-wispr/.local/state/opencode/registry
+  envoy:githubWebhookSecret:
+    secure: v1:kb4Dq9+22FdpMyKS:TddsOzBlO2icbVSvWlXr95m/7Z7pWAEg0GJ5tgmJmT79pgoIxI9HOehkzU4CXhid0MkeE7xGNzk=
+  envoy:slackSigningSecret:
+    secure: v1:UXOgMy5m0OkUPiXC:0udxatu8sR8AKagjGPBCI+hPK3GyH8VwZNUIs1HO+2YOo2F8gsbPc8P4HDGvju001w==
+  envoy:ghcrToken:
+    secure: v1:n9jTNhn4Yk/eJer7:jc7QuPq5Dx2Ta67Qaz3nHaE8kBNpZREVmkafRpeWI0E7EjujsjADx7V3SbG107ajOvCvsLwrOJU=
+encryptionsalt: v1:R5vvgmHVgJw=:v1:T7WdS5AO9zYdN0xD:83mEIYvoAB6yLBeqMlWe44tRSwIeIA==

--- a/packages/envoy/infra/index.ts
+++ b/packages/envoy/infra/index.ts
@@ -1,3 +1,4 @@
+import type * as docker from "@pulumi/docker";
 import * as pulumi from "@pulumi/pulumi";
 import { pullImages } from "./images";
 import type { MachineConfig } from "./machines";
@@ -19,9 +20,14 @@ const slackSigningSecret = cfg.requireSecret("slackSigningSecret");
 
 const secrets = { githubWebhookSecret, slackSigningSecret };
 
+// Registry auth for GHCR (private packages)
+const registryAuth: docker.types.input.ProviderRegistryAuth[] = [
+  { address: registry, username: "sjawhar", password: cfg.requireSecret("ghcrToken") },
+];
+
 // Deploy to each machine
 for (const machine of machines) {
-  const provider = createProvider(machine);
+  const provider = createProvider(machine, registryAuth);
   const images = pullImages(provider, machine, registry, imageTag, natsImage);
 
   // NATS peer — only on machines with nats config

--- a/packages/envoy/infra/machines.ts
+++ b/packages/envoy/infra/machines.ts
@@ -15,7 +15,7 @@ export interface ReceiverConfig {
 
 export interface MachineConfig {
   name: string;
-  sshHost: string;
+  sshHost?: string;
   machineId: string;
   tailscaleIp: string;
   nats?: NatsConfig;
@@ -23,8 +23,12 @@ export interface MachineConfig {
   receivers?: ReceiverConfig;
 }
 
-export function createProvider(machine: MachineConfig): docker.Provider {
+export function createProvider(
+  machine: MachineConfig,
+  registryAuth?: docker.types.input.ProviderRegistryAuth[]
+): docker.Provider {
   return new docker.Provider(`docker-${machine.name}`, {
     host: machine.sshHost,
+    registryAuth,
   });
 }

--- a/packages/envoy/infra/services.ts
+++ b/packages/envoy/infra/services.ts
@@ -96,10 +96,10 @@ export function createListener(
         interval: "10s",
         timeout: "3s",
         retries: 3,
-        startPeriod: "5s",
+        startPeriod: "30s",
       },
       wait: true,
-      waitTimeout: 30,
+      waitTimeout: 90,
     },
     { provider, dependsOn, deleteBeforeReplace: true }
   );

--- a/packages/envoy/infra/tsconfig.json
+++ b/packages/envoy/infra/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "ESNext",
+    "module": "commonjs",
     "lib": ["ESNext"],
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Changes

Fixes discovered during the Pulumi fleet deployment proof of concept:

1. **GHCR registryAuth** — Docker provider needs explicit registry auth for private GHCR packages (now public, but auth still needed for push)
2. **Optional sshHost** — sami-agents-mx uses local Docker socket, no SSH needed. Made `sshHost` optional in MachineConfig
3. **Health check timing** — increased `startPeriod` from 5s to 30s and `waitTimeout` from 30 to 90 for JetStream catchup (~60s on cold start)
4. **tsconfig** — changed `module` to commonjs and `moduleResolution` to node for Pulumi ts-node compatibility

## Context

These were applied during the live fleet deployment session. All 4 machines successfully deployed via `pulumi up` with these fixes.