### PR TITLE
sjawhar-legion-281: fix envoy plugin port resolution for non-default serve ports

### DIFF
--- a/packages/envoy-plugin/src/__tests__/port.test.ts
+++ b/packages/envoy-plugin/src/__tests__/port.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, mock } from "bun:test";
+import { resolvePort } from "../port";
+
+describe("resolvePort", () => {
+  const noopExec = (() => {
+    throw new Error("ss not available");
+  }) as typeof import("node:child_process").execFileSync;
+
+  const ssOutput = (pid: number, port: number) =>
+    [
+      "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+      `LISTEN 0      511    127.0.0.1:${port}  0.0.0.0:*  users:(("bun",pid=${pid},fd=6))`,
+      "",
+    ].join("\n");
+
+  describe("URL port extraction", () => {
+    it("returns port from standard non-default URL", () => {
+      expect(resolvePort(new URL("http://127.0.0.1:4096"), noopExec)).toBe(4096);
+    });
+
+    it("returns port for high serve ports", () => {
+      expect(resolvePort(new URL("http://127.0.0.1:13381"), noopExec)).toBe(13381);
+    });
+
+    it("returns port for localhost URLs", () => {
+      expect(resolvePort(new URL("http://localhost:4096"), noopExec)).toBe(4096);
+    });
+
+    it("returns port for IPv6 URLs", () => {
+      expect(resolvePort(new URL("http://[::1]:4096"), noopExec)).toBe(4096);
+    });
+  });
+
+  describe("ss fallback", () => {
+    it("uses ss when URL has no port (default HTTP)", () => {
+      const exec = mock(() => ssOutput(process.pid, 4096));
+      expect(resolvePort(new URL("http://127.0.0.1"), exec as never)).toBe(4096);
+      expect(exec).toHaveBeenCalledWith("ss", ["-tlnp"], { encoding: "utf-8" });
+    });
+
+    it("uses ss when URL port is 0", () => {
+      // URL("http://127.0.0.1:0").port is "0", which is not > 0
+      const exec = mock(() => ssOutput(process.pid, 13381));
+      expect(resolvePort(new URL("http://127.0.0.1:0"), exec as never)).toBe(13381);
+    });
+
+    it("ignores ss lines with different PIDs", () => {
+      const exec = mock(() => ssOutput(99999, 4096));
+      expect(resolvePort(new URL("http://127.0.0.1"), exec as never)).toBeNull();
+    });
+
+    it("handles multiple ss entries and picks the matching PID", () => {
+      const output = [
+        "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+        `LISTEN 0      511    127.0.0.1:8080  0.0.0.0:*  users:(("node",pid=99999,fd=6))`,
+        `LISTEN 0      511    127.0.0.1:4096  0.0.0.0:*  users:(("bun",pid=${process.pid},fd=7))`,
+        "",
+      ].join("\n");
+      const exec = mock(() => output);
+      expect(resolvePort(new URL("http://127.0.0.1"), exec as never)).toBe(4096);
+    });
+
+    it("handles IPv6 listening addresses in ss output", () => {
+      const output = [
+        "State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process",
+        `LISTEN 0      511    [::]:4096  [::]:*  users:(("bun",pid=${process.pid},fd=6))`,
+        "",
+      ].join("\n");
+      const exec = mock(() => output);
+      expect(resolvePort(new URL("http://127.0.0.1"), exec as never)).toBe(4096);
+    });
+  });
+  describe("failure cases", () => {
+    it("returns null when ss is not available", () => {
+      expect(resolvePort(new URL("http://127.0.0.1"), noopExec)).toBeNull();
+    });
+
+    it("returns null when ss returns empty output", () => {
+      const exec = mock(() => "");
+      expect(resolvePort(new URL("http://127.0.0.1"), exec as never)).toBeNull();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("URL.port is empty string for default HTTP port 80", () => {
+      // http://127.0.0.1:80 → URL.port is "" (80 is default for http)
+      const url = new URL("http://127.0.0.1:80");
+      expect(url.port).toBe("");
+      const exec = mock(() => ssOutput(process.pid, 4096));
+      expect(resolvePort(url, exec as never)).toBe(4096);
+    });
+
+    it("URL.port is empty string for default HTTPS port 443", () => {
+      const url = new URL("https://127.0.0.1:443");
+      expect(url.port).toBe("");
+      const exec = mock(() => ssOutput(process.pid, 4096));
+      expect(resolvePort(url, exec as never)).toBe(4096);
+    });
+
+    it("does not use ss fallback when URL port is valid", () => {
+      const exec = mock(() => ssOutput(process.pid, 9999));
+      expect(resolvePort(new URL("http://127.0.0.1:4096"), exec as never)).toBe(4096);
+      expect(exec).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/envoy-plugin/src/index.ts
+++ b/packages/envoy-plugin/src/index.ts
@@ -1,6 +1,6 @@
-import { execFileSync } from "node:child_process";
 import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { tool } from "@opencode-ai/plugin/tool";
+import { resolvePort } from "./port";
 
 const root = process.env.ENVOY_URL ?? "http://127.0.0.1:9020";
 
@@ -35,24 +35,17 @@ export default async (input: { serverUrl: URL }) => {
     } catch {}
   };
 
+  let portWarningLogged = false;
   const currentPort = () => {
-    const value = Number.parseInt(input.serverUrl.port, 10);
-    if (Number.isFinite(value) && value > 0) return value;
-
-    try {
-      const output = execFileSync("ss", ["-tlnp"], { encoding: "utf-8" });
-      for (const line of output.split("\n")) {
-        if (!line.includes(`pid=${process.pid}`)) continue;
-        const parts = line.trim().split(/\s+/);
-        const local = parts[3];
-        const match = local?.match(/:(\d+)$/);
-        if (!match) continue;
-        const port = Number.parseInt(match[1], 10);
-        if (Number.isFinite(port) && port > 0) return port;
-      }
-    } catch {}
-
-    return null;
+    const port = resolvePort(input.serverUrl);
+    if (!port && !portWarningLogged) {
+      portWarningLogged = true;
+      console.error(
+        `[envoy-plugin] Could not resolve serve port: serverUrl=${input.serverUrl.href}, pid=${process.pid}`
+      );
+    }
+    if (port) portWarningLogged = false;
+    return port;
   };
 
   const syncPort = (sessionID?: string) => {
@@ -128,16 +121,19 @@ export default async (input: { serverUrl: URL }) => {
               const session = await fetchSession(sessionID);
               if (session) update(sessionID, { session });
               syncPort(sessionID);
-              call("/v1/interests/subscribe", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                  session_id: sessionID,
-                  dir: process.cwd(),
-                  topics: [`notifications.agent.${sessionID}`],
-                  port: currentPort() ?? 0,
-                }),
-              }).catch(() => {});
+              const port = currentPort();
+              if (port) {
+                call("/v1/interests/subscribe", {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({
+                    session_id: sessionID,
+                    dir: process.cwd(),
+                    topics: [`notifications.agent.${sessionID}`],
+                    port,
+                  }),
+                }).catch(() => {});
+              }
             }
           }
           if (event.type === "session.updated") {
@@ -176,7 +172,7 @@ export default async (input: { serverUrl: URL }) => {
               session_id: ctx.sessionID,
               dir: ctx.directory,
               topics: args.topics,
-              port: Number.parseInt(input.serverUrl.port, 10) || 0,
+              port: currentPort() ?? 0,
             }),
           });
         },

--- a/packages/envoy-plugin/src/port.ts
+++ b/packages/envoy-plugin/src/port.ts
@@ -1,0 +1,34 @@
+import { execFileSync } from "node:child_process";
+
+/**
+ * Resolve the serve port from the server URL, with ss(8) fallback.
+ *
+ * Priority:
+ * 1. URL.port (standard: non-empty for non-default ports)
+ * 2. ss -tlnp PID match (finds listening port by process ID)
+ * 3. null (caller decides how to handle)
+ */
+export function resolvePort(
+  serverUrl: URL,
+  exec: typeof execFileSync = execFileSync
+): number | null {
+  // Try URL.port first (standard path for non-default ports like 4096, 13381)
+  const urlPort = Number.parseInt(serverUrl.port, 10);
+  if (Number.isFinite(urlPort) && urlPort > 0) return urlPort;
+
+  // Fallback: find listening port via ss(8) by PID
+  try {
+    const output = exec("ss", ["-tlnp"], { encoding: "utf-8" }) as string;
+    for (const line of output.split("\n")) {
+      if (!line.includes(`pid=${process.pid}`)) continue;
+      const parts = line.trim().split(/\s+/);
+      const local = parts[3];
+      const match = local?.match(/:(\d+)$/);
+      if (!match) continue;
+      const port = Number.parseInt(match[1], 10);
+      if (Number.isFinite(port) && port > 0) return port;
+    }
+  } catch {}
+
+  return null;
+}


### PR DESCRIPTION
Closes #281

## Summary

Fix envoy-plugin sending `port: 0` to the Envoy listener when serve runs on non-default ports (e.g., 4096), which caused the listener to skip the KV session put and block cross-machine delivery.

### Changes

**`packages/envoy-plugin/src/port.ts`** (new) — Extracted `resolvePort(serverUrl, exec?)` function with:
- URL.port extraction (primary path for non-default ports)
- `ss -tlnp` PID-based fallback (finds listening port when URL.port is empty)
- Dependency-injected `exec` param for testability

**`packages/envoy-plugin/src/index.ts`** — Three fixes:
- `envoy_subscribe` tool: replaced `Number.parseInt(input.serverUrl.port, 10) || 0` with `currentPort() ?? 0` — gets `ss` fallback, no longer silently sends 0 for non-default ports
- `session.status → busy` handler: guarded subscribe call with `if (port)` — matches existing heartbeat pattern, avoids sending `port: 0`
- `currentPort()`: simplified to delegate to `resolvePort`, with once-only error logging on failure

**`packages/envoy-plugin/src/__tests__/port.test.ts`** (new) — 14 tests covering URL extraction, ss fallback, failure cases, and edge cases (default HTTP/HTTPS ports, IPv6).