### PR TITLE
sjawhar-legion-283: add MCP bridge for WhatsApp event ingestion via Envoy

### DIFF
--- a/packages/contracts/scripts/gen-go.ts
+++ b/packages/contracts/scripts/gen-go.ts
@@ -50,6 +50,10 @@ const GhostWisprTopicPrefix = "notifications.ghostwispr."
 
 func GhostWisprSubject(recordingId string, kind string) string {
 	return GhostWisprTopicPrefix + recordingId + "." + kind
+}
+
+func WhatsappSubject(phone, jid, kind string) string {
+	return "notifications.whatsapp." + phone + "." + jid + "." + kind
 }`;
 
 function title(text: string) {

--- a/packages/contracts/src/envelope.test.ts
+++ b/packages/contracts/src/envelope.test.ts
@@ -5,6 +5,7 @@ import {
   ghostWisprSubject,
   githubResourceSubject,
   githubSubject,
+  whatsappSubject,
 } from "./subject";
 
 describe("EnvelopeSchema", () => {
@@ -96,5 +97,34 @@ describe("ghostWisprSubject", () => {
   test("starts with GHOSTWISPR_TOPIC_PREFIX", () => {
     const topic = ghostWisprSubject("rec-1", "transcript");
     expect(topic.startsWith(GHOSTWISPR_TOPIC_PREFIX)).toBe(true);
+  });
+});
+
+describe("whatsappSubject", () => {
+  test("returns message topic", () => {
+    expect(whatsappSubject("15551234567", "5551234567@s.whatsapp.net", "message")).toBe(
+      "notifications.whatsapp.15551234567.5551234567@s.whatsapp.net.message"
+    );
+  });
+
+  test("returns different kind", () => {
+    expect(whatsappSubject("15551234567", "5551234567@s.whatsapp.net", "status")).toBe(
+      "notifications.whatsapp.15551234567.5551234567@s.whatsapp.net.status"
+    );
+  });
+
+  test("accepts whatsapp source in envelope", () => {
+    const item = EnvelopeSchema.parse({
+      event_id: "evt-wa",
+      source: "whatsapp",
+      source_event_id: "whatsapp://messages/15551234567/5551234567@s.whatsapp.net",
+      topic: whatsappSubject("15551234567", "5551234567@s.whatsapp.net", "message"),
+      dedupe_key: "whatsapp.15551234567.5551234567@s.whatsapp.net.1712345678000",
+      issued_at: Date.now(),
+      payload_summary: "WhatsApp message in chat 5551234567@s.whatsapp.net",
+      trace_id: "trace-wa",
+    });
+
+    expect(item.source).toBe("whatsapp");
   });
 });

--- a/packages/contracts/src/subject.ts
+++ b/packages/contracts/src/subject.ts
@@ -26,3 +26,7 @@ export const GHOSTWISPR_TOPIC_PREFIX = "notifications.ghostwispr.";
 export function ghostWisprSubject(recordingId: string, kind: string) {
   return `${GHOSTWISPR_TOPIC_PREFIX}${recordingId}.${kind}`;
 }
+
+export function whatsappSubject(phone: string, jid: string, kind: string) {
+  return `notifications.whatsapp.${phone}.${jid}.${kind}`;
+}

--- a/packages/envoy/cmd/mcp/main.go
+++ b/packages/envoy/cmd/mcp/main.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/sjawhar/envoy/internal/bus"
+	"github.com/sjawhar/envoy/internal/mcpbridge"
+)
+
+func main() {
+	configPath := strings.TrimSpace(os.Getenv("ENVOY_MCP_CONFIG"))
+	if configPath == "" {
+		log.Fatal("ENVOY_MCP_CONFIG is required")
+	}
+	if strings.TrimSpace(os.Getenv("ENVOY_MACHINE_ID")) == "" {
+		log.Fatal("ENVOY_MACHINE_ID is required")
+	}
+	natsRaw := strings.TrimSpace(os.Getenv("NATS_URLS"))
+	if natsRaw == "" {
+		log.Fatal("NATS_URLS is required")
+	}
+	natsURLs := strings.FieldsFunc(natsRaw, func(r rune) bool { return r == ',' })
+	for i, u := range natsURLs {
+		natsURLs[i] = strings.TrimSpace(u)
+	}
+
+	port := 9012
+	if v := strings.TrimSpace(os.Getenv("PORT")); v != "" {
+		p, err := strconv.Atoi(v)
+		if err != nil {
+			log.Fatalf("invalid PORT: %v", err)
+		}
+		port = p
+	}
+	replicas := 1
+	if v := strings.TrimSpace(os.Getenv("ENVOY_NATS_REPLICAS")); v != "" {
+		r, err := strconv.Atoi(v)
+		if err != nil {
+			log.Fatalf("invalid ENVOY_NATS_REPLICAS: %v", err)
+		}
+		replicas = r
+	}
+
+	// Load and validate config.
+	cfg, err := mcpbridge.LoadConfig(configPath)
+	if err != nil {
+		log.Fatalf("config: %v", err)
+	}
+
+	// Connect to NATS.
+	client, err := bus.Connect(natsURLs, bus.WithReplicas(replicas))
+	if err != nil {
+		log.Fatalf("nats: %v", err)
+	}
+	defer client.Conn.Close()
+
+	// Create and start bridge.
+	bridge := mcpbridge.NewBridge(cfg, client)
+	if err := bridge.Start(); err != nil {
+		log.Fatalf("bridge start: %v", err)
+	}
+
+	// Health check endpoint.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		if !bridge.Healthy() {
+			http.Error(w, "unhealthy", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	server := &http.Server{
+		Addr:         ":" + strconv.Itoa(port),
+		Handler:      mux,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	// Handle shutdown signals.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+
+	go func() {
+		log.Printf("envoy-mcp listening on %d", port)
+		if err := server.ListenAndServe(); err != http.ErrServerClosed {
+			log.Fatalf("http: %v", err)
+		}
+	}()
+
+	<-sigCh
+	log.Printf("envoy-mcp shutting down")
+	bridge.Stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	server.Shutdown(ctx)
+}

--- a/packages/envoy/internal/contracts/generated.go
+++ b/packages/envoy/internal/contracts/generated.go
@@ -80,3 +80,7 @@ const GhostWisprTopicPrefix = "notifications.ghostwispr."
 func GhostWisprSubject(recordingId string, kind string) string {
 	return GhostWisprTopicPrefix + recordingId + "." + kind
 }
+
+func WhatsappSubject(phone, jid, kind string) string {
+	return "notifications.whatsapp." + phone + "." + jid + "." + kind
+}

--- a/packages/envoy/internal/contracts/normalize_test.go
+++ b/packages/envoy/internal/contracts/normalize_test.go
@@ -665,3 +665,38 @@ func TestGhostWisprSourceValidation(t *testing.T) {
 		t.Fatalf("expected ghostwispr source to be valid: %v", err)
 	}
 }
+
+func TestWhatsappSubject(t *testing.T) {
+	cases := []struct {
+		phone string
+		jid   string
+		kind  string
+		want  string
+	}{
+		{phone: "15551234567", jid: "5551234567@s.whatsapp.net", kind: "message", want: "notifications.whatsapp.15551234567.5551234567@s.whatsapp.net.message"},
+		{phone: "15559876543", jid: "group-abc@g.us", kind: "message", want: "notifications.whatsapp.15559876543.group-abc@g.us.message"},
+		{phone: "15551234567", jid: "5551234567@s.whatsapp.net", kind: "status", want: "notifications.whatsapp.15551234567.5551234567@s.whatsapp.net.status"},
+	}
+	for _, item := range cases {
+		got := WhatsappSubject(item.phone, item.jid, item.kind)
+		if got != item.want {
+			t.Fatalf("WhatsappSubject(%s, %s, %s) = %s, want %s", item.phone, item.jid, item.kind, got, item.want)
+		}
+	}
+}
+
+func TestWhatsappSourceValidation(t *testing.T) {
+	env := Envelope{
+		EventID:        "evt-wa",
+		Source:         "whatsapp",
+		SourceEventID:  "whatsapp://messages/15551234567/5551234567@s.whatsapp.net",
+		Topic:          WhatsappSubject("15551234567", "5551234567@s.whatsapp.net", "message"),
+		DedupeKey:      "whatsapp.15551234567.5551234567@s.whatsapp.net.1712345678000",
+		IssuedAt:       NowMillis(),
+		PayloadSummary: "WhatsApp message in chat 5551234567@s.whatsapp.net",
+		TraceID:        "trace-wa",
+	}
+	if err := env.Validate(); err != nil {
+		t.Fatalf("expected whatsapp source to be valid: %v", err)
+	}
+}

--- a/packages/envoy/internal/integration/delivery_test.go
+++ b/packages/envoy/internal/integration/delivery_test.go
@@ -1040,3 +1040,78 @@ func TestE2E_RegistryListReturnsSortedInterests(t *testing.T) {
 		t.Fatalf("expected third item to be ses_charlie, got %s", items[2].SessionID)
 	}
 }
+
+// --- WHATSAPP MCP BRIDGE INTEGRATION ---
+
+func TestE2E_WhatsappTopicRouting(t *testing.T) {
+	env := setupTestEnv(t)
+	port, deliveries, bodies, _ := mockSession(t)
+
+	// Subscribe to all WhatsApp messages for phone 15551234567
+	whatsappPattern := "notifications.whatsapp.15551234567.>"
+	env.registerSession("ses_whatsapp", port, []string{whatsappPattern})
+	env.startConsumer("test-machine")
+
+	// Publish a WhatsApp envelope (simulating what the MCP bridge would publish)
+	waTopic := contracts.WhatsappSubject("15551234567", "5551234567@s.whatsapp.net", "message")
+	waEnv := newEnvelope("whatsapp", waTopic, "Hello from WhatsApp", "dedupe-wa-1")
+	waEnv.SourceSession = "" // Bridge has no session
+	waEnv.PayloadRef = "whatsapp://messages/15551234567/5551234567@s.whatsapp.net"
+	publishEnvelope(env, waEnv)
+
+	time.Sleep(2 * time.Second)
+	if count := deliveries.Load(); count != 1 {
+		t.Fatalf("expected 1 delivery for WhatsApp message, got %d", count)
+	}
+
+	// Verify the body contains the WhatsApp message content
+	if len(*bodies) == 0 {
+		t.Fatal("no body captured")
+	}
+	if !contains((*bodies)[0], "Hello from WhatsApp") {
+		t.Fatalf("body should contain WhatsApp message, got: %s", (*bodies)[0])
+	}
+}
+
+func TestE2E_WhatsappDifferentPhoneNotDelivered(t *testing.T) {
+	env := setupTestEnv(t)
+	port, deliveries, _, _ := mockSession(t)
+
+	// Subscribe to messages for phone 15551234567 only
+	env.registerSession("ses_wa_filtered", port, []string{"notifications.whatsapp.15551234567.>"})
+	env.startConsumer("test-machine")
+
+	// Publish message for a DIFFERENT phone number
+	waTopicOther := contracts.WhatsappSubject("15559876543", "5551234567@s.whatsapp.net", "message")
+	publishEnvelope(env, newEnvelope("whatsapp", waTopicOther, "Wrong phone", "dedupe-wa-wrong"))
+
+	time.Sleep(2 * time.Second)
+	if count := deliveries.Load(); count != 0 {
+		t.Fatalf("expected 0 deliveries for wrong phone, got %d", count)
+	}
+}
+
+func TestE2E_WhatsappMultipleSubscribers(t *testing.T) {
+	env := setupTestEnv(t)
+
+	port1, deliveries1, _, _ := mockSession(t)
+	port2, deliveries2, _, _ := mockSession(t)
+
+	// Both sessions subscribe to WhatsApp messages
+	env.registerSession("ses_wa_a", port1, []string{"notifications.whatsapp.15551234567.>"})
+	env.registerSession("ses_wa_b", port2, []string{"notifications.whatsapp.15551234567.>"})
+	env.startConsumer("test-machine")
+
+	waTopic := contracts.WhatsappSubject("15551234567", "5551234567@s.whatsapp.net", "message")
+	item := newEnvelope("whatsapp", waTopic, "Broadcast WhatsApp", "dedupe-wa-broadcast")
+	item.SourceSession = ""
+	publishEnvelope(env, item)
+
+	time.Sleep(2 * time.Second)
+	if c1 := deliveries1.Load(); c1 != 1 {
+		t.Fatalf("session A expected 1 delivery, got %d", c1)
+	}
+	if c2 := deliveries2.Load(); c2 != 1 {
+		t.Fatalf("session B expected 1 delivery, got %d", c2)
+	}
+}

--- a/packages/envoy/internal/mcpbridge/bridge.go
+++ b/packages/envoy/internal/mcpbridge/bridge.go
@@ -1,0 +1,179 @@
+package mcpbridge
+
+import (
+	"log"
+	"sync"
+	"time"
+
+	"github.com/sjawhar/envoy/internal/bus"
+)
+
+// Bridge manages multiple MCP server connections and publishes events to NATS.
+type Bridge struct {
+	cfg     *Config
+	client  *bus.Client
+	servers []*ManagedServer
+	mu      sync.Mutex
+	stopCh  chan struct{}
+}
+
+// NewBridge creates a bridge from config and a NATS client.
+func NewBridge(cfg *Config, client *bus.Client) *Bridge {
+	return &Bridge{
+		cfg:    cfg,
+		client: client,
+		stopCh: make(chan struct{}),
+	}
+}
+
+// Start spawns all configured MCP servers and begins processing notifications.
+func (b *Bridge) Start() error {
+	for i := range b.cfg.Servers {
+		serverCfg := b.cfg.Servers[i]
+		s := NewManagedServer(serverCfg, b.makeHandler(&serverCfg))
+		if err := s.Start(); err != nil {
+			// Stop already-started servers.
+			for _, started := range b.servers {
+				started.Stop()
+			}
+			return err
+		}
+		b.mu.Lock()
+		b.servers = append(b.servers, s)
+		b.mu.Unlock()
+
+		// Monitor this server for unexpected exit.
+		go b.monitor(s, &serverCfg)
+	}
+	return nil
+}
+
+// Stop gracefully shuts down all managed servers.
+func (b *Bridge) Stop() {
+	close(b.stopCh)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, s := range b.servers {
+		s.Stop()
+	}
+}
+
+// Healthy returns true if all servers are ready and NATS is flushable.
+func (b *Bridge) Healthy() bool {
+	if err := b.client.Conn.FlushTimeout(3 * time.Second); err != nil {
+		return false
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, s := range b.servers {
+		if s.State() != StateReady {
+			return false
+		}
+	}
+	return true
+}
+
+func (b *Bridge) makeHandler(cfg *ServerConfig) func(uri string) {
+	return func(uri string) {
+		b.handleNotification(cfg, uri)
+	}
+}
+
+func (b *Bridge) handleNotification(cfg *ServerConfig, uri string) {
+	// Find the managed server for this config.
+	b.mu.Lock()
+	var server *ManagedServer
+	for _, s := range b.servers {
+		if s.cfg.Name == cfg.Name {
+			server = s
+			break
+		}
+	}
+	b.mu.Unlock()
+
+	if server == nil {
+		log.Printf("mcp-bridge: no server for %s", cfg.Name)
+		return
+	}
+
+	// Check if URI matches the pattern.
+	if _, err := cfg.RenderTopic(uri); err != nil {
+		log.Printf("mcp-bridge: %s: URI does not match pattern: %s", cfg.Name, uri)
+		return
+	}
+
+	// Read the resource content.
+	contents, err := server.ReadResource(uri)
+	if err != nil {
+		log.Printf("mcp-bridge: %s: resources/read failed for %s: %v", cfg.Name, uri, err)
+		return
+	}
+
+	// Build and publish envelope.
+	envelope, err := BuildEnvelope(cfg, uri, contents)
+	if err != nil {
+		log.Printf("mcp-bridge: %s: envelope construction failed: %v", cfg.Name, err)
+		return
+	}
+
+	if err := envelope.Validate(); err != nil {
+		log.Printf("mcp-bridge: %s: invalid envelope: %v", cfg.Name, err)
+		return
+	}
+
+	if err := b.client.Publish(envelope); err != nil {
+		log.Printf("mcp-bridge: %s: publish failed: %v", cfg.Name, err)
+		return
+	}
+
+	log.Printf("mcp-bridge: %s: published to %s", cfg.Name, envelope.Topic)
+}
+
+func (b *Bridge) monitor(s *ManagedServer, cfg *ServerConfig) {
+	backoff := time.Second
+	const maxBackoff = 30 * time.Second
+
+	for {
+		// Wait for exit.
+		err := s.WaitForExit()
+
+		select {
+		case <-b.stopCh:
+			return
+		default:
+		}
+
+		log.Printf("mcp-bridge: %s: process exited: %v", cfg.Name, err)
+
+		// Restart with exponential backoff.
+		for {
+			select {
+			case <-b.stopCh:
+				return
+			case <-time.After(backoff):
+			}
+
+			log.Printf("mcp-bridge: %s: restarting (backoff=%v)", cfg.Name, backoff)
+			newServer := NewManagedServer(*cfg, b.makeHandler(cfg))
+			if err := newServer.Start(); err != nil {
+				log.Printf("mcp-bridge: %s: restart failed: %v", cfg.Name, err)
+				backoff = min(backoff*2, maxBackoff)
+				continue
+			}
+
+			// Replace the old server.
+			b.mu.Lock()
+			for i, existing := range b.servers {
+				if existing == s {
+					b.servers[i] = newServer
+					break
+				}
+			}
+			b.mu.Unlock()
+
+			s = newServer
+			backoff = time.Second
+			break
+		}
+	}
+}

--- a/packages/envoy/internal/mcpbridge/config.go
+++ b/packages/envoy/internal/mcpbridge/config.go
@@ -1,0 +1,151 @@
+package mcpbridge
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// ServerConfig describes a single MCP server to connect to.
+type ServerConfig struct {
+	Name          string            `json:"name"`
+	Transport     string            `json:"transport"`
+	Command       []string          `json:"command"`
+	Env           map[string]string `json:"env"`
+	Resources     []string          `json:"resources"`
+	Source        string            `json:"source"`
+	TopicTemplate string            `json:"topic_template"`
+	URIPattern    string            `json:"uri_pattern"`
+
+	// compiled is the pre-compiled regex from URIPattern.
+	compiled *regexp.Regexp
+}
+
+// Config is the top-level configuration for the MCP bridge.
+type Config struct {
+	Servers []ServerConfig `json:"servers"`
+}
+
+// CompiledPattern returns the pre-compiled regex for URI extraction.
+func (s *ServerConfig) CompiledPattern() *regexp.Regexp {
+	return s.compiled
+}
+
+// LoadConfig reads and validates the MCP bridge configuration from a JSON file.
+func LoadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("config read: %w", err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("config parse: %w", err)
+	}
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func (c *Config) validate() error {
+	if len(c.Servers) == 0 {
+		return fmt.Errorf("config: no servers configured")
+	}
+	for i := range c.Servers {
+		if err := c.Servers[i].validate(); err != nil {
+			return fmt.Errorf("config: server[%d] (%s): %w", i, c.Servers[i].Name, err)
+		}
+	}
+	return nil
+}
+
+func (s *ServerConfig) validate() error {
+	if strings.TrimSpace(s.Name) == "" {
+		return fmt.Errorf("name is required")
+	}
+	if s.Transport != "stdio" {
+		return fmt.Errorf("transport must be \"stdio\", got %q", s.Transport)
+	}
+	if len(s.Command) == 0 {
+		return fmt.Errorf("command is required")
+	}
+	if strings.TrimSpace(s.Source) == "" {
+		return fmt.Errorf("source is required")
+	}
+	if strings.TrimSpace(s.TopicTemplate) == "" {
+		return fmt.Errorf("topic_template is required")
+	}
+	if strings.TrimSpace(s.URIPattern) == "" {
+		return fmt.Errorf("uri_pattern is required")
+	}
+
+	// Compile URI pattern.
+	re, err := regexp.Compile(s.URIPattern)
+	if err != nil {
+		return fmt.Errorf("uri_pattern: %w", err)
+	}
+	s.compiled = re
+
+	// Verify every {placeholder} in topic_template has a matching named capture group.
+	groups := make(map[string]bool)
+	for _, name := range re.SubexpNames() {
+		if name != "" {
+			groups[name] = true
+		}
+	}
+	placeholders := extractPlaceholders(s.TopicTemplate)
+	if len(placeholders) == 0 {
+		return fmt.Errorf("topic_template has no {placeholder} variables")
+	}
+	for _, ph := range placeholders {
+		if !groups[ph] {
+			return fmt.Errorf("topic_template placeholder {%s} has no matching named capture group in uri_pattern", ph)
+		}
+	}
+
+	// Verify command[0] exists.
+	if _, err := exec.LookPath(s.Command[0]); err != nil {
+		return fmt.Errorf("command[0] %q not found: %w", s.Command[0], err)
+	}
+
+	return nil
+}
+
+// extractPlaceholders returns all {name} placeholder names from a template string.
+func extractPlaceholders(tmpl string) []string {
+	var out []string
+	for {
+		start := strings.Index(tmpl, "{")
+		if start < 0 {
+			break
+		}
+		end := strings.Index(tmpl[start:], "}")
+		if end < 0 {
+			break
+		}
+		name := tmpl[start+1 : start+end]
+		if name != "" {
+			out = append(out, name)
+		}
+		tmpl = tmpl[start+end+1:]
+	}
+	return out
+}
+
+// RenderTopic fills topic_template placeholders with values extracted from a URI.
+func (s *ServerConfig) RenderTopic(uri string) (string, error) {
+	match := s.compiled.FindStringSubmatch(uri)
+	if match == nil {
+		return "", fmt.Errorf("uri %q does not match pattern %s", uri, s.URIPattern)
+	}
+	result := s.TopicTemplate
+	for i, name := range s.compiled.SubexpNames() {
+		if name != "" && i < len(match) {
+			result = strings.ReplaceAll(result, "{"+name+"}", match[i])
+		}
+	}
+	return result, nil
+}

--- a/packages/envoy/internal/mcpbridge/config_test.go
+++ b/packages/envoy/internal/mcpbridge/config_test.go
@@ -1,0 +1,266 @@
+package mcpbridge
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig_Valid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	os.WriteFile(path, []byte(`{
+		"servers": [{
+			"name": "whatsapp",
+			"transport": "stdio",
+			"command": ["echo", "hello"],
+			"resources": ["whatsapp://messages/new"],
+			"source": "whatsapp",
+			"topic_template": "notifications.whatsapp.{phone}.{jid}.message",
+			"uri_pattern": "whatsapp://messages/(?P<phone>[^/]+)/(?P<jid>.+)"
+		}]
+	}`), 0644)
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("expected valid config: %v", err)
+	}
+	if len(cfg.Servers) != 1 {
+		t.Fatalf("expected 1 server, got %d", len(cfg.Servers))
+	}
+	if cfg.Servers[0].Name != "whatsapp" {
+		t.Fatalf("unexpected name: %s", cfg.Servers[0].Name)
+	}
+}
+
+func TestLoadConfig_MissingFile(t *testing.T) {
+	_, err := LoadConfig("/nonexistent/config.json")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoadConfig_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	os.WriteFile(path, []byte("not json {{{"), 0644)
+
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestLoadConfig_NoServers(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.json")
+	os.WriteFile(path, []byte(`{"servers": []}`), 0644)
+
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for no servers")
+	}
+}
+
+func TestLoadConfig_MissingName(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	os.WriteFile(path, []byte(`{
+		"servers": [{
+			"transport": "stdio",
+			"command": ["echo"],
+			"source": "whatsapp",
+			"topic_template": "notifications.whatsapp.{phone}.message",
+			"uri_pattern": "whatsapp://(?P<phone>.+)"
+		}]
+	}`), 0644)
+
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+}
+
+func TestLoadConfig_UnsupportedTransport(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	os.WriteFile(path, []byte(`{
+		"servers": [{
+			"name": "test",
+			"transport": "http",
+			"command": ["echo"],
+			"source": "whatsapp",
+			"topic_template": "notifications.whatsapp.{phone}.message",
+			"uri_pattern": "whatsapp://(?P<phone>.+)"
+		}]
+	}`), 0644)
+
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for unsupported transport")
+	}
+}
+
+func TestLoadConfig_BadRegex(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	os.WriteFile(path, []byte(`{
+		"servers": [{
+			"name": "test",
+			"transport": "stdio",
+			"command": ["echo"],
+			"source": "whatsapp",
+			"topic_template": "notifications.whatsapp.{phone}.message",
+			"uri_pattern": "(?P<phone>[invalid"
+		}]
+	}`), 0644)
+
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for bad regex")
+	}
+}
+
+func TestLoadConfig_MissingCaptureGroup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	os.WriteFile(path, []byte(`{
+		"servers": [{
+			"name": "test",
+			"transport": "stdio",
+			"command": ["echo"],
+			"source": "whatsapp",
+			"topic_template": "notifications.whatsapp.{phone}.{jid}.message",
+			"uri_pattern": "whatsapp://(?P<phone>[^/]+)"
+		}]
+	}`), 0644)
+
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for missing capture group 'jid'")
+	}
+}
+
+func TestLoadConfig_NonexistentCommand(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	os.WriteFile(path, []byte(`{
+		"servers": [{
+			"name": "test",
+			"transport": "stdio",
+			"command": ["definitely_not_a_real_command_xyz_999"],
+			"source": "whatsapp",
+			"topic_template": "notifications.whatsapp.{phone}.message",
+			"uri_pattern": "whatsapp://(?P<phone>.+)"
+		}]
+	}`), 0644)
+
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for nonexistent command")
+	}
+}
+
+func TestRenderTopic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	os.WriteFile(path, []byte(`{
+		"servers": [{
+			"name": "whatsapp",
+			"transport": "stdio",
+			"command": ["echo"],
+			"source": "whatsapp",
+			"topic_template": "notifications.whatsapp.{phone}.{jid}.message",
+			"uri_pattern": "whatsapp://messages/(?P<phone>[^/]+)/(?P<jid>.+)"
+		}]
+	}`), 0644)
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	cases := []struct {
+		uri  string
+		want string
+		ok   bool
+	}{
+		{
+			uri:  "whatsapp://messages/15551234567/5551234567@s.whatsapp.net",
+			want: "notifications.whatsapp.15551234567.5551234567@s.whatsapp.net.message",
+			ok:   true,
+		},
+		{
+			uri:  "whatsapp://messages/15559876543/group-abc@g.us",
+			want: "notifications.whatsapp.15559876543.group-abc@g.us.message",
+			ok:   true,
+		},
+		{
+			uri: "something://else/entirely",
+			ok:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		got, err := cfg.Servers[0].RenderTopic(tc.uri)
+		if tc.ok {
+			if err != nil {
+				t.Fatalf("RenderTopic(%s): unexpected error: %v", tc.uri, err)
+			}
+			if got != tc.want {
+				t.Fatalf("RenderTopic(%s) = %s, want %s", tc.uri, got, tc.want)
+			}
+		} else {
+			if err == nil {
+				t.Fatalf("RenderTopic(%s): expected error, got %s", tc.uri, got)
+			}
+		}
+	}
+}
+
+func TestExtractPlaceholders(t *testing.T) {
+	cases := []struct {
+		tmpl string
+		want []string
+	}{
+		{tmpl: "notifications.whatsapp.{phone}.{jid}.message", want: []string{"phone", "jid"}},
+		{tmpl: "no.placeholders.here", want: nil},
+		{tmpl: "{single}", want: []string{"single"}},
+	}
+	for _, tc := range cases {
+		got := extractPlaceholders(tc.tmpl)
+		if len(got) != len(tc.want) {
+			t.Fatalf("extractPlaceholders(%q) = %v, want %v", tc.tmpl, got, tc.want)
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Fatalf("extractPlaceholders(%q)[%d] = %s, want %s", tc.tmpl, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+func TestLoadConfig_WithEnv(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	os.WriteFile(path, []byte(`{
+		"servers": [{
+			"name": "whatsapp",
+			"transport": "stdio",
+			"command": ["echo", "hello"],
+			"env": {"WHATSAPP_DATA_DIR": "/data/whatsapp"},
+			"resources": ["whatsapp://messages/new"],
+			"source": "whatsapp",
+			"topic_template": "notifications.whatsapp.{phone}.{jid}.message",
+			"uri_pattern": "whatsapp://messages/(?P<phone>[^/]+)/(?P<jid>.+)"
+		}]
+	}`), 0644)
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("expected valid config with env: %v", err)
+	}
+	if cfg.Servers[0].Env["WHATSAPP_DATA_DIR"] != "/data/whatsapp" {
+		t.Fatalf("env not parsed: %v", cfg.Servers[0].Env)
+	}
+}

--- a/packages/envoy/internal/mcpbridge/envelope.go
+++ b/packages/envoy/internal/mcpbridge/envelope.go
@@ -1,0 +1,56 @@
+package mcpbridge
+
+import (
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/sjawhar/envoy/internal/contracts"
+	"github.com/sjawhar/envoy/internal/id"
+)
+
+// BuildEnvelope constructs an Envoy envelope from an MCP notification and resource read.
+func BuildEnvelope(cfg *ServerConfig, notifyURI string, contents []resourceContent) (contracts.Envelope, error) {
+	topic, err := cfg.RenderTopic(notifyURI)
+	if err != nil {
+		return contracts.Envelope{}, err
+	}
+
+	now := contracts.NowMillis()
+	summary := buildSummary(cfg, notifyURI, contents)
+	dedupeKey := buildDedupeKey(cfg.Source, notifyURI)
+
+	return contracts.Envelope{
+		EventID:        id.New(),
+		Source:         cfg.Source,
+		SourceEventID:  notifyURI,
+		Topic:          topic,
+		DedupeKey:      dedupeKey,
+		IssuedAt:       now,
+		PayloadSummary: summary,
+		PayloadRef:     notifyURI,
+		TraceID:        id.New(),
+	}, nil
+}
+
+func buildSummary(cfg *ServerConfig, uri string, contents []resourceContent) string {
+	// Use text from the first content item if available.
+	for _, c := range contents {
+		if c.Text != "" {
+			return truncateSummary(c.Text, 200)
+		}
+	}
+	// Fallback: generic description.
+	return fmt.Sprintf("%s event from %s", cfg.Source, uri)
+}
+
+func buildDedupeKey(source string, uri string) string {
+	return source + "." + uri
+}
+
+func truncateSummary(s string, maxChars int) string {
+	if utf8.RuneCountInString(s) <= maxChars {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:maxChars])
+}

--- a/packages/envoy/internal/mcpbridge/envelope_test.go
+++ b/packages/envoy/internal/mcpbridge/envelope_test.go
@@ -1,0 +1,128 @@
+package mcpbridge
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func loadTestConfig(t *testing.T) *ServerConfig {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	os.WriteFile(path, []byte(`{
+		"servers": [{
+			"name": "whatsapp",
+			"transport": "stdio",
+			"command": ["echo"],
+			"source": "whatsapp",
+			"topic_template": "notifications.whatsapp.{phone}.{jid}.message",
+			"uri_pattern": "whatsapp://messages/(?P<phone>[^/]+)/(?P<jid>.+)"
+		}]
+	}`), 0644)
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	return &cfg.Servers[0]
+}
+
+func TestBuildEnvelope_WithContent(t *testing.T) {
+	cfg := loadTestConfig(t)
+	uri := "whatsapp://messages/15551234567/5551234567@s.whatsapp.net"
+	contents := []resourceContent{
+		{URI: uri, Text: "Hello from WhatsApp"},
+	}
+
+	env, err := BuildEnvelope(cfg, uri, contents)
+	if err != nil {
+		t.Fatalf("BuildEnvelope: %v", err)
+	}
+
+	if env.Source != "whatsapp" {
+		t.Fatalf("source = %s, want whatsapp", env.Source)
+	}
+	if env.Topic != "notifications.whatsapp.15551234567.5551234567@s.whatsapp.net.message" {
+		t.Fatalf("topic = %s", env.Topic)
+	}
+	if env.SourceEventID != uri {
+		t.Fatalf("source_event_id = %s", env.SourceEventID)
+	}
+	if env.PayloadRef != uri {
+		t.Fatalf("payload_ref = %s", env.PayloadRef)
+	}
+	if env.PayloadSummary != "Hello from WhatsApp" {
+		t.Fatalf("payload_summary = %s", env.PayloadSummary)
+	}
+	if env.EventID == "" {
+		t.Fatal("event_id is empty")
+	}
+	if env.TraceID == "" {
+		t.Fatal("trace_id is empty")
+	}
+	if env.IssuedAt == 0 {
+		t.Fatal("issued_at is zero")
+	}
+	if env.DedupeKey == "" {
+		t.Fatal("dedupe_key is empty")
+	}
+	if err := env.Validate(); err != nil {
+		t.Fatalf("envelope validation: %v", err)
+	}
+}
+
+func TestBuildEnvelope_NoContent(t *testing.T) {
+	cfg := loadTestConfig(t)
+	uri := "whatsapp://messages/15551234567/5551234567@s.whatsapp.net"
+
+	env, err := BuildEnvelope(cfg, uri, nil)
+	if err != nil {
+		t.Fatalf("BuildEnvelope: %v", err)
+	}
+
+	if !strings.Contains(env.PayloadSummary, "whatsapp") {
+		t.Fatalf("expected fallback summary to contain source, got: %s", env.PayloadSummary)
+	}
+}
+
+func TestBuildEnvelope_URIMismatch(t *testing.T) {
+	cfg := loadTestConfig(t)
+	_, err := BuildEnvelope(cfg, "something://else", nil)
+	if err == nil {
+		t.Fatal("expected error for URI mismatch")
+	}
+}
+
+func TestBuildEnvelope_SummaryTruncation(t *testing.T) {
+	cfg := loadTestConfig(t)
+	uri := "whatsapp://messages/15551234567/5551234567@s.whatsapp.net"
+	longText := strings.Repeat("a", 500)
+	contents := []resourceContent{
+		{URI: uri, Text: longText},
+	}
+
+	env, err := BuildEnvelope(cfg, uri, contents)
+	if err != nil {
+		t.Fatalf("BuildEnvelope: %v", err)
+	}
+
+	if len([]rune(env.PayloadSummary)) != 200 {
+		t.Fatalf("expected summary truncated to 200 chars, got %d", len([]rune(env.PayloadSummary)))
+	}
+}
+
+func TestBuildEnvelope_UniqueIDs(t *testing.T) {
+	cfg := loadTestConfig(t)
+	uri := "whatsapp://messages/15551234567/5551234567@s.whatsapp.net"
+
+	env1, _ := BuildEnvelope(cfg, uri, nil)
+	env2, _ := BuildEnvelope(cfg, uri, nil)
+
+	if env1.EventID == env2.EventID {
+		t.Fatal("event_id should be unique")
+	}
+	if env1.TraceID == env2.TraceID {
+		t.Fatal("trace_id should be unique")
+	}
+}

--- a/packages/envoy/internal/mcpbridge/mock_test.go
+++ b/packages/envoy/internal/mcpbridge/mock_test.go
@@ -1,0 +1,106 @@
+package mcpbridge
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// writeMockServer writes a Go program that acts as a mock MCP server to disk
+// and returns the path to the compiled binary.
+func writeMockServer(dir string) string {
+	src := `package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type request struct {
+	JSONRPC string          ` + "`json:\"jsonrpc\"`" + `
+	ID      int             ` + "`json:\"id\"`" + `
+	Method  string          ` + "`json:\"method\"`" + `
+	Params  json.RawMessage ` + "`json:\"params,omitempty\"`" + `
+}
+
+type response struct {
+	JSONRPC string          ` + "`json:\"jsonrpc\"`" + `
+	ID      *int            ` + "`json:\"id,omitempty\"`" + `
+	Result  json.RawMessage ` + "`json:\"result,omitempty\"`" + `
+	Method  string          ` + "`json:\"method,omitempty\"`" + `
+	Params  json.RawMessage ` + "`json:\"params,omitempty\"`" + `
+}
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 1<<20), 1<<20)
+
+	for scanner.Scan() {
+		var req request
+		if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+			continue
+		}
+
+		switch req.Method {
+		case "initialize":
+			resp := response{JSONRPC: "2.0", ID: &req.ID, Result: json.RawMessage(` + "`" + `{"protocolVersion":"2024-11-05","capabilities":{"resources":{"subscribe":true}},"serverInfo":{"name":"mock","version":"1.0.0"}}` + "`" + `)}
+			data, _ := json.Marshal(resp)
+			fmt.Fprintln(os.Stdout, string(data))
+
+		case "notifications/initialized":
+			// No response needed.
+
+		case "resources/subscribe":
+			resp := response{JSONRPC: "2.0", ID: &req.ID, Result: json.RawMessage(` + "`" + `{}` + "`" + `)}
+			data, _ := json.Marshal(resp)
+			fmt.Fprintln(os.Stdout, string(data))
+
+			// After subscribing, immediately send a notification.
+			var params struct{ URI string ` + "`json:\"uri\"`" + ` }
+			json.Unmarshal(req.Params, &params)
+			if params.URI != "" {
+				notif := response{
+					JSONRPC: "2.0",
+					Method:  "notifications/resources/updated",
+					Params:  json.RawMessage(fmt.Sprintf(` + "`" + `{"uri":"whatsapp://messages/15551234567/5551234567@s.whatsapp.net"}` + "`" + `)),
+				}
+				data, _ := json.Marshal(notif)
+				fmt.Fprintln(os.Stdout, string(data))
+			}
+
+		case "resources/read":
+			resp := response{JSONRPC: "2.0", ID: &req.ID, Result: json.RawMessage(` + "`" + `{"contents":[{"uri":"whatsapp://messages/15551234567/5551234567@s.whatsapp.net","text":"Hello from mock"}]}` + "`" + `)}
+			data, _ := json.Marshal(resp)
+			fmt.Fprintln(os.Stdout, string(data))
+		}
+	}
+}
+`
+	srcPath := filepath.Join(dir, "mock_mcp_server.go")
+	os.WriteFile(srcPath, []byte(src), 0644)
+	return srcPath
+}
+
+// mockServerConfig returns a minimal config that uses a compiled binary as a mock MCP server.
+
+// mockServerConfig returns a minimal config that uses a shell script as a mock MCP server.
+// This approach avoids needing to compile a separate Go binary during tests.
+func mockServerConfig(scriptPath string) string {
+	cfg := map[string]any{
+		"servers": []map[string]any{
+			{
+				"name":           "whatsapp",
+				"transport":      "stdio",
+				"command":        []string{scriptPath},
+				"source":         "whatsapp",
+				"topic_template": "notifications.whatsapp.{phone}.{jid}.message",
+				"uri_pattern":    "whatsapp://messages/(?P<phone>[^/]+)/(?P<jid>.+)",
+				"resources":      []string{"whatsapp://messages/new"},
+			},
+		},
+	}
+	data, _ := json.Marshal(cfg)
+	return string(data)
+}

--- a/packages/envoy/internal/mcpbridge/protocol.go
+++ b/packages/envoy/internal/mcpbridge/protocol.go
@@ -1,0 +1,70 @@
+package mcpbridge
+
+import "encoding/json"
+
+// JSON-RPC 2.0 types for the MCP protocol.
+
+type jsonrpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// jsonrpcNotification is a JSON-RPC 2.0 notification (no id field).
+type jsonrpcNotification struct {
+	JSONRPC string          `json:"jsonrpc"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type jsonrpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      *int            `json:"id,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *jsonrpcError   `json:"error,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type jsonrpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// MCP-specific types.
+
+type initializeParams struct {
+	ProtocolVersion string           `json:"protocolVersion"`
+	Capabilities    clientCaps       `json:"capabilities"`
+	ClientInfo      clientInfoParams `json:"clientInfo"`
+}
+
+type clientCaps struct{}
+
+type clientInfoParams struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type subscribeParams struct {
+	URI string `json:"uri"`
+}
+
+type readParams struct {
+	URI string `json:"uri"`
+}
+
+type notificationParams struct {
+	URI string `json:"uri"`
+}
+
+type resourceContent struct {
+	URI      string `json:"uri"`
+	MimeType string `json:"mimeType,omitempty"`
+	Text     string `json:"text,omitempty"`
+}
+
+type readResult struct {
+	Contents []resourceContent `json:"contents"`
+}

--- a/packages/envoy/internal/mcpbridge/server.go
+++ b/packages/envoy/internal/mcpbridge/server.go
@@ -1,0 +1,303 @@
+package mcpbridge
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ServerState tracks the readiness of a managed MCP server.
+type ServerState int32
+
+const (
+	StateStarting ServerState = iota
+	StateReady
+	StateDead
+)
+
+// ManagedServer wraps a child MCP server process with lifecycle management.
+type ManagedServer struct {
+	cfg       ServerConfig
+	cmd       *exec.Cmd
+	stdin     io.WriteCloser
+	scanner   *bufio.Scanner
+	state     atomic.Int32
+	nextID    atomic.Int32
+	mu        sync.Mutex
+	pending   map[int]chan jsonrpcResponse
+	onNotify  func(uri string)
+	stopCh    chan struct{}
+	closeOnce sync.Once
+}
+
+// NewManagedServer creates a managed server from config. Call Start() to spawn.
+func NewManagedServer(cfg ServerConfig, onNotify func(uri string)) *ManagedServer {
+	s := &ManagedServer{
+		cfg:      cfg,
+		pending:  make(map[int]chan jsonrpcResponse),
+		onNotify: onNotify,
+		stopCh:   make(chan struct{}),
+	}
+	s.state.Store(int32(StateStarting))
+	return s
+}
+
+// State returns the current server state.
+func (s *ManagedServer) State() ServerState {
+	return ServerState(s.state.Load())
+}
+
+// Start spawns the child process, performs the MCP handshake, and subscribes to resources.
+func (s *ManagedServer) Start() error {
+	cmd := exec.Command(s.cfg.Command[0], s.cfg.Command[1:]...)
+	cmd.Stderr = os.Stderr
+
+	// Pass configured env vars to child.
+	cmd.Env = os.Environ()
+	for k, v := range s.cfg.Env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start %s: %w", s.cfg.Name, err)
+	}
+
+	s.cmd = cmd
+	s.stdin = stdin
+	s.scanner = bufio.NewScanner(stdout)
+	s.scanner.Buffer(make([]byte, 1<<20), 1<<20) // 1MB line buffer
+
+	// Start reading responses in background.
+	go s.readLoop()
+
+	// Perform MCP handshake.
+	if err := s.initialize(); err != nil {
+		s.kill()
+		return fmt.Errorf("initialize %s: %w", s.cfg.Name, err)
+	}
+
+	// Subscribe to configured resources.
+	for _, uri := range s.cfg.Resources {
+		if err := s.subscribe(uri); err != nil {
+			s.kill()
+			return fmt.Errorf("subscribe %s to %s: %w", s.cfg.Name, uri, err)
+		}
+	}
+
+	s.state.Store(int32(StateReady))
+	log.Printf("mcp-bridge: server %s ready", s.cfg.Name)
+	return nil
+}
+
+// Stop gracefully shuts down the child process.
+func (s *ManagedServer) Stop() {
+	s.closeOnce.Do(func() { close(s.stopCh) })
+	s.state.Store(int32(StateDead))
+	if s.stdin != nil {
+		s.stdin.Close()
+	}
+	if s.cmd != nil && s.cmd.Process != nil {
+		done := make(chan struct{})
+		go func() {
+			s.cmd.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			s.cmd.Process.Kill()
+		}
+	}
+}
+
+// WaitForExit blocks until the child process exits.
+func (s *ManagedServer) WaitForExit() error {
+	if s.cmd == nil {
+		return fmt.Errorf("not started")
+	}
+	return s.cmd.Wait()
+}
+
+func (s *ManagedServer) kill() {
+	if s.stdin != nil {
+		s.stdin.Close()
+	}
+	if s.cmd != nil && s.cmd.Process != nil {
+		s.cmd.Process.Kill()
+		s.cmd.Wait()
+	}
+	s.state.Store(int32(StateDead))
+}
+
+func (s *ManagedServer) nextRequestID() int {
+	return int(s.nextID.Add(1))
+}
+
+func (s *ManagedServer) send(req jsonrpcRequest) error {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = s.stdin.Write(data)
+	return err
+}
+
+func (s *ManagedServer) sendNotification(method string) error {
+	data, err := json.Marshal(jsonrpcNotification{
+		JSONRPC: "2.0",
+		Method:  method,
+	})
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = s.stdin.Write(data)
+	return err
+}
+
+func (s *ManagedServer) call(method string, params any) (json.RawMessage, error) {
+	id := s.nextRequestID()
+	ch := make(chan jsonrpcResponse, 1)
+	s.mu.Lock()
+	s.pending[id] = ch
+	s.mu.Unlock()
+
+	defer func() {
+		s.mu.Lock()
+		delete(s.pending, id)
+		s.mu.Unlock()
+	}()
+
+	var raw json.RawMessage
+	if params != nil {
+		var err error
+		raw, err = json.Marshal(params)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := s.send(jsonrpcRequest{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  method,
+		Params:  raw,
+	}); err != nil {
+		return nil, err
+	}
+
+	select {
+	case resp := <-ch:
+		if resp.Error != nil {
+			return nil, fmt.Errorf("rpc error %d: %s", resp.Error.Code, resp.Error.Message)
+		}
+		return resp.Result, nil
+	case <-time.After(30 * time.Second):
+		return nil, fmt.Errorf("timeout waiting for response to %s (id=%d)", method, id)
+	case <-s.stopCh:
+		return nil, fmt.Errorf("server stopped")
+	}
+}
+
+func (s *ManagedServer) readLoop() {
+	for s.scanner.Scan() {
+		line := s.scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var resp jsonrpcResponse
+		if err := json.Unmarshal(line, &resp); err != nil {
+			log.Printf("mcp-bridge: %s: invalid JSON from server: %v", s.cfg.Name, err)
+			continue
+		}
+
+		// Notification (no ID).
+		if resp.ID == nil && resp.Method != "" {
+			s.handleNotification(resp)
+			continue
+		}
+
+		// Response to a pending request.
+		if resp.ID != nil {
+			s.mu.Lock()
+			ch, ok := s.pending[*resp.ID]
+			s.mu.Unlock()
+			if ok {
+				ch <- resp
+			}
+		}
+	}
+	if err := s.scanner.Err(); err != nil {
+		log.Printf("mcp-bridge: %s: read error: %v", s.cfg.Name, err)
+	}
+	s.state.Store(int32(StateDead))
+}
+
+func (s *ManagedServer) handleNotification(resp jsonrpcResponse) {
+	if resp.Method != "notifications/resources/updated" {
+		return
+	}
+	var params notificationParams
+	if err := json.Unmarshal(resp.Params, &params); err != nil {
+		log.Printf("mcp-bridge: %s: invalid notification params: %v", s.cfg.Name, err)
+		return
+	}
+	if params.URI == "" {
+		return
+	}
+	if s.onNotify != nil {
+		go s.onNotify(params.URI)
+	}
+}
+
+func (s *ManagedServer) initialize() error {
+	_, err := s.call("initialize", initializeParams{
+		ProtocolVersion: "2024-11-05",
+		Capabilities:    clientCaps{},
+		ClientInfo: clientInfoParams{
+			Name:    "envoy-mcp-bridge",
+			Version: "1.0.0",
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	// Send initialized notification (no ID — true JSON-RPC notification).
+	return s.sendNotification("notifications/initialized")
+}
+
+func (s *ManagedServer) subscribe(uri string) error {
+	_, err := s.call("resources/subscribe", subscribeParams{URI: uri})
+	return err
+}
+
+// ReadResource calls resources/read and returns the content.
+func (s *ManagedServer) ReadResource(uri string) ([]resourceContent, error) {
+	raw, err := s.call("resources/read", readParams{URI: uri})
+	if err != nil {
+		return nil, err
+	}
+	var result readResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, fmt.Errorf("parse read result: %w", err)
+	}
+	return result.Contents, nil
+}

--- a/packages/envoy/internal/mcpbridge/server_test.go
+++ b/packages/envoy/internal/mcpbridge/server_test.go
@@ -1,0 +1,114 @@
+package mcpbridge
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func buildMockBinary(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	srcPath := writeMockServer(dir)
+	binPath := filepath.Join(dir, "mock_mcp_server")
+	cmd := exec.Command("go", "build", "-o", binPath, srcPath)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to build mock server: %v", err)
+	}
+	return binPath
+}
+
+func TestManagedServer_StartAndStop(t *testing.T) {
+	bin := buildMockBinary(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+	os.WriteFile(cfgPath, []byte(mockServerConfig(bin)), 0644)
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	var notifiedURI string
+	s := NewManagedServer(cfg.Servers[0], func(uri string) {
+		notifiedURI = uri
+	})
+
+	if err := s.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer s.Stop()
+
+	if s.State() != StateReady {
+		t.Fatalf("expected ready state, got %d", s.State())
+	}
+
+	// The mock server sends a notification after subscribe.
+	// Give it a moment to arrive.
+	time.Sleep(500 * time.Millisecond)
+
+	if notifiedURI == "" {
+		t.Fatal("expected notification URI to be set")
+	}
+	if notifiedURI != "whatsapp://messages/15551234567/5551234567@s.whatsapp.net" {
+		t.Fatalf("unexpected notified URI: %s", notifiedURI)
+	}
+}
+
+func TestManagedServer_ReadResource(t *testing.T) {
+	bin := buildMockBinary(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+	os.WriteFile(cfgPath, []byte(mockServerConfig(bin)), 0644)
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	s := NewManagedServer(cfg.Servers[0], nil)
+	if err := s.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer s.Stop()
+
+	contents, err := s.ReadResource("whatsapp://messages/15551234567/5551234567@s.whatsapp.net")
+	if err != nil {
+		t.Fatalf("ReadResource: %v", err)
+	}
+	if len(contents) != 1 {
+		t.Fatalf("expected 1 content, got %d", len(contents))
+	}
+	if contents[0].Text != "Hello from mock" {
+		t.Fatalf("unexpected text: %s", contents[0].Text)
+	}
+}
+
+func TestManagedServer_StopSetsStateDead(t *testing.T) {
+	bin := buildMockBinary(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+	os.WriteFile(cfgPath, []byte(mockServerConfig(bin)), 0644)
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	s := NewManagedServer(cfg.Servers[0], nil)
+	if err := s.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	s.Stop()
+
+	if s.State() != StateDead {
+		t.Fatalf("expected dead state after stop, got %d", s.State())
+	}
+}

--- a/packages/envoy/internal/routing/match_test.go
+++ b/packages/envoy/internal/routing/match_test.go
@@ -93,3 +93,54 @@ func TestGhostWisprPerRecordingFiltering(t *testing.T) {
 		}
 	}
 }
+
+func TestWhatsappTopicFiltering(t *testing.T) {
+	// Wildcard subscription for all messages on a phone number
+	pattern := "notifications.whatsapp.15551234567.>"
+	cases := []struct {
+		topic string
+		ok    bool
+	}{
+		// Should match: WhatsApp messages for this phone number
+		{topic: "notifications.whatsapp.15551234567.5551234567@s.whatsapp.net.message", ok: true},
+		{topic: "notifications.whatsapp.15551234567.group-abc@g.us.message", ok: true},
+		{topic: "notifications.whatsapp.15551234567.5551234567@s.whatsapp.net.status", ok: true},
+		// Should NOT match: different phone number
+		{topic: "notifications.whatsapp.15559876543.5551234567@s.whatsapp.net.message", ok: false},
+		// Should NOT match: other source topics
+		{topic: "notifications.slack.T123.C456.message", ok: false},
+		{topic: "notifications.github.sjawhar.legion.pr", ok: false},
+		{topic: "notifications.agent.ses_123", ok: false},
+	}
+	for _, item := range cases {
+		got := Match(pattern, item.topic)
+		if got != item.ok {
+			t.Fatalf("pattern=%s topic=%s expected=%v got=%v", pattern, item.topic, item.ok, got)
+		}
+	}
+}
+
+func TestWhatsappPerJIDFiltering(t *testing.T) {
+	// Subscription for a specific phone+JID combination using > wildcard
+	// Note: JID contains dots (e.g., s.whatsapp.net) which create extra NATS subject levels
+	// The > wildcard is required (not *) to match across these levels
+	pattern := "notifications.whatsapp.15551234567.5551234567@s.whatsapp.net.>"
+	cases := []struct {
+		topic string
+		ok    bool
+	}{
+		// Should match: events for this specific chat
+		{topic: "notifications.whatsapp.15551234567.5551234567@s.whatsapp.net.message", ok: true},
+		{topic: "notifications.whatsapp.15551234567.5551234567@s.whatsapp.net.status", ok: true},
+		// Should NOT match: different JID on same phone
+		{topic: "notifications.whatsapp.15551234567.group-abc@g.us.message", ok: false},
+		// Should NOT match: different phone number
+		{topic: "notifications.whatsapp.15559876543.5551234567@s.whatsapp.net.message", ok: false},
+	}
+	for _, item := range cases {
+		got := Match(pattern, item.topic)
+		if got != item.ok {
+			t.Fatalf("pattern=%s topic=%s expected=%v got=%v", pattern, item.topic, item.ok, got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #283

## Summary

Adds a generic MCP bridge component (`packages/envoy/cmd/mcp/`) that connects to MCP servers as a client, subscribes to resource notifications, and publishes events to NATS. First target: WhatsApp messages.

### What's included

**Contracts** — `whatsappSubject()` (TS) and `WhatsappSubject()` (Go) subject helpers with filtering proof tests verifying `notifications.whatsapp.{phone}.>` matches WhatsApp topics and rejects non-WhatsApp topics.

**MCP bridge binary** (`packages/envoy/cmd/mcp/`) — Thin entrypoint loading JSON config, connecting to NATS, spawning MCP servers via stdio, and serving `/healthz`.

**Bridge internals** (`packages/envoy/internal/mcpbridge/`):
- Config parsing with fail-fast validation (regex compilation, placeholder↔capture group matching, command existence)
- Minimal JSON-RPC 2.0 client (initialize, subscribe, listen, read — hand-rolled, no external MCP library)
- Process lifecycle management with exponential backoff restart (1s→30s cap), re-initialize + re-subscribe on restart
- Envelope construction from MCP notifications + resource reads with correct field mapping
- Graceful shutdown via `server.Shutdown(ctx)` on SIGTERM/SIGINT

**Tests** — 20 unit tests (config validation, envelope construction, topic rendering, mock MCP server handshake), 2 WhatsApp subject helper tests, 2 filtering proof tests, 3 E2E integration tests proving WhatsApp topic routing through NATS to subscribed sessions.