### PR TITLE
sjawhar-legion-284: enable Ghost Wispr events through Envoy publish endpoint

### DIFF
--- a/packages/contracts/schemas/envelope.schema.json
+++ b/packages/contracts/schemas/envelope.schema.json
@@ -16,7 +16,7 @@
     "event_id": { "type": "string", "minLength": 1 },
     "source": {
       "type": "string",
-      "enum": ["agent", "github", "slack", "whatsapp"]
+      "enum": ["agent", "github", "slack", "whatsapp", "ghostwispr"]
     },
     "source_event_id": { "type": "string", "minLength": 1 },
     "source_session": { "type": "string" },

--- a/packages/contracts/scripts/gen-go.ts
+++ b/packages/contracts/scripts/gen-go.ts
@@ -44,6 +44,12 @@ func SlackSubject(team string, channel string, kind string) string {
 
 func GithubResourceSubject(owner string, repo string, resourceType string, resourceNumber string) string {
 	return "notifications.github." + owner + "." + repo + "." + resourceType + "." + resourceNumber
+}
+
+const GhostWisprTopicPrefix = "notifications.ghostwispr."
+
+func GhostWisprSubject(recordingId string, kind string) string {
+	return GhostWisprTopicPrefix + recordingId + "." + kind
 }`;
 
 function title(text: string) {

--- a/packages/contracts/src/envelope.test.ts
+++ b/packages/contracts/src/envelope.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { EnvelopeSchema } from "./envelope";
-import { githubResourceSubject, githubSubject } from "./subject";
+import {
+  GHOSTWISPR_TOPIC_PREFIX,
+  ghostWisprSubject,
+  githubResourceSubject,
+  githubSubject,
+} from "./subject";
 
 describe("EnvelopeSchema", () => {
   test("accepts the envoy envelope shape", () => {
@@ -16,6 +21,36 @@ describe("EnvelopeSchema", () => {
     });
 
     expect(item.topic).toBe("notifications.agent.ses_123");
+  });
+
+  test("accepts ghostwispr source", () => {
+    const item = EnvelopeSchema.parse({
+      event_id: "evt-2",
+      source: "ghostwispr",
+      source_event_id: "rec-abc123",
+      topic: "notifications.ghostwispr.rec-abc123.transcript",
+      dedupe_key: "ghostwispr.rec-abc123",
+      issued_at: Date.now(),
+      payload_summary: '{"type":"transcript"}',
+      trace_id: "trace-2",
+    });
+
+    expect(item.source).toBe("ghostwispr");
+  });
+
+  test("rejects unknown source", () => {
+    expect(() =>
+      EnvelopeSchema.parse({
+        event_id: "evt-3",
+        source: "unknown",
+        source_event_id: "src-3",
+        topic: "notifications.test.foo",
+        dedupe_key: "test.src-3",
+        issued_at: Date.now(),
+        payload_summary: "hello",
+        trace_id: "trace-3",
+      })
+    ).toThrow();
   });
 });
 
@@ -42,5 +77,24 @@ describe("githubResourceSubject", () => {
     const resource = githubResourceSubject("acme", "widgets", "pr", 7);
     const repoLevel = githubSubject("acme", "widgets", "pr");
     expect(resource.startsWith(`${repoLevel}.`)).toBe(true);
+  });
+});
+
+describe("ghostWisprSubject", () => {
+  test("returns transcript topic", () => {
+    expect(ghostWisprSubject("rec-abc123", "transcript")).toBe(
+      "notifications.ghostwispr.rec-abc123.transcript"
+    );
+  });
+
+  test("returns summary topic", () => {
+    expect(ghostWisprSubject("rec-abc123", "summary")).toBe(
+      "notifications.ghostwispr.rec-abc123.summary"
+    );
+  });
+
+  test("starts with GHOSTWISPR_TOPIC_PREFIX", () => {
+    const topic = ghostWisprSubject("rec-1", "transcript");
+    expect(topic.startsWith(GHOSTWISPR_TOPIC_PREFIX)).toBe(true);
   });
 });

--- a/packages/contracts/src/envelope.ts
+++ b/packages/contracts/src/envelope.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const EnvelopeSchema = z.object({
   event_id: z.string().min(1),
-  source: z.enum(["agent", "github", "slack", "whatsapp"]),
+  source: z.enum(["agent", "github", "slack", "whatsapp", "ghostwispr"]),
   source_event_id: z.string().min(1),
   source_session: z.string().optional(),
   topic: z.string().min(1),

--- a/packages/contracts/src/subject.ts
+++ b/packages/contracts/src/subject.ts
@@ -20,3 +20,9 @@ export function githubResourceSubject(
 ) {
   return `notifications.github.${owner}.${repo}.${resourceType}.${resourceNumber}`;
 }
+
+export const GHOSTWISPR_TOPIC_PREFIX = "notifications.ghostwispr.";
+
+export function ghostWisprSubject(recordingId: string, kind: string) {
+  return `${GHOSTWISPR_TOPIC_PREFIX}${recordingId}.${kind}`;
+}

--- a/packages/envoy/cmd/listener/main.go
+++ b/packages/envoy/cmd/listener/main.go
@@ -52,6 +52,7 @@ func publishHandler(state *atomic.Pointer[listenerDeps]) http.HandlerFunc {
 			return
 		}
 		var body struct {
+			Source        string `json:"source"`
 			SourceSession string `json:"source_session"`
 			Topic         string `json:"topic"`
 			Message       string `json:"message"`
@@ -68,9 +69,12 @@ func publishHandler(state *atomic.Pointer[listenerDeps]) http.HandlerFunc {
 			http.Error(w, "cannot publish to agent topics; use /v1/messages/send for direct agent messages", http.StatusBadRequest)
 			return
 		}
+		if body.Source == "" {
+			body.Source = "agent"
+		}
 		item := contracts.Envelope{
 			EventID:        id.New(),
-			Source:         "agent",
+			Source:         body.Source,
 			SourceSession:  body.SourceSession,
 			SourceEventID:  id.New(),
 			Topic:          body.Topic,

--- a/packages/envoy/cmd/listener/main_test.go
+++ b/packages/envoy/cmd/listener/main_test.go
@@ -196,6 +196,121 @@ func TestPublishHandler_MethodNotAllowed(t *testing.T) {
 	}
 }
 
+func TestPublishHandler_RejectsInvalidSource(t *testing.T) {
+	// Validation runs before deps.client is used, so nil inner fields
+	// are enough for rejection-path tests.
+	var state atomic.Pointer[listenerDeps]
+	state.Store(&listenerDeps{})
+	handler := publishHandler(&state)
+
+	cases := []struct {
+		name       string
+		body       string
+		wantSubstr string
+	}{
+		{
+			name:       "rejects invalid source",
+			body:       `{"source":"invalid","topic":"notifications.test.foo","message":"hello"}`,
+			wantSubstr: "source must be one of",
+		},
+		{
+			name:       "rejects empty-ish source after trim",
+			body:       `{"source":" ","topic":"notifications.test.foo","message":"hello"}`,
+			wantSubstr: "source is required",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/v1/messages/publish", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d (body: %s)", rr.Code, rr.Body.String())
+			}
+			if !strings.Contains(rr.Body.String(), tc.wantSubstr) {
+				t.Fatalf("expected body to contain %q, got %q", tc.wantSubstr, rr.Body.String())
+			}
+		})
+	}
+}
+
+func setupPublishTestClient(t *testing.T) *bus.Client {
+	t.Helper()
+	ctx := context.Background()
+	ctr, err := tcnats.Run(ctx, "nats:2.10")
+	if err != nil {
+		t.Fatalf("failed to start NATS: %v", err)
+	}
+	t.Cleanup(func() { ctr.Terminate(ctx) })
+	uri, err := ctr.ConnectionString(ctx)
+	if err != nil {
+		t.Fatalf("failed to get NATS URI: %v", err)
+	}
+	client, err := bus.Connect([]string{uri}, bus.WithReplicas(1))
+	if err != nil {
+		t.Fatalf("failed to connect bus: %v", err)
+	}
+	t.Cleanup(func() { client.Conn.Close() })
+	return client
+}
+
+func TestPublishHandler_SourceFieldWithNATS(t *testing.T) {
+	client := setupPublishTestClient(t)
+	var state atomic.Pointer[listenerDeps]
+	state.Store(&listenerDeps{client: client})
+	handler := publishHandler(&state)
+
+	cases := []struct {
+		name       string
+		body       string
+		wantSource string
+	}{
+		{
+			name:       "defaults to agent when source omitted",
+			body:       `{"topic":"notifications.test.foo","message":"hello"}`,
+			wantSource: "agent",
+		},
+		{
+			name:       "defaults to agent when source empty",
+			body:       `{"source":"","topic":"notifications.test.foo","message":"hello"}`,
+			wantSource: "agent",
+		},
+		{
+			name:       "accepts ghostwispr source",
+			body:       `{"source":"ghostwispr","topic":"notifications.ghostwispr.rec-1.transcript","message":"{}"}`,
+			wantSource: "ghostwispr",
+		},
+		{
+			name:       "accepts github source",
+			body:       `{"source":"github","topic":"notifications.github.acme.widgets.pr","message":"{}"}`,
+			wantSource: "github",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/v1/messages/publish", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+			}
+			var env contracts.Envelope
+			if err := json.NewDecoder(rr.Body).Decode(&env); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if env.Source != tc.wantSource {
+				t.Fatalf("expected source %q, got %q", tc.wantSource, env.Source)
+			}
+		})
+	}
+}
+
 func setupAdminTestRegistry(t *testing.T, interests map[string][]string) *store.Registry {
 	t.Helper()
 	ctx := context.Background()

--- a/packages/envoy/internal/contracts/generated.go
+++ b/packages/envoy/internal/contracts/generated.go
@@ -46,9 +46,9 @@ func (e Envelope) Validate() error {
 		return fmt.Errorf("trace_id is required")
 	}
 	switch e.Source {
-	case "agent", "github", "slack", "whatsapp":
+	case "agent", "github", "slack", "whatsapp", "ghostwispr":
 	default:
-		return fmt.Errorf("source must be one of: agent, github, slack, whatsapp")
+		return fmt.Errorf("source must be one of: agent, github, slack, whatsapp, ghostwispr")
 	}
 	return nil
 }
@@ -73,4 +73,10 @@ func SlackSubject(team string, channel string, kind string) string {
 
 func GithubResourceSubject(owner string, repo string, resourceType string, resourceNumber string) string {
 	return "notifications.github." + owner + "." + repo + "." + resourceType + "." + resourceNumber
+}
+
+const GhostWisprTopicPrefix = "notifications.ghostwispr."
+
+func GhostWisprSubject(recordingId string, kind string) string {
+	return GhostWisprTopicPrefix + recordingId + "." + kind
 }

--- a/packages/envoy/internal/contracts/normalize_test.go
+++ b/packages/envoy/internal/contracts/normalize_test.go
@@ -491,7 +491,7 @@ func TestGithubSummaryJSON(t *testing.T) {
 				"pull_request": map[string]any{
 					"number": 10, "title": "New feature", "body": "This PR adds a new feature",
 					"html_url": "https://github.com/sjawhar/legion/pull/10",
-					"user": map[string]any{"login": "author"},
+					"user":     map[string]any{"login": "author"},
 				},
 			},
 			expectedKeys: []string{"kind", "action", "repo", "number", "title", "author", "body", "url"},
@@ -509,7 +509,7 @@ func TestGithubSummaryJSON(t *testing.T) {
 				"issue": map[string]any{
 					"number": 5, "title": "Bug: crash on startup", "body": "Steps to reproduce...",
 					"html_url": "https://github.com/sjawhar/legion/issues/5",
-					"user": map[string]any{"login": "reporter"},
+					"user":     map[string]any{"login": "reporter"},
 				},
 			},
 			expectedKeys: []string{"kind", "action", "repo", "number", "title", "author", "body", "url"},
@@ -536,9 +536,9 @@ func TestGithubSummaryJSON(t *testing.T) {
 			checkValues:  map[string]string{"kind": "unknown", "action": "created", "repo": "sjawhar/legion"},
 		},
 		{
-			name:  "missing webhook data produces empty strings",
-			event: "issue_comment",
-			body:  map[string]any{"action": "created"},
+			name:         "missing webhook data produces empty strings",
+			event:        "issue_comment",
+			body:         map[string]any{"action": "created"},
 			expectedKeys: []string{"kind", "action", "repo", "number", "title", "parent_kind", "author", "body", "url"},
 			checkValues: map[string]string{
 				"kind": "comment", "action": "created", "repo": "", "number": "", "title": "",
@@ -619,5 +619,49 @@ func TestGithubResourceSubject(t *testing.T) {
 		if got != item.want {
 			t.Fatalf("GithubResourceSubject(%s, %s, %s, %s) = %s, want %s", item.owner, item.repo, item.resourceType, item.resourceNum, got, item.want)
 		}
+	}
+}
+
+func TestGhostWisprSubject(t *testing.T) {
+	cases := []struct {
+		recordingId string
+		kind        string
+		want        string
+	}{
+		{recordingId: "rec-abc123", kind: "transcript", want: "notifications.ghostwispr.rec-abc123.transcript"},
+		{recordingId: "rec-abc123", kind: "summary", want: "notifications.ghostwispr.rec-abc123.summary"},
+		{recordingId: "rec-xyz789", kind: "transcript", want: "notifications.ghostwispr.rec-xyz789.transcript"},
+	}
+	for _, item := range cases {
+		got := GhostWisprSubject(item.recordingId, item.kind)
+		if got != item.want {
+			t.Fatalf("GhostWisprSubject(%s, %s) = %s, want %s", item.recordingId, item.kind, got, item.want)
+		}
+	}
+}
+
+func TestGhostWisprTopicPrefix(t *testing.T) {
+	if GhostWisprTopicPrefix != "notifications.ghostwispr." {
+		t.Fatalf("unexpected prefix: %s", GhostWisprTopicPrefix)
+	}
+	subject := GhostWisprSubject("rec-1", "transcript")
+	if !strings.HasPrefix(subject, GhostWisprTopicPrefix) {
+		t.Fatalf("subject %s does not start with prefix %s", subject, GhostWisprTopicPrefix)
+	}
+}
+
+func TestGhostWisprSourceValidation(t *testing.T) {
+	env := Envelope{
+		EventID:        "evt-1",
+		Source:         "ghostwispr",
+		SourceEventID:  "src-1",
+		Topic:          "notifications.ghostwispr.rec-1.transcript",
+		DedupeKey:      "ghostwispr.src-1",
+		IssuedAt:       NowMillis(),
+		PayloadSummary: "{}",
+		TraceID:        "trace-1",
+	}
+	if err := env.Validate(); err != nil {
+		t.Fatalf("expected ghostwispr source to be valid: %v", err)
 	}
 }

--- a/packages/envoy/internal/routing/match_test.go
+++ b/packages/envoy/internal/routing/match_test.go
@@ -47,3 +47,49 @@ func TestPerPRFiltering(t *testing.T) {
 		}
 	}
 }
+
+func TestGhostWisprTopicFiltering(t *testing.T) {
+	// Wildcard subscription for all Ghost Wispr events
+	pattern := "notifications.ghostwispr.>"
+	cases := []struct {
+		topic string
+		ok    bool
+	}{
+		// Should match: ghostwispr events
+		{topic: "notifications.ghostwispr.rec-abc123.transcript", ok: true},
+		{topic: "notifications.ghostwispr.rec-abc123.summary", ok: true},
+		{topic: "notifications.ghostwispr.rec-xyz789.transcript", ok: true},
+		// Should NOT match: other source topics
+		{topic: "notifications.github.sjawhar.legion.pr", ok: false},
+		{topic: "notifications.slack.T123.C456.message", ok: false},
+		{topic: "notifications.agent.ses_123", ok: false},
+	}
+	for _, item := range cases {
+		got := Match(pattern, item.topic)
+		if got != item.ok {
+			t.Fatalf("pattern=%s topic=%s expected=%v got=%v", pattern, item.topic, item.ok, got)
+		}
+	}
+}
+
+func TestGhostWisprPerRecordingFiltering(t *testing.T) {
+	// Subscription for a specific recording's events
+	pattern := "notifications.ghostwispr.rec-abc123.>"
+	cases := []struct {
+		topic string
+		ok    bool
+	}{
+		// Should match: target recording events
+		{topic: "notifications.ghostwispr.rec-abc123.transcript", ok: true},
+		{topic: "notifications.ghostwispr.rec-abc123.summary", ok: true},
+		// Should NOT match: different recording
+		{topic: "notifications.ghostwispr.rec-xyz789.transcript", ok: false},
+		{topic: "notifications.ghostwispr.rec-xyz789.summary", ok: false},
+	}
+	for _, item := range cases {
+		got := Match(pattern, item.topic)
+		if got != item.ok {
+			t.Fatalf("pattern=%s topic=%s expected=%v got=%v", pattern, item.topic, item.ok, got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #284

## Summary

Enable Ghost Wispr to publish events (transcripts, recordings) through Envoy so any session on any machine can subscribe to Ghost Wispr notifications.

### Changes

- **Publish handler**: Accept optional `source` field from request body (defaults to `"agent"` for backward compatibility). Invalid sources are rejected by envelope validation.
- **Contracts**: Add `"ghostwispr"` to the source enum across TS (envelope.ts, envelope.schema.json), Go generation (gen-go.ts), and regenerated Go contracts.
- **Subject helpers**: Add `ghostWisprSubject(recordingId, kind)` in TS and `GhostWisprSubject` / `GhostWisprTopicPrefix` in Go for building `notifications.ghostwispr.{recording_id}.{kind}` topics.
- **Tests**: TS envelope tests for ghostwispr source acceptance/rejection, Go handler tests for source field (default, custom, invalid), routing tests for ghostwispr topic wildcard matching, and Go contract tests for subject helpers and source validation.

### How It Works

Ghost Wispr publishes events by POSTing to the existing Envoy listener endpoint:
```
POST http://127.0.0.1:9020/v1/messages/publish
{
  "source": "ghostwispr",
  "topic": "notifications.ghostwispr.<recording_id>.transcript",
  "message": "{...}"
}
```

Sessions subscribe to `notifications.ghostwispr.>` for all events, or `notifications.ghostwispr.<recording_id>.>` for a specific recording. Cross-machine delivery works via existing NATS fanout — no new receiver needed.