### PR TITLE
sjawhar-legion-175: support issue/PR-specific GitHub subscriptions in Envoy

### DIFF
--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -1407,6 +1407,7 @@ describe("daemon server", () => {
       expect(envoySubscribeCalls[0].body.session_id).toBe(body.sessionId);
       expect(envoySubscribeCalls[0].body.topics).toEqual([
         "notifications.github.acme.widgets.issue.42.>",
+        "notifications.github.acme.widgets.pr.42.>",
       ]);
     });
 
@@ -1700,7 +1701,10 @@ describe("daemon server", () => {
       }>;
       const planWorker = workers.find((w) => w.id === "acme-widgets-70-plan");
       expect(planWorker).toBeDefined();
-      expect(planWorker?.envoyTopics).toEqual(["notifications.github.acme.widgets.issue.70.>"]);
+      expect(planWorker?.envoyTopics).toEqual([
+        "notifications.github.acme.widgets.issue.70.>",
+        "notifications.github.acme.widgets.pr.70.>",
+      ]);
     });
 
     it("omits envoyTopics for non-plan mode dispatch", async () => {

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -545,6 +545,7 @@ export function startServer(opts: ServerOptions): {
               if (repoRef) {
                 const topics = [
                   `notifications.github.${repoRef.owner}.${repoRef.repo}.issue.${issueNumber}.>`,
+                  `notifications.github.${repoRef.owner}.${repoRef.repo}.pr.${issueNumber}.>`,
                 ];
                 subscribeWorkerToEnvoy(actualSessionId, topics);
                 entry.envoyTopics = topics;

--- a/packages/envoy/cmd/github/main.go
+++ b/packages/envoy/cmd/github/main.go
@@ -134,10 +134,6 @@ func githubEvent(event string) bool {
 	return false
 }
 
-func githubSkip(event string) bool {
-	switch event {
-	case "check_run", "check_suite":
-		return true
-	}
+func githubSkip(_ string) bool {
 	return false
 }

--- a/packages/envoy/internal/contracts/normalize.go
+++ b/packages/envoy/internal/contracts/normalize.go
@@ -39,6 +39,27 @@ func GithubEnvelope(input GithubEnvelopeInput) Envelope {
 func GithubEnvelopes(input GithubEnvelopeInput, trigger string) []Envelope {
 	item := GithubEnvelope(input)
 	out := []Envelope{item}
+	if githubCIEvent(input.Event) {
+		prs := githubCIPullRequests(input.Event, input.Body)
+		if len(prs) > 0 {
+			owner := nestedString(input.Body, "repository", "owner", "login")
+			if owner == "" {
+				owner = "unknown"
+			}
+			repo := nestedString(input.Body, "repository", "name")
+			if repo == "" {
+				repo = "unknown"
+			}
+			out = make([]Envelope, 0, len(prs))
+			for _, pr := range prs {
+				ci := item
+				ci.Topic = GithubSubject(owner, repo, "pr."+pr+".ci")
+				ci.DedupeKey = "github." + input.Delivery + ".pr." + pr
+				out = append(out, ci)
+			}
+		}
+		return out
+	}
 	if !githubCommentEvent(input.Event) {
 		return out
 	}
@@ -85,7 +106,7 @@ func ContainsMention(body string, trigger string) bool {
 		if mentionEdge(body, idx, idx+len(trigger)) {
 			return true
 		}
-	next := idx + len(trigger)
+		next := idx + len(trigger)
 		if next >= len(body) {
 			return false
 		}
@@ -224,6 +245,10 @@ func githubNumber(event string, body map[string]any) string {
 		if n != nil {
 			return fmt.Sprintf("%v", n)
 		}
+	case "check_run", "check_suite":
+		if nums := githubCIPullRequests(event, body); len(nums) > 0 {
+			return nums[0]
+		}
 	}
 	return ""
 }
@@ -234,6 +259,43 @@ func githubCommentEvent(event string) bool {
 		return true
 	}
 	return false
+}
+
+func githubCIEvent(event string) bool {
+	switch event {
+	case "check_run", "check_suite":
+		return true
+	}
+	return false
+}
+
+func githubCIPullRequests(event string, body map[string]any) []string {
+	var key string
+	switch event {
+	case "check_run":
+		key = "check_run"
+	case "check_suite":
+		key = "check_suite"
+	default:
+		return nil
+	}
+	obj, _ := body[key].(map[string]any)
+	if obj == nil {
+		return nil
+	}
+	prs, _ := obj["pull_requests"].([]any)
+	var nums []string
+	for _, pr := range prs {
+		prMap, _ := pr.(map[string]any)
+		if prMap == nil {
+			continue
+		}
+		n := prMap["number"]
+		if n != nil {
+			nums = append(nums, fmt.Sprintf("%v", n))
+		}
+	}
+	return nums
 }
 
 func githubCommentBody(event string, body map[string]any) string {
@@ -323,6 +385,25 @@ func githubSummary(event string, body map[string]any) string {
 			"repo": repo,
 			"ref":  stringValue(body["ref"]),
 		}
+	case "check_run":
+		data = map[string]string{
+			"kind":       "ci",
+			"action":     action,
+			"repo":       repo,
+			"number":     num,
+			"name":       nestedString(body, "check_run", "name"),
+			"status":     nestedString(body, "check_run", "status"),
+			"conclusion": nestedString(body, "check_run", "conclusion"),
+		}
+	case "check_suite":
+		data = map[string]string{
+			"kind":       "ci",
+			"action":     action,
+			"repo":       repo,
+			"number":     num,
+			"status":     nestedString(body, "check_suite", "status"),
+			"conclusion": nestedString(body, "check_suite", "conclusion"),
+		}
 	default:
 		data = map[string]string{
 			"kind":   "unknown",
@@ -333,22 +414,6 @@ func githubSummary(event string, body map[string]any) string {
 
 	out, _ := json.Marshal(data)
 	return string(out)
-}
-
-func githubName(body map[string]any) string {
-	repo := nestedString(body, "repository", "name")
-	if repo != "" {
-		return repo
-	}
-	return "unknown"
-}
-
-func githubRepo(body map[string]any) string {
-	owner := nestedString(body, "repository", "owner", "login")
-	if owner != "" {
-		return owner
-	}
-	return "unknown"
 }
 
 func mentionEdge(body string, start int, end int) bool {

--- a/packages/envoy/internal/contracts/normalize_test.go
+++ b/packages/envoy/internal/contracts/normalize_test.go
@@ -526,6 +526,37 @@ func TestGithubSummaryJSON(t *testing.T) {
 			checkValues:  map[string]string{"kind": "push", "repo": "sjawhar/legion", "ref": "refs/heads/main"},
 		},
 		{
+			name:  "check_run",
+			event: "check_run",
+			body: map[string]any{
+				"action":     "completed",
+				"repository": map[string]any{"full_name": "sjawhar/legion"},
+				"check_run": map[string]any{
+					"name":          "test",
+					"status":        "completed",
+					"conclusion":    "success",
+					"pull_requests": []any{},
+				},
+			},
+			expectedKeys: []string{"kind", "action", "repo", "number", "name", "status", "conclusion"},
+			checkValues:  map[string]string{"kind": "ci", "action": "completed", "repo": "sjawhar/legion", "number": "", "name": "test", "status": "completed", "conclusion": "success"},
+		},
+		{
+			name:  "check_suite",
+			event: "check_suite",
+			body: map[string]any{
+				"action":     "completed",
+				"repository": map[string]any{"full_name": "sjawhar/legion"},
+				"check_suite": map[string]any{
+					"status":        "completed",
+					"conclusion":    "failure",
+					"pull_requests": []any{},
+				},
+			},
+			expectedKeys: []string{"kind", "action", "repo", "number", "status", "conclusion"},
+			checkValues:  map[string]string{"kind": "ci", "action": "completed", "repo": "sjawhar/legion", "number": "", "status": "completed", "conclusion": "failure"},
+		},
+		{
 			name:  "unknown event",
 			event: "deployment",
 			body: map[string]any{
@@ -619,6 +650,160 @@ func TestGithubResourceSubject(t *testing.T) {
 		if got != item.want {
 			t.Fatalf("GithubResourceSubject(%s, %s, %s, %s) = %s, want %s", item.owner, item.repo, item.resourceType, item.resourceNum, got, item.want)
 		}
+	}
+}
+
+func TestGithubEnvelopesCICheckRunNoPRs(t *testing.T) {
+	items := GithubEnvelopes(GithubEnvelopeInput{
+		Event:    "check_run",
+		Delivery: "d1",
+		EventID:  "e1",
+		TraceID:  "t1",
+		Body: map[string]any{
+			"action": "completed",
+			"repository": map[string]any{
+				"full_name": "sjawhar/legion",
+				"name":      "legion",
+				"owner":     map[string]any{"login": "sjawhar"},
+			},
+			"check_run": map[string]any{
+				"name":          "test",
+				"status":        "completed",
+				"conclusion":    "success",
+				"pull_requests": []any{},
+			},
+		},
+	}, "@legion")
+	if len(items) != 1 {
+		t.Fatalf("expected 1 envelope, got %d", len(items))
+	}
+	if items[0].Topic != "notifications.github.sjawhar.legion.ci" {
+		t.Fatalf("unexpected topic: %s", items[0].Topic)
+	}
+	if items[0].DedupeKey != "github.d1" {
+		t.Fatalf("unexpected dedupe key: %s", items[0].DedupeKey)
+	}
+}
+
+func TestGithubEnvelopesCICheckRunOnePR(t *testing.T) {
+	items := GithubEnvelopes(GithubEnvelopeInput{
+		Event:    "check_run",
+		Delivery: "d1",
+		EventID:  "e1",
+		TraceID:  "t1",
+		Body: map[string]any{
+			"action": "completed",
+			"repository": map[string]any{
+				"full_name": "sjawhar/legion",
+				"name":      "legion",
+				"owner":     map[string]any{"login": "sjawhar"},
+			},
+			"check_run": map[string]any{
+				"name":       "test",
+				"status":     "completed",
+				"conclusion": "success",
+				"pull_requests": []any{
+					map[string]any{"number": 42},
+				},
+			},
+		},
+	}, "@legion")
+	if len(items) != 1 {
+		t.Fatalf("expected 1 envelope, got %d", len(items))
+	}
+	if items[0].Topic != "notifications.github.sjawhar.legion.pr.42.ci" {
+		t.Fatalf("unexpected topic: %s", items[0].Topic)
+	}
+	if items[0].DedupeKey != "github.d1.pr.42" {
+		t.Fatalf("unexpected dedupe key: %s", items[0].DedupeKey)
+	}
+}
+
+func TestGithubEnvelopesCICheckRunMultiplePRs(t *testing.T) {
+	items := GithubEnvelopes(GithubEnvelopeInput{
+		Event:    "check_run",
+		Delivery: "d1",
+		EventID:  "e1",
+		TraceID:  "t1",
+		Body: map[string]any{
+			"action": "completed",
+			"repository": map[string]any{
+				"full_name": "sjawhar/legion",
+				"name":      "legion",
+				"owner":     map[string]any{"login": "sjawhar"},
+			},
+			"check_run": map[string]any{
+				"name":       "test",
+				"status":     "completed",
+				"conclusion": "success",
+				"pull_requests": []any{
+					map[string]any{"number": 42},
+					map[string]any{"number": 43},
+					map[string]any{"number": 44},
+				},
+			},
+		},
+	}, "@legion")
+	if len(items) != 3 {
+		t.Fatalf("expected 3 envelopes, got %d", len(items))
+	}
+	expectedTopics := []string{
+		"notifications.github.sjawhar.legion.pr.42.ci",
+		"notifications.github.sjawhar.legion.pr.43.ci",
+		"notifications.github.sjawhar.legion.pr.44.ci",
+	}
+	expectedDedupeKeys := []string{
+		"github.d1.pr.42",
+		"github.d1.pr.43",
+		"github.d1.pr.44",
+	}
+	for i, item := range items {
+		if item.Topic != expectedTopics[i] {
+			t.Fatalf("envelope[%d] unexpected topic: %s, want %s", i, item.Topic, expectedTopics[i])
+		}
+		if item.DedupeKey != expectedDedupeKeys[i] {
+			t.Fatalf("envelope[%d] unexpected dedupe key: %s, want %s", i, item.DedupeKey, expectedDedupeKeys[i])
+		}
+	}
+	seen := map[string]bool{}
+	for _, item := range items {
+		if seen[item.DedupeKey] {
+			t.Fatalf("duplicate dedupe key: %s", item.DedupeKey)
+		}
+		seen[item.DedupeKey] = true
+	}
+}
+
+func TestGithubEnvelopesCICheckSuiteOnePR(t *testing.T) {
+	items := GithubEnvelopes(GithubEnvelopeInput{
+		Event:    "check_suite",
+		Delivery: "d2",
+		EventID:  "e2",
+		TraceID:  "t2",
+		Body: map[string]any{
+			"action": "completed",
+			"repository": map[string]any{
+				"full_name": "sjawhar/legion",
+				"name":      "legion",
+				"owner":     map[string]any{"login": "sjawhar"},
+			},
+			"check_suite": map[string]any{
+				"status":     "completed",
+				"conclusion": "success",
+				"pull_requests": []any{
+					map[string]any{"number": 99},
+				},
+			},
+		},
+	}, "@legion")
+	if len(items) != 1 {
+		t.Fatalf("expected 1 envelope, got %d", len(items))
+	}
+	if items[0].Topic != "notifications.github.sjawhar.legion.pr.99.ci" {
+		t.Fatalf("unexpected topic: %s", items[0].Topic)
+	}
+	if items[0].DedupeKey != "github.d2.pr.99" {
+		t.Fatalf("unexpected dedupe key: %s", items[0].DedupeKey)
 	}
 }
 

--- a/packages/envoy/internal/routing/match_test.go
+++ b/packages/envoy/internal/routing/match_test.go
@@ -144,3 +144,23 @@ func TestWhatsappPerJIDFiltering(t *testing.T) {
 		}
 	}
 }
+
+func TestCITopicFiltering(t *testing.T) {
+	pattern := "notifications.github.acme.widgets.pr.42.>"
+	cases := []struct {
+		topic string
+		ok    bool
+	}{
+		{topic: "notifications.github.acme.widgets.pr.42.ci", ok: true},
+		{topic: "notifications.github.acme.widgets.pr.42.comment", ok: true},
+		{topic: "notifications.github.acme.widgets.pr.42.review", ok: true},
+		{topic: "notifications.github.acme.widgets.pr.43.ci", ok: false},
+		{topic: "notifications.github.acme.widgets.ci", ok: false},
+	}
+	for _, item := range cases {
+		got := Match(pattern, item.topic)
+		if got != item.ok {
+			t.Fatalf("pattern=%s topic=%s expected=%v got=%v", pattern, item.topic, item.ok, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #175

Enables CI event normalization with per-PR fan-out and dual issue+PR subscriptions so agents receive only events for their specific resource.

### Changes
- **Go normalization**: Add CI event handling — `githubCIPullRequests()` helper, CI cases in `githubNumber()`, `githubKind()`, and `githubSummary()`; multi-PR fan-out in `GithubEnvelopes()` with unique dedupe keys
- **Go receiver**: Remove `check_run`/`check_suite` from skip list
- **TS daemon**: Subscribe workers to both `issue.NUMBER.>` and `pr.NUMBER.>` topics
- **Tests**: CI envelope routing, fan-out, topic filtering, dual-subscription
- **Cleanup**: Remove unused `githubName()`/`githubRepo()` functions, fix whitespace in `ContainsMention()`