### PR TITLE
sjawhar-legion-246: Envoy agent messages include reply instructions

### DIFF
--- a/packages/envoy/internal/integration/delivery_test.go
+++ b/packages/envoy/internal/integration/delivery_test.go
@@ -508,9 +508,22 @@ func TestE2E_ReplyToInBody(t *testing.T) {
 	if len(*bodies) == 0 {
 		t.Fatal("no delivery received")
 	}
-	body := (*bodies)[0]
-	if !contains(body, "ses_sender_xyz") {
-		t.Fatalf("body should contain source session 'ses_sender_xyz', got: %s", body)
+	var parsed struct {
+		Parts []map[string]string `json:"parts"`
+	}
+	if err := json.Unmarshal([]byte((*bodies)[0]), &parsed); err != nil {
+		t.Fatalf("failed to parse body: %v", err)
+	}
+	if len(parsed.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(parsed.Parts))
+	}
+	text := parsed.Parts[0]["text"]
+	if !contains(text, "ses_sender_xyz") {
+		t.Fatalf("text should contain source session 'ses_sender_xyz', got: %s", text)
+	}
+	replyInstruction := `Use envoy_send(target_session="ses_sender_xyz", message="...") to reply to this message.`
+	if !contains(text, replyInstruction) {
+		t.Fatalf("text should contain exact reply instruction %q, got: %s", replyInstruction, text)
 	}
 }
 

--- a/packages/envoy/internal/session/session.go
+++ b/packages/envoy/internal/session/session.go
@@ -85,7 +85,11 @@ func (d Deliverer) Text(item contracts.Envelope) string {
 	if item.SourceSession != "" {
 		header = fmt.Sprintf("[NOTIFICATION from %s (reply-to: %s)]", item.Source, item.SourceSession)
 	}
-	return fmt.Sprintf("%s\n%s\n\nTopic: %s\nEvent ID: %s", header, item.PayloadSummary, item.Topic, item.EventID)
+	text := fmt.Sprintf("%s\n%s\n\nTopic: %s\nEvent ID: %s", header, item.PayloadSummary, item.Topic, item.EventID)
+	if item.SourceSession != "" {
+		text += fmt.Sprintf("\nUse envoy_send(target_session=\"%s\", message=\"...\") to reply to this message.", item.SourceSession)
+	}
+	return text
 }
 
 func (d Deliverer) prompt(port int, sessionID string, text string) error {

--- a/packages/envoy/internal/session/session_test.go
+++ b/packages/envoy/internal/session/session_test.go
@@ -149,6 +149,45 @@ func TestDeliver_PromptAsyncBody(t *testing.T) {
 			t.Errorf("notification text missing %q: %s", want, text)
 		}
 	}
+	replyInstruction := `Use envoy_send(target_session="ses_sender_123", message="...") to reply to this message.`
+	if !strings.Contains(text, replyInstruction) {
+		t.Errorf("notification text missing reply instruction: %s", text)
+	}
+}
+
+func TestText_WithSourceSession(t *testing.T) {
+	deliverer := newDeliverer(t.TempDir())
+	item := contracts.Envelope{
+		EventID:        "evt-1",
+		Source:         "agent",
+		SourceSession:  "ses_abc",
+		Topic:          "notifications.agent.ses_target",
+		PayloadSummary: "hello world",
+	}
+	got := deliverer.Text(item)
+	want := "[NOTIFICATION from agent (reply-to: ses_abc)]\nhello world\n\nTopic: notifications.agent.ses_target\nEvent ID: evt-1\nUse envoy_send(target_session=\"ses_abc\", message=\"...\") to reply to this message."
+	if got != want {
+		t.Errorf("Text() mismatch\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestText_WithoutSourceSession(t *testing.T) {
+	deliverer := newDeliverer(t.TempDir())
+	item := contracts.Envelope{
+		EventID:        "evt-2",
+		Source:         "slack",
+		SourceSession:  "",
+		Topic:          "notifications.slack.T1.C1.mention",
+		PayloadSummary: "no sender",
+	}
+	got := deliverer.Text(item)
+	want := "[NOTIFICATION from slack]\nno sender\n\nTopic: notifications.slack.T1.C1.mention\nEvent ID: evt-2"
+	if got != want {
+		t.Errorf("Text() mismatch\ngot:  %q\nwant: %q", got, want)
+	}
+	if strings.Contains(got, "envoy_send") {
+		t.Error("Text() should NOT contain reply instruction when SourceSession is empty")
+	}
 }
 
 func TestDeliver_NoAgentField(t *testing.T) {


### PR DESCRIPTION
Closes #246

## Summary

- When `SourceSession` is non-empty, `Deliverer.Text()` now appends a reply instruction as the final line: `Use envoy_send(target_session="<session_id>", message="...") to reply to this message.`
- The existing `(reply-to: <session_id>)` header is preserved unchanged
- When `SourceSession` is empty, no reply instruction is appended (format unchanged)
- Added exact-format unit tests (`TestText_WithSourceSession`, `TestText_WithoutSourceSession`) in `session_test.go`
- Tightened `TestE2E_ReplyToInBody` integration test to assert exact instruction line, not just substring presence