### PR TITLE
sjawhar-legion-174: add POST /workers/prune endpoint for bulk worker cleanup

### DIFF
--- a/.opencode/skills/legion-controller/SKILL.md
+++ b/.opencode/skills/legion-controller/SKILL.md
@@ -497,11 +497,22 @@ component. When in doubt, route to Backlog.
 ### 6. Cleanup Done
 
 For Done issues without live workers:
+
+1. Remove workspace:
 ```bash
 curl -s -X DELETE "http://127.0.0.1:$LEGION_DAEMON_PORT/workers/$WORKER_ID/workspace" \
   -H 'Content-Type: application/json' \
   -d '{"repo": "'"'$OWNER/$REPO'"'"}'
 ```
+
+2. Prune all worker entries and crash history for the issue:
+```bash
+curl -s -X POST "http://127.0.0.1:$LEGION_DAEMON_PORT/workers/prune" \
+  -H 'Content-Type: application/json' \
+  -d '{"issueIds": ["'$ISSUE_ID'"]}'
+```
+
+Both calls are idempotent. The prune call removes all worker modes for the issue, their crash history, and the dispatch validation cache.
 
 ### 7. Write Heartbeat
 

--- a/packages/daemon/src/daemon/AGENTS.md
+++ b/packages/daemon/src/daemon/AGENTS.md
@@ -13,6 +13,7 @@ HTTP server + shared `opencode serve` instance. One long-lived serve process han
 | `PATCH` | `/workers/:id` | Update status (`running`, `dead`) |
 | `DELETE` | `/workers/:id` | Remove tracking (session goes idle naturally) |
 | `GET` | `/workers/:id/status` | Proxy to worker's OpenCode `/session/status` |
+| `POST` | `/workers/prune` | Bulk-remove workers + crash history by issue ID — `{issueIds: string[]}` → `{pruned, crashHistoryPruned}` |
 | `POST` | `/shutdown` | Graceful shutdown — stop shared serve, persist state |
 
 **Worker ID format:** `{issueId}-{mode}` lowercase (e.g., `eng-21-implement`)

--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -651,7 +651,7 @@ describe("daemon server", () => {
     });
 
     expect(cleanupResponse.status).toBe(200);
-    expect(await cleanupResponse.json()).toEqual({ status: "cleaned" });
+    expect(await cleanupResponse.json()).toEqual({ status: "cleaned", workerRemoved: true });
     expect(runJjCalls).toEqual([
       ["workspace", "forget", "eng-79", "-R", "/tmp/legion-data/repos/github.com/acme/widgets"],
     ]);
@@ -2057,6 +2057,262 @@ describe("daemon server", () => {
       const body = (await response.json()) as Record<string, unknown>;
       expect(body).not.toHaveProperty("promptDelivered");
       expect(sendPromptCalls).toHaveLength(0);
+    });
+  });
+
+  describe("POST /workers/prune", () => {
+    it("prunes all workers for given issue IDs", async () => {
+      await startTestServer();
+      // Create workers for two issues with multiple modes
+      await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({ issueId: "ENG-100", mode: "implement", workspace: "/tmp/w1" }),
+      });
+      await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({ issueId: "ENG-100", mode: "review", workspace: "/tmp/w2" }),
+      });
+      await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({ issueId: "ENG-200", mode: "implement", workspace: "/tmp/w3" }),
+      });
+
+      const pruneResponse = await requestJson("/workers/prune", {
+        method: "POST",
+        body: JSON.stringify({ issueIds: ["ENG-100"] }),
+      });
+      expect(pruneResponse.status).toBe(200);
+      const pruneBody = (await pruneResponse.json()) as {
+        pruned: string[];
+        crashHistoryPruned: string[];
+      };
+      expect(pruneBody.pruned.sort()).toEqual(["eng-100-implement", "eng-100-review"]);
+
+      // ENG-200 worker should still exist
+      const listResponse = await requestJson("/workers");
+      const workers = (await listResponse.json()) as WorkerEntry[];
+      expect(workers).toHaveLength(1);
+      expect(workers[0].id).toBe("eng-200-implement");
+    });
+
+    it("prunes crash history for matching workers", async () => {
+      await startTestServer();
+      // Create worker, mark dead with max crashes (creates crash history entry)
+      const createResponse = await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({ issueId: "ENG-300", mode: "implement", workspace: "/tmp/w" }),
+      });
+      const created = (await createResponse.json()) as { id: string };
+
+      await requestJson(`/workers/${created.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({
+          status: "dead",
+          crashCount: 3,
+          lastCrashAt: new Date().toISOString(),
+        }),
+      });
+
+      // Prune the issue (worker is dead in map + has crash history)
+      const pruneResponse = await requestJson("/workers/prune", {
+        method: "POST",
+        body: JSON.stringify({ issueIds: ["ENG-300"] }),
+      });
+      expect(pruneResponse.status).toBe(200);
+      const pruneBody = (await pruneResponse.json()) as {
+        pruned: string[];
+        crashHistoryPruned: string[];
+      };
+      expect(pruneBody.pruned).toEqual(["eng-300-implement"]);
+      expect(pruneBody.crashHistoryPruned).toEqual(["eng-300-implement"]);
+
+      // Verify crash history is gone — respawn succeeds despite previous 3 crashes
+      const respawn = await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({ issueId: "ENG-300", mode: "implement", workspace: "/tmp/w" }),
+      });
+      expect(respawn.status).toBe(200);
+    });
+    it("returns empty lists when no workers match", async () => {
+      await startTestServer();
+      await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({ issueId: "ENG-400", mode: "implement", workspace: "/tmp/w" }),
+      });
+
+      const pruneResponse = await requestJson("/workers/prune", {
+        method: "POST",
+        body: JSON.stringify({ issueIds: ["ENG-999"] }),
+      });
+      expect(pruneResponse.status).toBe(200);
+      const body = (await pruneResponse.json()) as {
+        pruned: string[];
+        crashHistoryPruned: string[];
+      };
+      expect(body.pruned).toEqual([]);
+      expect(body.crashHistoryPruned).toEqual([]);
+
+      // Original worker still exists
+      const listResponse = await requestJson("/workers");
+      const workers = (await listResponse.json()) as WorkerEntry[];
+      expect(workers).toHaveLength(1);
+    });
+
+    it("rejects missing issueIds field", async () => {
+      await startTestServer();
+      const response = await requestJson("/workers/prune", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+      expect(response.status).toBe(400);
+    });
+
+    it("rejects non-array issueIds", async () => {
+      await startTestServer();
+      const response = await requestJson("/workers/prune", {
+        method: "POST",
+        body: JSON.stringify({ issueIds: "not-an-array" }),
+      });
+      expect(response.status).toBe(400);
+    });
+
+    it("handles case-insensitive issue ID matching", async () => {
+      await startTestServer();
+      await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({ issueId: "ENG-500", mode: "implement", workspace: "/tmp/w" }),
+      });
+
+      // Prune with different casing
+      const pruneResponse = await requestJson("/workers/prune", {
+        method: "POST",
+        body: JSON.stringify({ issueIds: ["eng-500"] }),
+      });
+      expect(pruneResponse.status).toBe(200);
+      const body = (await pruneResponse.json()) as { pruned: string[] };
+      expect(body.pruned).toEqual(["eng-500-implement"]);
+    });
+
+    it("persists state after pruning", async () => {
+      await startTestServer();
+      await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({ issueId: "ENG-600", mode: "implement", workspace: "/tmp/w" }),
+      });
+
+      await requestJson("/workers/prune", {
+        method: "POST",
+        body: JSON.stringify({ issueIds: ["ENG-600"] }),
+      });
+
+      // Read state file directly to verify persistence
+      const raw = await readFile(path.join(tempDir ?? os.tmpdir(), "workers.json"), "utf-8");
+      const parsed = JSON.parse(raw) as PersistedWorkerState;
+      expect(Object.keys(parsed.workers)).toHaveLength(0);
+    });
+
+    it("prunes workers loaded from pre-existing state file", async () => {
+      const existing: WorkerEntry = {
+        id: "eng-700-implement",
+        port: sharedServePort,
+        sessionId: computeSessionId(legionId, "eng-700", "implement"),
+        workspace: "/tmp",
+        startedAt: "2026-02-01T00:00:00.000Z",
+        status: "running",
+        crashCount: 0,
+        lastCrashAt: null,
+      };
+      await startTestServer({
+        state: {
+          workers: { [existing.id]: existing },
+          crashHistory: {
+            "eng-700-implement": { crashCount: 1, lastCrashAt: "2026-01-01T00:00:00.000Z" },
+          },
+        },
+      });
+
+      const pruneResponse = await requestJson("/workers/prune", {
+        method: "POST",
+        body: JSON.stringify({ issueIds: ["eng-700"] }),
+      });
+      expect(pruneResponse.status).toBe(200);
+      const body = (await pruneResponse.json()) as {
+        pruned: string[];
+        crashHistoryPruned: string[];
+      };
+      expect(body.pruned).toEqual(["eng-700-implement"]);
+      expect(body.crashHistoryPruned).toEqual(["eng-700-implement"]);
+
+      // Verify workers list is empty
+      const listResponse = await requestJson("/workers");
+      const workers = (await listResponse.json()) as WorkerEntry[];
+      expect(workers).toHaveLength(0);
+    });
+
+    it("returns 404 for non-POST methods", async () => {
+      await startTestServer();
+      const response = await requestJson("/workers/prune");
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("DELETE /workers/:id/workspace prunes worker", () => {
+    it("removes worker entry after workspace cleanup", async () => {
+      const paths: LegionPaths = {
+        dataDir: "/tmp/legion-data",
+        stateDir: "/tmp/legion-state",
+        reposDir: "/tmp/legion-data/repos",
+        workspacesDir: "/tmp/legion-data/workspaces",
+        legionsFile: "/tmp/legion-state/legions.json",
+        forLegion: (projectId: string) => ({
+          legionStateDir: `/tmp/legion-state/legions/${projectId}`,
+          workersFile: `/tmp/legion-state/legions/${projectId}/workers.json`,
+          feedbackFile: `/tmp/legion-state/legions/${projectId}/feedback.jsonl`,
+          logDir: `/tmp/legion-state/legions/${projectId}/logs`,
+          workspacesDir: `/tmp/legion-data/workspaces/${projectId}`,
+        }),
+        repoClonePath: (host: string, owner: string, repo: string) =>
+          `/tmp/legion-data/repos/${host}/${owner}/${repo}`,
+      };
+      const repoManagerDeps: RepoManagerDeps = {
+        runJj: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+        exists: async () => true,
+        rmDir: async () => {},
+        symlink: async () => {},
+      };
+      await startTestServer({ paths, repoManagerDeps });
+
+      // Create a worker with repo context
+      const createRes = await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({
+          issueId: "acme-widgets-800",
+          mode: "implement",
+          repo: "acme/widgets",
+          issueNumber: 800,
+        }),
+      });
+      expect(createRes.status).toBe(200);
+      const created = (await createRes.json()) as { id: string };
+
+      // Verify worker exists
+      const before = await requestJson("/workers");
+      const workersBefore = (await before.json()) as WorkerEntry[];
+      expect(workersBefore).toHaveLength(1);
+
+      // Delete workspace — should also remove the worker
+      const deleteRes = await requestJson(`/workers/${created.id}/workspace`, {
+        method: "DELETE",
+        body: JSON.stringify({ repo: "acme/widgets" }),
+      });
+      expect(deleteRes.status).toBe(200);
+      const deleteBody = (await deleteRes.json()) as { status: string; workerRemoved: boolean };
+      expect(deleteBody.workerRemoved).toBe(true);
+
+      // Verify worker is gone
+      const after = await requestJson("/workers");
+      const workersAfter = (await after.json()) as WorkerEntry[];
+      expect(workersAfter).toHaveLength(0);
     });
   });
 });

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -624,7 +624,13 @@ export function startServer(opts: ServerOptions): {
             return serverError(`Failed to cleanup workspace: ${(error as Error).message}`);
           }
 
-          return jsonResponse({ status: "cleaned" });
+          // Also remove the worker entry — workspace deletion means the issue is done
+          workers.delete(workerId);
+          crashHistory.delete(workerId);
+          await persistState();
+          unsubscribeWorkerFromEnvoy(entry.sessionId);
+
+          return jsonResponse({ status: "cleaned", workerRemoved: true });
         }
 
         if (segments.length === 3 && segments[0] === "workers" && segments[2] === "env") {
@@ -649,6 +655,65 @@ export function startServer(opts: ServerOptions): {
             }
           }
           return jsonResponse({ env: safeEnv });
+        }
+
+        if (segments.length === 2 && segments[0] === "workers" && segments[1] === "prune") {
+          await stateLoaded;
+          if (method !== "POST") {
+            return notFound();
+          }
+          let payload: Record<string, unknown>;
+          try {
+            payload = await parseJson(request);
+          } catch {
+            return badRequest("invalid_json");
+          }
+
+          const issueIds = payload.issueIds;
+          if (!Array.isArray(issueIds) || !issueIds.every((id) => typeof id === "string")) {
+            return badRequest("issueIds must be an array of strings");
+          }
+
+          const normalizedIssueIds = new Set(issueIds.map((id: string) => id.toLowerCase()));
+          const prunedWorkers: string[] = [];
+          const prunedCrashHistory: string[] = [];
+          const prunedSessionIds: string[] = [];
+
+          for (const [workerId, entry] of workers.entries()) {
+            const workerIssueId = extractIssueIdFromWorkerId(workerId);
+            if (workerIssueId && normalizedIssueIds.has(workerIssueId.toLowerCase())) {
+              prunedWorkers.push(workerId);
+              prunedSessionIds.push(entry.sessionId);
+            }
+          }
+          for (const id of prunedWorkers) {
+            workers.delete(id);
+          }
+
+          for (const crashId of [...crashHistory.keys()]) {
+            const crashIssueId = extractIssueIdFromWorkerId(crashId);
+            if (crashIssueId && normalizedIssueIds.has(crashIssueId.toLowerCase())) {
+              prunedCrashHistory.push(crashId);
+              crashHistory.delete(crashId);
+            }
+          }
+
+          for (const issueId of normalizedIssueIds) {
+            issueStateCache.delete(issueId);
+          }
+
+          if (prunedWorkers.length > 0 || prunedCrashHistory.length > 0) {
+            await persistState();
+          }
+
+          for (const sessionId of prunedSessionIds) {
+            unsubscribeWorkerFromEnvoy(sessionId);
+          }
+
+          return jsonResponse({
+            pruned: prunedWorkers,
+            crashHistoryPruned: prunedCrashHistory,
+          });
         }
 
         if (segments.length === 2 && segments[0] === "workers") {

--- a/packages/daemon/src/state/__tests__/fetch.test.ts
+++ b/packages/daemon/src/state/__tests__/fetch.test.ts
@@ -28,9 +28,15 @@ describe("getLiveWorkers", () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = mock(
       async () =>
-        new Response(JSON.stringify([{ id: "ENG-21-implement" }, { id: "ENG-22-plan" }]), {
-          status: 200,
-        })
+        new Response(
+          JSON.stringify([
+            { id: "ENG-21-implement", status: "running" },
+            { id: "ENG-22-plan", status: "running" },
+          ]),
+          {
+            status: 200,
+          }
+        )
     ) as unknown as typeof fetch;
 
     try {
@@ -48,9 +54,15 @@ describe("getLiveWorkers", () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = mock(
       async () =>
-        new Response(JSON.stringify([{ id: "eng-21-implement" }, { id: "Eng-22-plan" }]), {
-          status: 200,
-        })
+        new Response(
+          JSON.stringify([
+            { id: "eng-21-implement", status: "running" },
+            { id: "Eng-22-plan", status: "running" },
+          ]),
+          {
+            status: 200,
+          }
+        )
     ) as unknown as typeof fetch;
 
     try {
@@ -110,15 +122,41 @@ describe("getLiveWorkers", () => {
     }
   });
 
-  it("handles workers without status field (backwards compat)", async () => {
+  it("excludes workers without status field (stale entries)", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = mock(
-      async () => new Response(JSON.stringify([{ id: "eng-21-implement" }]), { status: 200 })
+      async () =>
+        new Response(
+          JSON.stringify([{ id: "eng-21-implement" }, { id: "eng-22-plan", status: "running" }]),
+          { status: 200 }
+        )
     ) as unknown as typeof fetch;
 
     try {
       const result = await getLiveWorkers("http://localhost:3000");
-      expect(result).toEqual({ "ENG-21": { mode: "implement", status: "running" } });
+      // Workers without status are stale — only running/starting count as live
+      expect(result).toEqual({ "ENG-22": { mode: "plan", status: "running" } });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("excludes workers with null status", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          JSON.stringify([
+            { id: "eng-21-implement", status: null },
+            { id: "eng-22-plan", status: "running" },
+          ]),
+          { status: 200 }
+        )
+    ) as unknown as typeof fetch;
+
+    try {
+      const result = await getLiveWorkers("http://localhost:3000");
+      expect(result).toEqual({ "ENG-22": { mode: "plan", status: "running" } });
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -172,8 +210,8 @@ describe("getLiveWorkers", () => {
       async () =>
         new Response(
           JSON.stringify([
-            { id: "TEAM-PROJECT-123-implement" },
-            { id: "MY-COMPLEX-ISSUE-456-plan" },
+            { id: "TEAM-PROJECT-123-implement", status: "running" },
+            { id: "MY-COMPLEX-ISSUE-456-plan", status: "running" },
           ]),
           { status: 200 }
         )
@@ -750,7 +788,10 @@ describe("fetchAllIssueData", () => {
   it("fetches data for issues", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = mock(
-      async () => new Response(JSON.stringify([{ id: "ENG-21-implement" }]), { status: 200 })
+      async () =>
+        new Response(JSON.stringify([{ id: "ENG-21-implement", status: "running" }]), {
+          status: 200,
+        })
     ) as unknown as typeof fetch;
 
     try {

--- a/packages/daemon/src/state/fetch.ts
+++ b/packages/daemon/src/state/fetch.ts
@@ -113,7 +113,7 @@ export async function getLiveWorkers(
     const result: Record<string, { mode: string; status: string }> = {};
 
     for (const worker of workers) {
-      if (worker.status && worker.status !== "running" && worker.status !== "starting") {
+      if (worker.status !== "running" && worker.status !== "starting") {
         continue;
       }
 


### PR DESCRIPTION
Closes #174

## Summary

Adds a `POST /workers/prune` endpoint to the daemon HTTP API and **wires three cleanup triggers** so workers are actually removed from `workers.json` when they should be.

### Three Cleanup Triggers

| Trigger | Mechanism | Files |
|---------|-----------|-------|
| **Issue reaches Done** | Controller skill's Cleanup Done step now calls `POST /workers/prune` after workspace deletion | `legion-controller/SKILL.md` |
| **Workspace deleted** | `DELETE /workers/:id/workspace` now also removes the worker entry, crash history, and Envoy subscription | `server.ts` |
| **Session unreachable** | Fixed null-status bug in `getLiveWorkers()` — workers with `null`/missing status were incorrectly counted as live, blocking cleanup | `fetch.ts` |

### New Endpoint

**`POST /workers/prune`**
- **Request:** `{ issueIds: string[] }` — issue IDs whose workers should be removed
- **Response:** `{ pruned: string[], crashHistoryPruned: string[] }` — IDs of removed entries
- Case-insensitive issue ID matching
- Clears workers, crash history, dispatch validation cache, and Envoy subscriptions
- Only persists state if something was actually pruned

### Changes

- **`packages/daemon/src/daemon/server.ts`** — New `POST /workers/prune` handler + workspace delete now also removes worker
- **`packages/daemon/src/daemon/__tests__/server.test.ts`** — 10 new test cases (prune + workspace-prune)
- **`packages/daemon/src/state/fetch.ts`** — Fix null-status bug in `getLiveWorkers()`
- **`packages/daemon/src/state/__tests__/fetch.test.ts`** — Updated tests for null-status fix + new null/missing status tests
- **`.opencode/skills/legion-controller/SKILL.md`** — Cleanup Done step now calls prune endpoint
- **`packages/daemon/src/daemon/AGENTS.md`** — Documented new endpoint