### PR TITLE
sjawhar-legion-249: deduplicate worker completion notifications

### DIFF
--- a/.opencode/skills/legion-controller/SKILL.md
+++ b/.opencode/skills/legion-controller/SKILL.md
@@ -87,7 +87,7 @@ The controller MUST NOT ask "should I continue?" for routine operations. Act on 
 
 ## Envoy Notifications
 
-The daemon automatically subscribes the controller to `notifications.legion.controller` and `notifications.agent.<session_id>` at startup. Workers broadcast to `notifications.legion.controller` when they finish a phase, giving you instant notification instead of waiting for the next polling cycle. The `worker-done` label remains the source of truth — Envoy is a speed optimization.
+The daemon automatically subscribes the controller to `notifications.agent.<session_id>` at startup. Workers send completion notifications directly to the controller session via `envoy_send` (the controller session ID is included in the dispatch prompt's ENVOY section). This gives you instant notification instead of waiting for the next polling cycle. The `worker-done` label remains the source of truth — Envoy is a speed optimization.
 
 ## Algorithm
 

--- a/.opencode/skills/legion-retro/SKILL.md
+++ b/.opencode/skills/legion-retro/SKILL.md
@@ -274,8 +274,8 @@ Then remove `worker-active`:
 - **GitHub:** `gh issue edit $ISSUE_NUMBER --remove-label "worker-active" -R $OWNER/$REPO`
 - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current labels without "worker-active"])`
 
-Then notify the controller via Envoy (best-effort):
+Then notify the controller via Envoy (best-effort, exactly one notification):
 ```
-envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER retro completed. Ready for merge.")
+envoy_send(target_session="$CONTROLLER_SESSION_ID", message="Worker done: $ISSUE_NUMBER retro completed. Ready for merge.")
 ```
-If `envoy_publish` fails, continue — the label is the source of truth.
+If `envoy_send` fails, continue — the label is the source of truth.

--- a/.opencode/skills/legion-worker/SKILL.md
+++ b/.opencode/skills/legion-worker/SKILL.md
@@ -35,7 +35,7 @@ Use the **backend** from your prompt to choose GitHub CLI or Linear MCP commands
 4. **Signal completion (MOST IMPORTANT)** — before you stop for ANY reason, you MUST: push your work, add `worker-done` label, remove `worker-active` label. If you skip this, the issue silently stalls. Create a todo for this at session start (see Required Startup Todos below).
 4.5. **Write handoff data before signaling.** Each workflow has a handoff write step — you MUST attempt it before adding `worker-done`. The `|| true` means CLI failures don't block you, but skipping the attempt is not acceptable. If the write fails, note it in your exit comment.
 5. **Clean up on exit** - remove `worker-active` label when exiting (done or blocked)
-6. **Notify the controller via Envoy** — after adding `worker-done`, broadcast a completion notification so the controller doesn't have to wait for its next polling cycle. Use `envoy_publish(topic="notifications.legion.controller", message="Worker done: <issue> <mode> <outcome>")`. If `envoy_publish` fails, that's fine — the label is the source of truth.
+6. **Notify the controller via Envoy** — after adding `worker-done`, send exactly one completion notification so the controller doesn't have to wait for its next polling cycle. Use `envoy_send(target_session="$CONTROLLER_SESSION_ID", message="Worker done: <issue> <mode> <outcome>")`. The controller session ID (`$CONTROLLER_SESSION_ID`) is provided in your dispatch prompt's ENVOY section. If `envoy_send` fails, that's fine — the label is the source of truth. **Do not also call `envoy_publish` — one notification only.**
 
 ## Skill Discipline
 
@@ -183,9 +183,9 @@ Then update labels:
 
 Then notify the controller via Envoy (best-effort, non-blocking):
 ```
-envoy_publish(topic="notifications.legion.controller", message="Worker done: <issue-id> <mode> completed")
+envoy_send(target_session="$CONTROLLER_SESSION_ID", message="Worker done: <issue-id> <mode> completed")
 ```
-If `envoy_publish` fails, continue — the label is the source of truth.
+If `envoy_send` fails, continue — the label is the source of truth.
 
 ## Mode Routing
 

--- a/.opencode/skills/legion-worker/workflows/architect.md
+++ b/.opencode/skills/legion-worker/workflows/architect.md
@@ -240,11 +240,11 @@ linear_linear(action="update",
 - **GitHub:** `gh issue edit $ISSUE_NUMBER --remove-label "worker-active" -R $OWNER/$REPO`
 - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current labels without "worker-active"])`
 
-Then notify the controller via Envoy (best-effort):
+Then notify the controller via Envoy (best-effort, exactly one notification):
 ```
-envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER architect completed. Sub-issues ready for planning.")
+envoy_send(target_session="$CONTROLLER_SESSION_ID", message="Worker done: $ISSUE_NUMBER architect completed. Sub-issues ready for planning.")
 ```
-If `envoy_publish` fails, continue — the label is the source of truth.
+If `envoy_send` fails, continue — the label is the source of truth.
 
 ## Common Mistakes
 

--- a/.opencode/skills/legion-worker/workflows/implement.md
+++ b/.opencode/skills/legion-worker/workflows/implement.md
@@ -406,11 +406,11 @@ current_labels = [l.name for l in issue.labels if l.name != "worker-active"]
 linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "worker-done"])
 ```
 
-Then notify the controller via Envoy (best-effort):
+Then notify the controller via Envoy (best-effort, exactly one notification):
 ```
-envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER implement completed. PR ready for testing.")
+envoy_send(target_session="$CONTROLLER_SESSION_ID", message="Worker done: $ISSUE_NUMBER implement completed. PR ready for testing.")
 ```
-If `envoy_publish` fails, continue — the label is the source of truth.
+If `envoy_send` fails, continue — the label is the source of truth.
 
 ---
 
@@ -546,8 +546,8 @@ current_labels = [l.name for l in issue.labels if l.name != "worker-active"]
 linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "worker-done"])
 ```
 
-Then notify the controller via Envoy (best-effort):
+Then notify the controller via Envoy (best-effort, exactly one notification):
 ```
-envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER implement completed after changes. PR ready for re-testing.")
+envoy_send(target_session="$CONTROLLER_SESSION_ID", message="Worker done: $ISSUE_NUMBER implement completed after changes. PR ready for re-testing.")
 ```
-If `envoy_publish` fails, continue — the label is the source of truth.
+If `envoy_send` fails, continue — the label is the source of truth.

--- a/.opencode/skills/legion-worker/workflows/plan.md
+++ b/.opencode/skills/legion-worker/workflows/plan.md
@@ -408,11 +408,11 @@ Then remove `worker-active`:
 - **GitHub:** `gh issue edit $ISSUE_NUMBER --remove-label "worker-active" -R $OWNER/$REPO`
 - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current labels without "worker-active"])`
 
-Then notify the controller via Envoy (best-effort):
+Then notify the controller via Envoy (best-effort, exactly one notification):
 ```
-envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER plan completed. Ready for implementation.")
+envoy_send(target_session="$CONTROLLER_SESSION_ID", message="Worker done: $ISSUE_NUMBER plan completed. Ready for implementation.")
 ```
-If `envoy_publish` fails, continue — the label is the source of truth.
+If `envoy_send` fails, continue — the label is the source of truth.
 
 **CRITICAL:** Only add `worker-done` after successfully posting the plan. Never add this label if:
 - Requirements were unclear and could not be resolved (use `user-input-needed` instead)

--- a/.opencode/skills/legion-worker/workflows/review.md
+++ b/.opencode/skills/legion-worker/workflows/review.md
@@ -265,11 +265,11 @@ current_labels = [l.name for l in issue.labels if l.name != "worker-active"]
 linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "worker-done"])
 ```
 
-Then notify the controller via Envoy (best-effort):
+Then notify the controller via Envoy (best-effort, exactly one notification):
 ```
-envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER review completed. See PR for review outcome.")
+envoy_send(target_session="$CONTROLLER_SESSION_ID", message="Worker done: $ISSUE_NUMBER review completed. See PR for review outcome.")
 ```
-If `envoy_publish` fails, continue — the label is the source of truth.
+If `envoy_send` fails, continue — the label is the source of truth.
 
 ## Common Mistakes
 

--- a/.opencode/skills/legion-worker/workflows/test.md
+++ b/.opencode/skills/legion-worker/workflows/test.md
@@ -332,9 +332,9 @@ current_labels = [l.name for l in issue.labels if l.name != "worker-active"]
 linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "worker-done", "test-passed"])
 ```
 
-Then notify the controller via Envoy (best-effort):
+Then notify the controller via Envoy (best-effort, exactly one notification):
 ```
-envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER test passed.")
+envoy_send(target_session="$CONTROLLER_SESSION_ID", message="Worker done: $ISSUE_NUMBER test passed.")
 ```
 
 **If any criterion fails:**
@@ -356,12 +356,12 @@ current_labels = [l.name for l in issue.labels if l.name != "worker-active"]
 linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "worker-done", "test-failed"])
 ```
 
-Then notify the controller via Envoy (best-effort):
+Then notify the controller via Envoy (best-effort, exactly one notification):
 ```
-envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER test failed. See PR comments for details.")
+envoy_send(target_session="$CONTROLLER_SESSION_ID", message="Worker done: $ISSUE_NUMBER test failed. See PR comments for details.")
 ```
 
-If `envoy_publish` fails, continue — the label is the source of truth.
+If `envoy_send` fails, continue — the label is the source of truth.
 
 ## Blocking on User Input
 


### PR DESCRIPTION
Closes #249

## Summary

Workers were sending 2-3 duplicate completion notifications per phase: `envoy_send` (verbose), `envoy_send` (short), and `envoy_publish` to `notifications.legion.controller`. This created 3x notification noise for the controller.

**Fix:** Changed all worker workflow files and the worker SKILL.md to use exactly one `envoy_send(target_session="$CONTROLLER_SESSION_ID", ...)` per completion. Removed all `envoy_publish` calls from worker exit sections.

### Files changed
- `.opencode/skills/legion-worker/SKILL.md` — Essential Rule #6 and Exiting section: `envoy_publish` → `envoy_send`, added "one notification only" guidance
- `.opencode/skills/legion-worker/workflows/implement.md` — Both exit sections (fresh + address-comments)
- `.opencode/skills/legion-worker/workflows/test.md` — Both exit sections (pass + fail)
- `.opencode/skills/legion-worker/workflows/review.md` — Exit section
- `.opencode/skills/legion-worker/workflows/architect.md` — Completion signals section
- `.opencode/skills/legion-worker/workflows/plan.md` — Signal completion section
- `.opencode/skills/legion-retro/SKILL.md` — Exit section
- `.opencode/skills/legion-controller/SKILL.md` — Updated Envoy Notifications description to reflect `envoy_send` pattern