### PR TITLE
sjawhar-legion-253: install envoy-plugin from GitHub release instead of npm

### DIFF
--- a/packages/envoy-plugin/README.md
+++ b/packages/envoy-plugin/README.md
@@ -20,8 +20,14 @@ Do not use workspace slugs like `trajectorylabs` in the topic path.
 ## Sync to another machine
 
 ```bash
-cd ~/legion/default/packages/envoy-plugin
-./scripts/sync-host.sh sami@sami
+# From the repo root:
+./packages/envoy-plugin/scripts/sync-host.sh sami@sami
+
+# Or via the combined envoy sync:
+./scripts/sync-envoy-host.sh sami@sami
 ```
 
-This syncs the built plugin dist and the dotfiles shim to the target host.
+The sync script downloads the latest envoy-plugin release tarball from GitHub,
+extracts it to `~/legion/default/packages/envoy-plugin/` on the remote host, and
+updates the remote's `opencode.json` to use a `file://` reference instead of the
+npm package. Requires `gh` CLI on the machine running the script.

--- a/packages/envoy-plugin/scripts/sync-host.sh
+++ b/packages/envoy-plugin/scripts/sync-host.sh
@@ -2,7 +2,55 @@
 set -euo pipefail
 
 host="${1:?usage: sync-host.sh user@host}"
-root="$(cd "$(dirname "$0")/../../.." && pwd)"
 
-rsync -az "$root/packages/envoy-plugin/dist/" "$host:~/legion/default/packages/envoy-plugin/dist/"
-rsync -az "$HOME/.dotfiles/opencode/plugins/envoy.ts" "$host:~/.dotfiles/opencode/plugins/envoy.ts"
+PLUGIN_DIR="legion/default/packages/envoy-plugin"
+PLUGIN_REF="file://{env:HOME}/${PLUGIN_DIR}/dist/index.js"
+REPO="sjawhar/legion"
+
+# Find latest envoy release tag
+tag=$(gh release list --repo "$REPO" --limit 10 --json tagName \
+  --jq '[.[] | select(.tagName | startswith("legion-envoy-"))][0].tagName')
+if [ -z "$tag" ]; then
+  echo "ERROR: No legion-envoy release found" >&2
+  exit 1
+fi
+echo "Using release: $tag"
+
+# Download plugin tarball
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+gh release download "$tag" \
+  --repo "$REPO" \
+  --pattern '*.tgz' \
+  --dir "$tmpdir" \
+  --clobber
+
+tgz=$(find "$tmpdir" -name '*.tgz' -print -quit)
+if [ -z "$tgz" ]; then
+  echo "ERROR: No .tgz found in release $tag" >&2
+  exit 1
+fi
+echo "Downloaded: $(basename "$tgz")"
+
+# Install on remote: extract tarball (strip package/ prefix from npm pack output)
+ssh "$host" "rm -rf ~/${PLUGIN_DIR} && mkdir -p ~/${PLUGIN_DIR}"
+scp -q "$tgz" "$host:/tmp/envoy-plugin.tgz"
+ssh "$host" "tar xzf /tmp/envoy-plugin.tgz --strip-components=1 -C ~/${PLUGIN_DIR} && rm /tmp/envoy-plugin.tgz"
+echo "Installed plugin to ~/${PLUGIN_DIR}"
+
+# Update opencode.json: replace npm package reference with file:// path
+# Resolves symlinks so we don't clobber dotfiles symlink structure
+ssh "$host" "
+  CONFIG=\$(readlink -f \$HOME/.config/opencode/opencode.json 2>/dev/null || echo \$HOME/.config/opencode/opencode.json)
+  if [ -f \"\$CONFIG\" ]; then
+    jq --arg ref '$PLUGIN_REF' \\
+      '(.plugin // []) |= [.[] | if (test(\"opencode-legion-envoy\") and (test(\"^file://\") | not)) then \$ref else . end]' \\
+      \"\$CONFIG\" > /tmp/opencode.json.tmp && mv /tmp/opencode.json.tmp \"\$CONFIG\"
+    echo \"Updated opencode.json: \$CONFIG\"
+  else
+    echo \"WARNING: opencode.json not found at \$CONFIG — add plugin manually: $PLUGIN_REF\"
+  fi
+"
+
+echo "Done: $host envoy-plugin synced from release $tag"

--- a/scripts/sync-envoy-host.sh
+++ b/scripts/sync-envoy-host.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 host="${1:?usage: sync-envoy-host.sh user@host}"
 root="$(cd "$(dirname "$0")/.." && pwd)"
 
-ssh "$host" 'mkdir -p ~/legion/default/packages/envoy ~/legion/default/packages/envoy-plugin/dist ~/.dotfiles/opencode/plugins'
+ssh "$host" 'mkdir -p ~/legion/default/packages/envoy'
 
 "$root/packages/envoy/deploy/scripts/sync-host.sh" "$host"
 "$root/packages/envoy-plugin/scripts/sync-host.sh" "$host"


### PR DESCRIPTION
Closes #253

## Summary

Updates the envoy-plugin sync scripts to install from GitHub release artifacts instead of the stale npm package (`@sjawhar/opencode-legion-envoy@0.1.0-alpha.0`).

**Changes:**
- **`packages/envoy-plugin/scripts/sync-host.sh`**: Rewritten to download the latest `legion-envoy-*` release tarball from GitHub, extract it on the remote host, and update the remote's `opencode.json` to use a `file://` reference instead of the npm package
- **`scripts/sync-envoy-host.sh`**: Removed stale `mkdir` for `~/.dotfiles/opencode/plugins` and `envoy-plugin/dist` (no longer needed — the sync script handles extraction)
- **`packages/envoy-plugin/README.md`**: Updated docs to reflect the new sync approach