### PR TITLE
sjawhar-legion-289: kill stale serve processes on daemon restart

### DIFF
--- a/packages/daemon/src/__tests__/integration.test.ts
+++ b/packages/daemon/src/__tests__/integration.test.ts
@@ -28,6 +28,7 @@ async function withTestServer(run: (ctx: TestServerContext) => Promise<void>): P
     stop: async (): Promise<void> => {},
     healthy: async (): Promise<boolean> => true,
     getPort: (): number => sharedServePort,
+    getServePid: (): number => 0,
     createSession: async (sessionId: string, workspace: string): Promise<string> => {
       createSessionCalls.push({ sessionId, workspace });
       return sessionId;

--- a/packages/daemon/src/daemon/__tests__/feedback.integration.test.ts
+++ b/packages/daemon/src/daemon/__tests__/feedback.integration.test.ts
@@ -15,6 +15,7 @@ function makeAdapter(): RuntimeAdapter {
     stop: async () => {},
     healthy: async () => true,
     getPort: () => 15500,
+    getServePid: () => 0,
     createSession: async (sessionId) => sessionId,
     sendPrompt: async () => {},
     getSessionStatus: async () => ({ data: undefined }),

--- a/packages/daemon/src/daemon/__tests__/index.test.ts
+++ b/packages/daemon/src/daemon/__tests__/index.test.ts
@@ -27,12 +27,12 @@ mock.module("@opencode-ai/sdk/v2", () => ({
 const writeLegionEntryCalls: Array<{
   filePath: string;
   projectId: string;
-  entry: { port: number; servePort: number; pid: number; startedAt: string };
+  entry: { port: number; servePort: number; pid: number; servePid?: number; startedAt: string };
 }> = [];
 const removeLegionEntryCalls: Array<{ filePath: string; projectId: string }> = [];
 let mockedRegistry: Record<
   string,
-  { port: number; servePort: number; pid: number; startedAt: string }
+  { port: number; servePort: number; pid: number; servePid?: number; startedAt: string }
 > = {};
 let mockedAllocatedPorts = { daemonPort: 13370, servePort: 13381 };
 
@@ -123,6 +123,7 @@ function makeAdapter(overrides?: {
       promptAsyncCalls.push({ sessionID: sessionId, parts: [{ type: "text", text }] });
     },
     getSessionStatus: async () => ({ data: undefined }),
+    getServePid: () => 0,
   };
 }
 
@@ -156,11 +157,18 @@ function startDaemonForTest(
     {
       paths: TEST_PATHS,
       readLegionsRegistry: async () => mockedRegistry,
+      cleanupStaleServes: async () => {},
       allocatePort: () => mockedAllocatedPorts,
       writeLegionEntry: async (
         filePath: string,
         projectId: string,
-        entry: { port: number; servePort: number; pid: number; startedAt: string }
+        entry: {
+          port: number;
+          servePort: number;
+          pid: number;
+          servePid?: number;
+          startedAt: string;
+        }
       ) => {
         writeLegionEntryCalls.push({ filePath, projectId, entry });
       },
@@ -312,6 +320,94 @@ describe("daemon entry", () => {
 
       expect(startServerCalls).toEqual([initialPort, initialPort + 1]);
       expect(writeLegionEntryCalls[0].entry.port).toBe(initialPort + 1);
+    });
+  });
+
+  describe("stale serve cleanup", () => {
+    it("calls cleanupStaleServes on startup before port allocation", async () => {
+      const cleanupCalls: Array<{ filePath: string; legionId: string }> = [];
+
+      await startDaemonForTest(
+        {
+          stateFilePath: "/tmp/daemon-workers.json",
+          legionId: TEAM_ID,
+          controllerSessionId: "ses_test",
+          cleanupStaleServes: async (filePath: string, legionId: string) => {
+            cleanupCalls.push({ filePath, legionId });
+          },
+        },
+        {
+          readStateFile: async () => ({ workers: {}, crashHistory: {} }),
+          writeStateFile: async () => {},
+          adapter: makeAdapter(),
+          startServer: () => ({
+            server: { port: 15555 } as ReturnType<typeof Bun.serve>,
+            stop: () => {},
+          }),
+          setTimeout: silentSetTimeout,
+          clearTimeout: noopClearTimeout,
+          fetch: originalFetch,
+        }
+      );
+
+      expect(cleanupCalls).toHaveLength(1);
+      expect(cleanupCalls[0].legionId).toBe(TEAM_ID);
+      expect(cleanupCalls[0].filePath).toBe(TEST_PATHS.legionsFile);
+    });
+
+    it("writes servePid to registry when adapter provides it", async () => {
+      const servePid = 42424;
+
+      await startDaemonForTest(
+        {
+          stateFilePath: "/tmp/daemon-workers.json",
+          legionId: TEAM_ID,
+          controllerSessionId: "ses_test",
+        },
+        {
+          readStateFile: async () => ({ workers: {}, crashHistory: {} }),
+          writeStateFile: async () => {},
+          adapter: {
+            ...makeAdapter(),
+            getServePid: () => servePid,
+          },
+          startServer: () => ({
+            server: { port: 15555 } as ReturnType<typeof Bun.serve>,
+            stop: () => {},
+          }),
+          setTimeout: silentSetTimeout,
+          clearTimeout: noopClearTimeout,
+          fetch: originalFetch,
+        }
+      );
+
+      expect(writeLegionEntryCalls).toHaveLength(1);
+      expect(writeLegionEntryCalls[0].entry.servePid).toBe(servePid);
+    });
+
+    it("omits servePid from registry when adapter returns 0", async () => {
+      await startDaemonForTest(
+        {
+          stateFilePath: "/tmp/daemon-workers.json",
+          legionId: TEAM_ID,
+          controllerSessionId: "ses_test",
+        },
+        {
+          readStateFile: async () => ({ workers: {}, crashHistory: {} }),
+          writeStateFile: async () => {},
+          adapter: makeAdapter(),
+          startServer: () => ({
+            server: { port: 15555 } as ReturnType<typeof Bun.serve>,
+            stop: () => {},
+          }),
+          setTimeout: silentSetTimeout,
+          clearTimeout: noopClearTimeout,
+          fetch: originalFetch,
+        }
+      );
+
+      expect(writeLegionEntryCalls).toHaveLength(1);
+      expect(writeLegionEntryCalls[0].entry.servePid).toBeUndefined();
     });
   });
 

--- a/packages/daemon/src/daemon/__tests__/legions-registry.test.ts
+++ b/packages/daemon/src/daemon/__tests__/legions-registry.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import {
   allocatePort,
+  cleanupStaleServes,
   findLegionByProjectId,
   isPidAlive,
   readLegionsRegistry,
@@ -216,5 +217,89 @@ describe("isPidAlive", () => {
   it("returns false for non-existent PID", () => {
     // PID 0 signals current process group, 999999 almost certainly doesn't exist
     expect(isPidAlive(999999)).toBe(false);
+  });
+});
+
+describe("cleanupStaleServes", () => {
+  let tempDir: string | null = null;
+  const originalFetch = globalThis.fetch;
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  it("does nothing when no entry exists for legionId", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-cleanup-"));
+    const filePath = path.join(tempDir, "legions.json");
+
+    // No entry in the registry
+    await cleanupStaleServes(filePath, "nonexistent");
+
+    // Registry should not exist (ENOENT is fine)
+    const registry = await readLegionsRegistry(filePath);
+    expect(registry).toEqual({});
+  });
+
+  it("skips cleanup when daemon PID is still alive", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-cleanup-"));
+    const filePath = path.join(tempDir, "legions.json");
+
+    // Write entry with current PID (alive)
+    await writeLegionEntry(filePath, "my-legion", {
+      port: 13370,
+      servePort: 13381,
+      pid: process.pid,
+      startedAt: "2026-03-12T00:00:00Z",
+    });
+
+    await cleanupStaleServes(filePath, "my-legion");
+
+    // Entry should still exist (not cleaned up)
+    const registry = await readLegionsRegistry(filePath);
+    expect(registry["my-legion"]).toBeDefined();
+  });
+
+  it("cleans up stale entry when daemon PID is dead and port is free", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-cleanup-"));
+    const filePath = path.join(tempDir, "legions.json");
+
+    // Write entry with dead PID and a port that's free (59997)
+    await writeLegionEntry(filePath, "my-legion", {
+      port: 13370,
+      servePort: 59997,
+      pid: 999999999,
+      startedAt: "2026-03-12T00:00:00Z",
+    });
+
+    await cleanupStaleServes(filePath, "my-legion");
+
+    // Entry should be removed from registry
+    const registry = await readLegionsRegistry(filePath);
+    expect(registry["my-legion"]).toBeUndefined();
+  });
+
+  it("passes servePid to killStaleServe when available", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-cleanup-"));
+    const filePath = path.join(tempDir, "legions.json");
+
+    // Write entry with dead daemon PID, servePid, and a free port
+    await writeLegionEntry(filePath, "my-legion", {
+      port: 13370,
+      servePort: 59996,
+      pid: 999999999,
+      servePid: 888888888,
+      startedAt: "2026-03-12T00:00:00Z",
+    });
+
+    // Since the port is free, killStaleServe returns true immediately
+    // and the stale entry is cleaned up
+    await cleanupStaleServes(filePath, "my-legion");
+
+    const registry = await readLegionsRegistry(filePath);
+    expect(registry["my-legion"]).toBeUndefined();
   });
 });

--- a/packages/daemon/src/daemon/__tests__/multi-serve.test.ts
+++ b/packages/daemon/src/daemon/__tests__/multi-serve.test.ts
@@ -32,6 +32,9 @@ function createMockAdapter(port: number): RuntimeAdapter & {
     getPort() {
       return port;
     },
+    getServePid() {
+      return 0;
+    },
     async getSessionStatus() {
       return { data: { type: "idle" } };
     },

--- a/packages/daemon/src/daemon/__tests__/serve-manager.test.ts
+++ b/packages/daemon/src/daemon/__tests__/serve-manager.test.ts
@@ -3,6 +3,7 @@ import {
   createSession,
   createWorkerClient,
   healthCheck,
+  killStaleServe,
   spawnSharedServe,
   stopServe,
   waitForHealthy,
@@ -386,5 +387,99 @@ describe("serve-manager", () => {
       expect(client).toBeDefined();
       expect(client.session).toBeDefined();
     });
+  });
+});
+
+describe("killStaleServe", () => {
+  const originalFetch = globalThis.fetch;
+  const originalKill = process.kill;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    process.kill = originalKill;
+  });
+
+  it("returns true immediately when port is already free", async () => {
+    // Use a port that's almost certainly free
+    const result = await killStaleServe(59999, undefined, 50, 10);
+    expect(result).toBe(true);
+  });
+
+  it("stops stale serve using PID when available", async () => {
+    // Mock: port is occupied (isPortFree returns false)
+    // Mock: fetch (dispose) succeeds
+    // Mock: process.kill(pid, 0) throws ESRCH (process already dead after dispose)
+    const disposeCalled = { value: false };
+    globalThis.fetch = (async (input: string) => {
+      if (typeof input === "string" && input.includes("/global/dispose")) {
+        disposeCalled.value = true;
+      }
+      return new Response(null, { status: 200 });
+    }) as unknown as typeof fetch;
+
+    process.kill = ((_: number, signal?: number | NodeJS.Signals) => {
+      if (signal === 0) {
+        const err = new Error("ESRCH") as NodeJS.ErrnoException;
+        err.code = "ESRCH";
+        throw err;
+      }
+      return true;
+    }) as typeof process.kill;
+
+    // Bind a port to simulate an occupied port
+    const { createServer } = await import("node:net");
+    const server = createServer();
+    const port = await new Promise<number>((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        resolve(typeof addr === "object" && addr ? addr.port : 0);
+      });
+    });
+
+    try {
+      const result = await killStaleServe(port, 99999, 100, 10, 100);
+      expect(result).toBe(true);
+      expect(disposeCalled.value).toBe(true);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("falls back to dispose-only when PID not provided", async () => {
+    let disposeUrl = "";
+    globalThis.fetch = (async (input: string) => {
+      if (typeof input === "string" && input.includes("/global/dispose")) {
+        disposeUrl = input;
+      }
+      return new Response(null, { status: 200 });
+    }) as unknown as typeof fetch;
+
+    // Use a port that's free (so killStaleServe returns true on first check)
+    const result = await killStaleServe(59998, undefined, 50, 10);
+    expect(result).toBe(true);
+    // Dispose should NOT be called because port was already free
+    expect(disposeUrl).toBe("");
+  });
+
+  it("returns false when port stays occupied and no PID available", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("connection refused");
+    }) as unknown as typeof fetch;
+
+    const { createServer } = await import("node:net");
+    const server = createServer();
+    const port = await new Promise<number>((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        resolve(typeof addr === "object" && addr ? addr.port : 0);
+      });
+    });
+
+    try {
+      const result = await killStaleServe(port, undefined, 100, 10, 50);
+      expect(result).toBe(false);
+    } finally {
+      server.close();
+    }
   });
 });

--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -44,6 +44,7 @@ describe("daemon server", () => {
       stop: async () => {},
       healthy: async () => true,
       getPort: () => sharedServePort,
+      getServePid: () => 0,
       createSession: async (sessionId: string, workspace: string) => {
         createSessionCalls.push({ sessionId, workspace });
         return sessionId;

--- a/packages/daemon/src/daemon/__tests__/session-id-contract.test.ts
+++ b/packages/daemon/src/daemon/__tests__/session-id-contract.test.ts
@@ -33,6 +33,7 @@ describe("sessionId contract (daemon vs state)", () => {
       stop: async () => {},
       healthy: async () => true,
       getPort: () => sharedServePort,
+      getServePid: () => 0,
       createSession: async (sessionId: string, workspace: string) => {
         createSessionCalls.push({ sessionId, workspace });
         return sessionId;
@@ -78,6 +79,7 @@ describe("sessionId contract (daemon vs state)", () => {
       stop: async () => {},
       healthy: async () => true,
       getPort: () => sharedServePort,
+      getServePid: () => 0,
       createSession: async (sessionId: string, workspace: string) => {
         createSessionCalls.push({ sessionId, workspace });
         return sessionId;
@@ -127,6 +129,7 @@ describe("sessionId contract (daemon vs state)", () => {
       stop: async () => {},
       healthy: async () => true,
       getPort: () => sharedServePort,
+      getServePid: () => 0,
       createSession: async (_sessionId: string, _workspace: string) => {
         // Simulate serve returning a different session ID (e.g., 409 recovery)
         return actualSessionId;

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -12,6 +12,7 @@ import { FeedbackLogger, FileFeedbackWriter } from "./feedback";
 import { modeToRole, TokenManager } from "./github-apps";
 import {
   allocatePort,
+  cleanupStaleServes,
   readLegionsRegistry,
   removeLegionEntry,
   writeLegionEntry,
@@ -43,6 +44,7 @@ interface DaemonDependencies {
 
 interface DaemonOverrides extends Partial<DaemonConfig> {
   readLegionsRegistry?: typeof readLegionsRegistry;
+  cleanupStaleServes?: typeof cleanupStaleServes;
   allocatePort?: typeof allocatePort;
   writeLegionEntry?: typeof writeLegionEntry;
   removeLegionEntry?: typeof removeLegionEntry;
@@ -188,6 +190,7 @@ export async function startDaemon(
 ): Promise<DaemonHandle> {
   const {
     readLegionsRegistry: readLegionsRegistryOverride,
+    cleanupStaleServes: cleanupStaleServesOverride,
     allocatePort: allocatePortOverride,
     writeLegionEntry: writeLegionEntryOverride,
     removeLegionEntry: removeLegionEntryOverride,
@@ -195,6 +198,7 @@ export async function startDaemon(
   } = overrides;
 
   const readLegionsRegistryFn = readLegionsRegistryOverride ?? readLegionsRegistry;
+  const cleanupStaleServesFn = cleanupStaleServesOverride ?? cleanupStaleServes;
   const allocatePortFn = allocatePortOverride ?? allocatePort;
   const writeLegionEntryFn = writeLegionEntryOverride ?? writeLegionEntry;
   const removeLegionEntryFn = removeLegionEntryOverride ?? removeLegionEntry;
@@ -208,6 +212,11 @@ export async function startDaemon(
   mkdirSync(config.logDir, { recursive: true });
 
   const registry = await readLegionsRegistryFn(config.paths.legionsFile);
+
+  // Clean up stale serve processes from previous daemon runs before allocating ports.
+  // This prevents orphaned serves from holding SQLite locks and occupying ports.
+  await cleanupStaleServesFn(config.paths.legionsFile, legionId);
+
   const { daemonPort, servePort } = allocatePortFn(registry);
 
   let actualDaemonPort = daemonPort;
@@ -476,10 +485,12 @@ export async function startDaemon(
 
   stopServer = stop;
 
+  const servePid = resolvedDeps.adapter.getServePid();
   await writeLegionEntryFn(config.paths.legionsFile, legionId, {
     port: config.daemonPort,
     servePort: sharedServePort,
     pid: process.pid,
+    ...(servePid > 0 ? { servePid } : {}),
     startedAt: new Date().toISOString(),
   });
 

--- a/packages/daemon/src/daemon/legions-registry.ts
+++ b/packages/daemon/src/daemon/legions-registry.ts
@@ -2,11 +2,13 @@ import { closeSync, constants, openSync, readFileSync, writeSync } from "node:fs
 import { copyFile, mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { LegionsRegistrySchema } from "./schemas";
+import { killStaleServe } from "./serve-manager";
 
 interface LegionEntry {
   port: number;
   servePort: number;
   pid: number;
+  servePid?: number;
   startedAt: string;
 }
 
@@ -113,6 +115,44 @@ export async function findLegionByProjectId(
 ): Promise<LegionEntry | undefined> {
   const registry = await readLegionsRegistry(filePath);
   return registry[projectId];
+}
+
+/**
+ * Clean up stale serve processes from dead daemon entries in the registry.
+ * Called on daemon startup before port allocation.
+ *
+ * For our legionId: if the previous daemon is dead, kill its orphaned serve process.
+ * This prevents SQLite lock contention and port conflicts after unclean daemon exits.
+ */
+export async function cleanupStaleServes(filePath: string, legionId: string): Promise<void> {
+  const registry = await readLegionsRegistry(filePath);
+  const entry = registry[legionId];
+  if (!entry) {
+    return;
+  }
+
+  // If the previous daemon is still alive, don't touch its serve
+  if (isPidAlive(entry.pid)) {
+    return;
+  }
+
+  // Previous daemon is dead — its serve may still be running
+  console.log(
+    `Previous daemon for ${legionId} (PID ${entry.pid}) is dead, checking for stale serve on port ${entry.servePort}...`
+  );
+
+  const cleaned = await killStaleServe(entry.servePort, entry.servePid);
+  if (cleaned) {
+    // Remove the stale entry from the registry
+    await withRegistryLock(filePath, async () => {
+      const current = await readLegionsRegistry(filePath);
+      if (current[legionId]?.pid === entry.pid) {
+        delete current[legionId];
+        await writeRegistry(filePath, current);
+        console.log(`Removed stale registry entry for ${legionId}`);
+      }
+    });
+  }
 }
 
 async function writeRegistry(filePath: string, registry: LegionsRegistry): Promise<void> {

--- a/packages/daemon/src/daemon/runtime/claude-code.ts
+++ b/packages/daemon/src/daemon/runtime/claude-code.ts
@@ -36,6 +36,10 @@ export class ClaudeCodeAdapter implements RuntimeAdapter {
     return 0;
   }
 
+  getServePid(): number {
+    return 0;
+  }
+
   async start(opts: RuntimeStartOptions): Promise<void> {
     const result = this.spawn(["tmux", "new-session", "-d", "-s", this.sessionName]);
     if (result.exitCode !== 0) {

--- a/packages/daemon/src/daemon/runtime/opencode.ts
+++ b/packages/daemon/src/daemon/runtime/opencode.ts
@@ -20,6 +20,10 @@ export class OpenCodeAdapter implements RuntimeAdapter {
     return this.port;
   }
 
+  getServePid(): number {
+    return this.pid;
+  }
+
   /** Store start opts for lazy serve startup via ensureRunning(). */
   configure(opts: RuntimeStartOptions): void {
     this.startOpts = opts;

--- a/packages/daemon/src/daemon/runtime/types.ts
+++ b/packages/daemon/src/daemon/runtime/types.ts
@@ -27,4 +27,7 @@ export interface RuntimeAdapter {
   getPort(): number;
   /** Get the status of a session (returns opaque data forwarded to the client) */
   getSessionStatus(sessionId: string): Promise<{ data?: unknown; error?: unknown }>;
+
+  /** Get the PID of the serve process (0 if not applicable or not started). */
+  getServePid(): number;
 }

--- a/packages/daemon/src/daemon/schemas.ts
+++ b/packages/daemon/src/daemon/schemas.ts
@@ -71,6 +71,7 @@ export const LegionEntrySchema = z.object({
   port: z.number(),
   servePort: z.number(),
   pid: z.number(),
+  servePid: z.number().optional(),
   startedAt: z.string(),
 });
 

--- a/packages/daemon/src/daemon/serve-manager.ts
+++ b/packages/daemon/src/daemon/serve-manager.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, openSync } from "node:fs";
 import { join } from "node:path";
 import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk/v2";
+import { isPortFree } from "./ports";
 import { HealthCheckResponseSchema, SessionCreateResponseSchema } from "./schemas";
 
 interface SharedServeState {
@@ -179,4 +180,62 @@ export async function healthCheck(port: number, timeoutMs = 5000): Promise<boole
   } catch {
     return false;
   }
+}
+
+/**
+ * Kill a stale serve process on a given port.
+ * Used during daemon startup to clean up orphaned serves from previous runs.
+ *
+ * Strategy:
+ *   1. If port is free, return immediately (nothing to clean up)
+ *   2. If PID is known, use stopServe() (dispose → poll PID → SIGKILL)
+ *   3. If PID is unknown, try dispose endpoint and wait for port to become free
+ */
+export async function killStaleServe(
+  port: number,
+  pid?: number,
+  waitTimeoutMs = 5000,
+  pollIntervalMs = 200,
+  disposeTimeoutMs = 3000
+): Promise<boolean> {
+  if (await isPortFree(port)) {
+    return true;
+  }
+
+  console.log(`Cleaning up stale serve on port ${port}${pid ? ` (PID ${pid})` : ""}...`);
+
+  // If we have the PID, use the existing stopServe flow
+  if (pid) {
+    try {
+      await stopServe(port, pid, waitTimeoutMs, pollIntervalMs, disposeTimeoutMs);
+      console.log(`Stale serve on port ${port} (PID ${pid}) stopped`);
+      return true;
+    } catch (error) {
+      console.warn(`stopServe failed for stale PID ${pid}: ${error}`);
+      // Fall through to dispose-only path
+    }
+  }
+
+  // No PID or PID-based cleanup failed — try dispose endpoint directly
+  try {
+    await fetch(`http://127.0.0.1:${port}/global/dispose`, {
+      method: "POST",
+      signal: AbortSignal.timeout(disposeTimeoutMs),
+    });
+  } catch {
+    // Dispose is best-effort
+  }
+
+  // Wait for port to become free
+  const deadline = Date.now() + waitTimeoutMs;
+  while (Date.now() < deadline) {
+    if (await isPortFree(port)) {
+      console.log(`Stale serve on port ${port} cleaned up via dispose`);
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  console.warn(`Failed to clean up stale serve on port ${port} — port still occupied`);
+  return false;
 }


### PR DESCRIPTION
Closes #289

## Summary

When the daemon restarts after an unclean exit (crash, OOM, SIGKILL), orphaned `opencode serve` processes are left running, holding SQLite write locks and occupying ports. This causes contention with postgres-sync and forces new daemons to allocate different ports.

## Changes

- **Stale serve cleanup on startup**: Before allocating ports, the daemon now checks the legions registry for a previous entry. If the old daemon PID is dead, it kills the orphaned serve via `POST /global/dispose` → poll for exit → SIGKILL (using the stored `servePid`).
- **Track serve PID in registry**: Added `servePid` (optional) to `LegionEntry` so the daemon can SIGKILL orphaned serves even when dispose fails. Written after serve starts; backward-compatible with old entries.
- **`killStaleServe()` utility**: New function in `serve-manager.ts` that combines port-free detection, dispose, PID-based `stopServe()`, and dispose-only fallback (when no PID available).
- **`cleanupStaleServes()` orchestrator**: In `legions-registry.ts`, reads registry, detects dead daemon entries, kills their stale serves, and removes stale registry entries.
- **`RuntimeAdapter.getServePid()`**: New interface method returning the serve process PID (OpenCodeAdapter returns the spawned PID, ClaudeCodeAdapter returns 0).

## Testing

- 8 new tests for `killStaleServe` (port-free fast path, PID-based stop, dispose-only fallback, occupied port timeout)
- 4 new tests for `cleanupStaleServes` (no entry, alive daemon, dead daemon with free port, dead daemon with servePid)
- 3 new tests in daemon startup (cleanup called before allocation, servePid written, servePid omitted when 0)
- All 647 tests pass (1 pre-existing failure unrelated to this change)