### PR TITLE
sjawhar-legion-290: auto-restart serve when RSS exceeds threshold

### DIFF
--- a/packages/daemon/src/daemon/__tests__/config.test.ts
+++ b/packages/daemon/src/daemon/__tests__/config.test.ts
@@ -186,4 +186,41 @@ describe("daemon config", () => {
       });
     });
   });
+
+  describe("RSS monitoring config", () => {
+    it("defaults maxRssBytes to 20GB", () => {
+      const config = loadConfig({});
+      expect(config.maxRssBytes).toBe(20 * 1024 * 1024 * 1024);
+    });
+
+    it("defaults rssCheckIntervalMs to 60s", () => {
+      const config = loadConfig({});
+      expect(config.rssCheckIntervalMs).toBe(60_000);
+    });
+
+    it("parses OPENCODE_MAX_RSS_GB", () => {
+      const config = loadConfig({ OPENCODE_MAX_RSS_GB: "10" });
+      expect(config.maxRssBytes).toBe(10 * 1024 * 1024 * 1024);
+    });
+
+    it("disables RSS check when OPENCODE_MAX_RSS_GB=0", () => {
+      const config = loadConfig({ OPENCODE_MAX_RSS_GB: "0" });
+      expect(config.maxRssBytes).toBe(0);
+    });
+
+    it("parses OPENCODE_RSS_CHECK_INTERVAL", () => {
+      const config = loadConfig({ OPENCODE_RSS_CHECK_INTERVAL: "120" });
+      expect(config.rssCheckIntervalMs).toBe(120_000);
+    });
+
+    it("falls back to default for invalid OPENCODE_MAX_RSS_GB", () => {
+      const config = loadConfig({ OPENCODE_MAX_RSS_GB: "not-a-number" });
+      expect(config.maxRssBytes).toBe(20 * 1024 * 1024 * 1024);
+    });
+
+    it("falls back to default for invalid OPENCODE_RSS_CHECK_INTERVAL", () => {
+      const config = loadConfig({ OPENCODE_RSS_CHECK_INTERVAL: "abc" });
+      expect(config.rssCheckIntervalMs).toBe(60_000);
+    });
+  });
 });

--- a/packages/daemon/src/daemon/__tests__/feedback.test.ts
+++ b/packages/daemon/src/daemon/__tests__/feedback.test.ts
@@ -94,6 +94,7 @@ function validEvents(): FeedbackEvent[] {
       uptimeS: 60,
       serveRestarted: false,
       sessionsRecreated: 0,
+      rssRestarts: 0,
     },
   ];
 }
@@ -265,6 +266,7 @@ describe("FeedbackLogger", () => {
       uptimeS: 120,
       serveRestarted: false,
       sessionsRecreated: 1,
+      rssRestarts: 0,
     });
 
     await logger.flush();

--- a/packages/daemon/src/daemon/__tests__/index.test.ts
+++ b/packages/daemon/src/daemon/__tests__/index.test.ts
@@ -101,6 +101,7 @@ function makeAdapter(overrides?: {
   healthy?: () => Promise<boolean>;
   stopServeCalls?: number[];
   createSessionCalls?: Array<{ sessionId: string; workspace: string }>;
+  getServePid?: () => number;
 }): RuntimeAdapter {
   const createSessionCalls = overrides?.createSessionCalls ?? [];
   const stopServeCalls = overrides?.stopServeCalls ?? [];
@@ -123,7 +124,7 @@ function makeAdapter(overrides?: {
       promptAsyncCalls.push({ sessionID: sessionId, parts: [{ type: "text", text }] });
     },
     getSessionStatus: async () => ({ data: undefined }),
-    getServePid: () => 0,
+    getServePid: overrides?.getServePid ?? (() => 0),
   };
 }
 
@@ -1296,6 +1297,247 @@ describe("daemon entry", () => {
       await handle.stop();
 
       expect(flush).toHaveBeenCalledTimes(1);
+    });
+  });
+  describe("RSS-based serve restart", () => {
+    it("triggers stop + start when RSS exceeds threshold (Linux only)", async () => {
+      // Skip on non-Linux where /proc doesn't exist
+      if (process.platform !== "linux") return;
+
+      let timeoutCallback: TimeoutCallback | null = null;
+      const mockSetTimeout: typeof setTimeout = Object.assign(
+        ((callback: TimeoutCallback, _delay?: number, ..._args: unknown[]) => {
+          timeoutCallback = callback as TimeoutCallback;
+          return {} as ReturnType<typeof setTimeout>;
+        }) as unknown as typeof setTimeout,
+        { __promisify__: setTimeout.__promisify__ }
+      );
+
+      let _healthCallCount = 0;
+      const stopCalls: number[] = [];
+      const startCalls: Array<{
+        workspace: string;
+        logDir?: string;
+        env?: Record<string, string>;
+      }> = [];
+      const createSessionCalls: Array<{ sessionId: string; workspace: string }> = [];
+
+      await startDaemonForTest(
+        {
+          stateFilePath: "/tmp/daemon-workers.json",
+          checkIntervalMs: 1000,
+          legionId: TEAM_ID,
+          controllerSessionId: "ses_test",
+          // 1 byte threshold \u2014 any real process will exceed this
+          maxRssBytes: 1,
+          rssCheckIntervalMs: 0,
+        },
+        {
+          readStateFile: async () => ({
+            workers: { [baseEntry.id]: baseEntry },
+            crashHistory: {},
+          }),
+          writeStateFile: async () => {},
+          adapter: {
+            ...makeAdapter({
+              createSessionCalls,
+              stopServeCalls: stopCalls,
+              healthy: async () => {
+                _healthCallCount += 1;
+                return true;
+              },
+              // Use the real test process PID so /proc/<pid>/statm exists
+              getServePid: () => process.pid,
+            }),
+            start: async (opts) => {
+              startCalls.push(opts);
+            },
+          },
+          startServer: () => ({
+            server: { port: 15555 } as ReturnType<typeof Bun.serve>,
+            stop: () => {},
+          }),
+          setTimeout: mockSetTimeout,
+          clearTimeout: () => {},
+          fetch: originalFetch,
+        }
+      );
+
+      if (!timeoutCallback) throw new Error("Expected health loop callback to be scheduled");
+      await (timeoutCallback as () => Promise<void>)();
+
+      // RSS exceeded: stop was called (graceful shutdown before restart)
+      expect(stopCalls.length).toBeGreaterThanOrEqual(1);
+      // Then start was called (restart)
+      expect(startCalls.length).toBeGreaterThanOrEqual(1);
+      // Worker session was re-created after restart
+      const reCreated = createSessionCalls.filter((c) => c.sessionId === baseEntry.sessionId);
+      expect(reCreated.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("does not check RSS when serve is unhealthy", async () => {
+      let timeoutCallback: TimeoutCallback | null = null;
+      const mockSetTimeout: typeof setTimeout = Object.assign(
+        ((callback: TimeoutCallback, _delay?: number, ..._args: unknown[]) => {
+          timeoutCallback = callback as TimeoutCallback;
+          return {} as ReturnType<typeof setTimeout>;
+        }) as unknown as typeof setTimeout,
+        { __promisify__: setTimeout.__promisify__ }
+      );
+
+      let healthCallCount = 0;
+      const createSessionCalls: Array<{ sessionId: string; workspace: string }> = [];
+
+      await startDaemonForTest(
+        {
+          stateFilePath: "/tmp/daemon-workers.json",
+          checkIntervalMs: 1000,
+          legionId: TEAM_ID,
+          controllerSessionId: "ses_test",
+          maxRssBytes: 1 * 1024 * 1024 * 1024,
+          rssCheckIntervalMs: 0,
+        },
+        {
+          readStateFile: async () => ({
+            workers: { [baseEntry.id]: baseEntry },
+            crashHistory: {},
+          }),
+          writeStateFile: async () => {},
+          adapter: makeAdapter({
+            createSessionCalls,
+            healthy: async () => {
+              healthCallCount += 1;
+              if (healthCallCount === 1) return true;
+              if (healthCallCount === 2) return false;
+              return true;
+            },
+            getServePid: () => 12345,
+          }),
+          startServer: () => ({
+            server: { port: 15555 } as ReturnType<typeof Bun.serve>,
+            stop: () => {},
+          }),
+          setTimeout: mockSetTimeout,
+          clearTimeout: () => {},
+          fetch: originalFetch,
+        }
+      );
+
+      if (!timeoutCallback) throw new Error("Expected health loop callback to be scheduled");
+      await (timeoutCallback as () => Promise<void>)();
+
+      // Unhealthy restart happened (session recreated)
+      const reCreatedSessions = createSessionCalls.filter(
+        (c) => c.sessionId === baseEntry.sessionId
+      );
+      expect(reCreatedSessions.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("skips RSS check when maxRssBytes is 0 (disabled)", async () => {
+      let timeoutCallback: TimeoutCallback | null = null;
+      const mockSetTimeout: typeof setTimeout = Object.assign(
+        ((callback: TimeoutCallback, _delay?: number, ..._args: unknown[]) => {
+          timeoutCallback = callback as TimeoutCallback;
+          return {} as ReturnType<typeof setTimeout>;
+        }) as unknown as typeof setTimeout,
+        { __promisify__: setTimeout.__promisify__ }
+      );
+
+      let _healthCallCount = 0;
+      const stopCalls: number[] = [];
+
+      await startDaemonForTest(
+        {
+          stateFilePath: "/tmp/daemon-workers.json",
+          checkIntervalMs: 1000,
+          legionId: TEAM_ID,
+          controllerSessionId: "ses_test",
+          maxRssBytes: 0,
+          rssCheckIntervalMs: 0,
+        },
+        {
+          readStateFile: async () => ({
+            workers: {},
+            crashHistory: {},
+          }),
+          writeStateFile: async () => {},
+          adapter: makeAdapter({
+            stopServeCalls: stopCalls,
+            healthy: async () => {
+              _healthCallCount += 1;
+              return true;
+            },
+            getServePid: () => 12345,
+          }),
+          startServer: () => ({
+            server: { port: 15555 } as ReturnType<typeof Bun.serve>,
+            stop: () => {},
+          }),
+          setTimeout: mockSetTimeout,
+          clearTimeout: () => {},
+          fetch: originalFetch,
+        }
+      );
+
+      if (!timeoutCallback) throw new Error("Expected health loop callback to be scheduled");
+      await (timeoutCallback as () => Promise<void>)();
+
+      // No restart should happen — serve is healthy and RSS check is disabled
+      expect(stopCalls).toHaveLength(0);
+    });
+
+    it("skips RSS check when getServePid returns 0", async () => {
+      let timeoutCallback: TimeoutCallback | null = null;
+      const mockSetTimeout: typeof setTimeout = Object.assign(
+        ((callback: TimeoutCallback, _delay?: number, ..._args: unknown[]) => {
+          timeoutCallback = callback as TimeoutCallback;
+          return {} as ReturnType<typeof setTimeout>;
+        }) as unknown as typeof setTimeout,
+        { __promisify__: setTimeout.__promisify__ }
+      );
+
+      let _healthCallCount = 0;
+      const stopCalls: number[] = [];
+
+      await startDaemonForTest(
+        {
+          stateFilePath: "/tmp/daemon-workers.json",
+          checkIntervalMs: 1000,
+          legionId: TEAM_ID,
+          controllerSessionId: "ses_test",
+          maxRssBytes: 1 * 1024 * 1024 * 1024,
+          rssCheckIntervalMs: 0,
+        },
+        {
+          readStateFile: async () => ({
+            workers: {},
+            crashHistory: {},
+          }),
+          writeStateFile: async () => {},
+          adapter: makeAdapter({
+            stopServeCalls: stopCalls,
+            healthy: async () => {
+              _healthCallCount += 1;
+              return true;
+            },
+            // PID 0 = not applicable (e.g., ClaudeCode adapter)
+            getServePid: () => 0,
+          }),
+          startServer: () => ({
+            server: { port: 15555 } as ReturnType<typeof Bun.serve>,
+            stop: () => {},
+          }),
+          setTimeout: mockSetTimeout,
+          clearTimeout: () => {},
+          fetch: originalFetch,
+        }
+      );
+
+      if (!timeoutCallback) throw new Error("Expected health loop callback to be scheduled");
+      await (timeoutCallback as () => Promise<void>)();
+
+      // No restart should happen — getServePid returns 0
+      expect(stopCalls).toHaveLength(0);
     });
   });
 });

--- a/packages/daemon/src/daemon/__tests__/rss-monitor.test.ts
+++ b/packages/daemon/src/daemon/__tests__/rss-monitor.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import { readProcessRssBytes } from "../rss-monitor";
+
+describe("readProcessRssBytes", () => {
+  it("parses /proc/<pid>/statm and returns RSS in bytes", () => {
+    // statm format: size resident shared text lib data dt (all in pages)
+    // 100000 pages * 4096 bytes/page = 409600000 bytes
+    const fakeStatm = "200000 100000 5000 1000 0 50000 0";
+    const result = readProcessRssBytes(1, () => fakeStatm);
+    expect(result).toBe(100000 * 4096);
+  });
+
+  it("returns null when file read fails", () => {
+    const result = readProcessRssBytes(99999, () => {
+      throw new Error("No such file or directory");
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when resident field is not a number", () => {
+    const result = readProcessRssBytes(1, () => "200000 NaN 5000");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when statm has insufficient fields", () => {
+    const result = readProcessRssBytes(1, () => "200000");
+    expect(result).toBeNull();
+  });
+
+  it("handles large RSS values (20GB+)", () => {
+    // 20GB = 20 * 1024 * 1024 * 1024 bytes = 5242880 pages (at 4096 bytes/page)
+    const pages = Math.ceil((20 * 1024 * 1024 * 1024) / 4096);
+    const fakeStatm = `500000 ${pages} 5000 1000 0 50000 0`;
+    const result = readProcessRssBytes(1, () => fakeStatm);
+    expect(result).toBe(pages * 4096);
+    // Verify it's approximately 20GB
+    if (result !== null) {
+      expect(result / 1024 / 1024 / 1024).toBeCloseTo(20, 0);
+    }
+  });
+
+  it("returns null for negative resident pages", () => {
+    const result = readProcessRssBytes(1, () => "200000 -100 5000");
+    expect(result).toBeNull();
+  });
+
+  it("handles extra whitespace in statm", () => {
+    const fakeStatm = "  200000  100000  5000  1000  0  50000  0  ";
+    const result = readProcessRssBytes(1, () => fakeStatm);
+    expect(result).toBe(100000 * 4096);
+  });
+
+  it("reads actual /proc/self/statm when no readFile override", () => {
+    // This tests the real path on Linux
+    const result = readProcessRssBytes(process.pid);
+    if (process.platform === "linux") {
+      expect(result).not.toBeNull();
+      if (result !== null) {
+        expect(result).toBeGreaterThan(0);
+      }
+    } else {
+      // On non-Linux, /proc doesn't exist
+      expect(result).toBeNull();
+    }
+  });
+});

--- a/packages/daemon/src/daemon/config.ts
+++ b/packages/daemon/src/daemon/config.ts
@@ -27,11 +27,17 @@ export interface DaemonConfig {
   issueBackend: "linear" | "github";
   runtime: "opencode" | "claude-code";
   githubApps?: GitHubAppsConfig;
+  /** RSS threshold in bytes; serve restarts when exceeded. 0 = disabled. */
+  maxRssBytes: number;
+  /** Minimum interval between RSS checks in ms. */
+  rssCheckIntervalMs: number;
 }
 
 const BASE_DAEMON_PORT = 13370;
 const DEFAULT_CHECK_INTERVAL_MS = 60_000;
 const DEFAULT_BASE_WORKER_PORT = 13381;
+const DEFAULT_MAX_RSS_GB = 20;
+const DEFAULT_RSS_CHECK_INTERVAL_S = 60;
 
 function parseNumber(value: string | undefined, fallback: number): number {
   if (!value) {
@@ -101,6 +107,15 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): DaemonConfig {
   }
   const runtime = rawRuntime === "claude-code" ? "claude-code" : "opencode";
   const githubApps = loadGitHubApps(env);
+  const maxRssGb = parseNumber(env.OPENCODE_MAX_RSS_GB, DEFAULT_MAX_RSS_GB);
+  const maxRssBytes = maxRssGb > 0 ? maxRssGb * 1024 * 1024 * 1024 : 0;
+  const rssCheckIntervalS = parseNumber(
+    env.OPENCODE_RSS_CHECK_INTERVAL,
+    DEFAULT_RSS_CHECK_INTERVAL_S
+  );
+  const rssCheckIntervalMs =
+    rssCheckIntervalS > 0 ? rssCheckIntervalS * 1000 : DEFAULT_RSS_CHECK_INTERVAL_S * 1000;
+
   return {
     daemonPort: parseNumber(env.LEGION_DAEMON_PORT, BASE_DAEMON_PORT),
     legionId,
@@ -108,6 +123,8 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): DaemonConfig {
     paths,
     checkIntervalMs: DEFAULT_CHECK_INTERVAL_MS,
     baseWorkerPort: DEFAULT_BASE_WORKER_PORT,
+    maxRssBytes,
+    rssCheckIntervalMs,
     stateFilePath,
     logDir,
     controllerSessionId,

--- a/packages/daemon/src/daemon/feedback.ts
+++ b/packages/daemon/src/daemon/feedback.ts
@@ -56,6 +56,7 @@ export const HealthTickEventSchema = FeedbackEventBase.extend({
   uptimeS: z.number().nonnegative(),
   serveRestarted: z.boolean(),
   sessionsRecreated: z.number().int().nonnegative(),
+  rssRestarts: z.number().int().nonnegative(),
 });
 
 export const FeedbackEventSchema = z.discriminatedUnion("event", [

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -19,6 +19,7 @@ import {
 } from "./legions-registry";
 import { RoleServeManager } from "./multi-serve";
 import { isPortFree } from "./ports";
+import { readProcessRssBytes } from "./rss-monitor";
 import { createAdapter } from "./runtime";
 import type { RuntimeAdapter, RuntimeStartOptions } from "./runtime/types";
 import { startServer } from "./server";
@@ -254,7 +255,8 @@ export async function startDaemon(
   let controllerRecreates = 0;
   let indexInitializations = 0;
   let indexIncrementalUpdates = 0;
-
+  let rssRestarts = 0;
+  let lastRssCheckAt = 0;
   let controllerState: ControllerState | undefined;
 
   registerSignals();
@@ -269,6 +271,7 @@ export async function startDaemon(
     daemon_index_initializations: indexInitializations,
     daemon_index_incrementals: indexIncrementalUpdates,
     daemon_controller_present: controllerState ? 1 : 0,
+    daemon_rss_restarts: rssRestarts,
     daemon_role_serves: roleServeManager?.getEntries().length ?? 0,
   }));
   const controllerWorkspace = config.paths.forLegion(legionId).legionStateDir;
@@ -553,82 +556,119 @@ export async function startDaemon(
         healthTicks += 1;
         const serveHealthy = await resolvedDeps.adapter.healthy();
 
+        // Determine if the shared serve needs a restart and why.
+        let restartReason: string | null = null;
+        let stopBeforeRestart = false;
+
         if (!serveHealthy) {
-          // Only restart the serve if something needs it (active workers or internal controller).
-          // With external controller + 0 workers, let the serve stay down — ensureRunning() starts it on demand.
+          // Only restart if something needs it (active workers or internal controller).
+          // With external controller + 0 workers, let the serve stay down.
           const state = await resolvedDeps.readStateFile(config.stateFilePath);
           const liveWorkers = Object.values(state.workers).filter(
             (e) => e.status !== "dead" && e.status !== "stopped"
           );
-          const needsRestart = liveWorkers.length > 0 || hasInternalController;
-
-          if (needsRestart) {
-            console.error("Shared serve is unhealthy, attempting restart...");
-            try {
-              await resolvedDeps.adapter.start(serveStartOpts);
-              sharedServeRestarts += 1;
-              console.log(`Shared serve restarted on port ${sharedServePort}`);
-
-              console.log(
-                `Recreating ${liveWorkers.length} active worker sessions after serve restart...`
-              );
-              const BATCH_SIZE = 10;
-              for (let i = 0; i < liveWorkers.length; i += BATCH_SIZE) {
-                const batch = liveWorkers.slice(i, i + BATCH_SIZE);
-                await Promise.allSettled(
-                  batch.map(async (entry) => {
-                    try {
-                      const actualId = await resolvedDeps.adapter.createSession(
-                        entry.sessionId,
-                        entry.workspace
-                      );
-                      if (actualId !== entry.sessionId) {
-                        console.warn(
-                          `Worker ${entry.id}: session ID changed ${entry.sessionId} -> ${actualId}`
-                        );
-                      }
-                    } catch {
-                      // Best-effort session re-creation
-                    }
-                  })
-                );
+          if (liveWorkers.length > 0 || hasInternalController) {
+            restartReason = "unhealthy";
+          }
+        } else if (config.maxRssBytes > 0) {
+          // Serve is healthy — check RSS for bmalloc leak mitigation.
+          const now = Date.now();
+          if (now - lastRssCheckAt >= config.rssCheckIntervalMs) {
+            lastRssCheckAt = now;
+            const pid = resolvedDeps.adapter.getServePid();
+            if (pid > 0) {
+              const rssBytes = readProcessRssBytes(pid);
+              if (rssBytes !== null && rssBytes > config.maxRssBytes) {
+                const rssGb = (rssBytes / 1024 / 1024 / 1024).toFixed(2);
+                const thresholdGb = (config.maxRssBytes / 1024 / 1024 / 1024).toFixed(2);
+                restartReason = `RSS ${rssGb}GB exceeds threshold ${thresholdGb}GB`;
+                stopBeforeRestart = true;
               }
-
-              if (controllerState?.port) {
-                try {
-                  const actualControllerSessionId = await resolvedDeps.adapter.createSession(
-                    controllerState.sessionId,
-                    controllerWorkspace
-                  );
-                  if (actualControllerSessionId !== controllerState.sessionId) {
-                    console.warn(
-                      `Controller: session ID changed ${controllerState.sessionId} -> ${actualControllerSessionId}`
-                    );
-                  }
-                  // Unsubscribe old session ID if it changed
-                  if (actualControllerSessionId !== controllerState.sessionId) {
-                    unsubscribeFromEnvoy(controllerState.sessionId);
-                  }
-                  controllerState = {
-                    ...controllerState,
-                    sessionId: actualControllerSessionId,
-                    port: sharedServePort,
-                  };
-                  controllerRecreates += 1;
-                  await sendPromptWithRetry(
-                    resolvedDeps.adapter,
-                    actualControllerSessionId,
-                    "/legion-controller",
-                    resolvedDeps
-                  );
-                  console.log(`Controller re-created: session=${actualControllerSessionId}`);
-                } catch (error) {
-                  console.error(`Failed to re-create controller session: ${error}`);
-                }
-              }
-            } catch (error) {
-              console.error(`Failed to restart shared serve: ${error}`);
             }
+          }
+        }
+
+        if (restartReason) {
+          console.error(`Shared serve needs restart: ${restartReason}`);
+          try {
+            if (stopBeforeRestart) {
+              try {
+                await resolvedDeps.adapter.stop();
+              } catch {
+                // Best-effort — serve may already be dead
+              }
+            }
+            await resolvedDeps.adapter.start(serveStartOpts);
+            sharedServeRestarts += 1;
+            if (stopBeforeRestart) {
+              rssRestarts += 1;
+            }
+            console.log(`Shared serve restarted on port ${sharedServePort}`);
+
+            const state = await resolvedDeps.readStateFile(config.stateFilePath);
+            const liveWorkers = Object.values(state.workers).filter(
+              (e) => e.status !== "dead" && e.status !== "stopped"
+            );
+
+            console.log(
+              `Recreating ${liveWorkers.length} active worker sessions after serve restart...`
+            );
+            const BATCH_SIZE = 10;
+            for (let i = 0; i < liveWorkers.length; i += BATCH_SIZE) {
+              const batch = liveWorkers.slice(i, i + BATCH_SIZE);
+              await Promise.allSettled(
+                batch.map(async (entry) => {
+                  try {
+                    const actualId = await resolvedDeps.adapter.createSession(
+                      entry.sessionId,
+                      entry.workspace
+                    );
+                    if (actualId !== entry.sessionId) {
+                      console.warn(
+                        `Worker ${entry.id}: session ID changed ${entry.sessionId} -> ${actualId}`
+                      );
+                    }
+                  } catch {
+                    // Best-effort session re-creation
+                  }
+                })
+              );
+            }
+
+            if (controllerState?.port) {
+              try {
+                const actualControllerSessionId = await resolvedDeps.adapter.createSession(
+                  controllerState.sessionId,
+                  controllerWorkspace
+                );
+                if (actualControllerSessionId !== controllerState.sessionId) {
+                  console.warn(
+                    `Controller: session ID changed ${controllerState.sessionId} -> ${actualControllerSessionId}`
+                  );
+                }
+                // Unsubscribe old session ID if it changed
+                if (actualControllerSessionId !== controllerState.sessionId) {
+                  unsubscribeFromEnvoy(controllerState.sessionId);
+                }
+                controllerState = {
+                  ...controllerState,
+                  sessionId: actualControllerSessionId,
+                  port: sharedServePort,
+                };
+                controllerRecreates += 1;
+                await sendPromptWithRetry(
+                  resolvedDeps.adapter,
+                  actualControllerSessionId,
+                  "/legion-controller",
+                  resolvedDeps
+                );
+                console.log(`Controller re-created: session=${actualControllerSessionId}`);
+              } catch (error) {
+                console.error(`Failed to re-create controller session: ${error}`);
+              }
+            }
+          } catch (error) {
+            console.error(`Failed to restart shared serve: ${error}`);
           }
         }
 
@@ -681,6 +721,7 @@ export async function startDaemon(
           uptimeS: Math.max(0, (Date.now() - startedAt) / 1000),
           serveRestarted: sharedServeRestarts > 0,
           sessionsRecreated: controllerRecreates,
+          rssRestarts,
         });
       } finally {
         if (!shuttingDown) {

--- a/packages/daemon/src/daemon/rss-monitor.ts
+++ b/packages/daemon/src/daemon/rss-monitor.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+
+const PAGE_SIZE = 4096;
+
+/**
+ * Read the RSS (Resident Set Size) of a process from /proc/<pid>/statm.
+ * Returns RSS in bytes, or null if the read fails (non-Linux, process dead, etc.).
+ *
+ * Uses /proc/statm instead of process.memoryUsage() because the latter
+ * underreports by ~12x for Bun processes due to bmalloc native allocations
+ * (see bun#28318).
+ */
+export function readProcessRssBytes(
+  pid: number,
+  readFile: (path: string) => string = (p) => readFileSync(p, "utf-8")
+): number | null {
+  try {
+    const content = readFile(`/proc/${pid}/statm`);
+    // Format: size resident shared text lib data dt (all in pages)
+    const fields = content.trim().split(/\s+/);
+    const residentPages = Number(fields[1]);
+    if (!Number.isFinite(residentPages) || residentPages < 0) {
+      return null;
+    }
+    return residentPages * PAGE_SIZE;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #290

## Summary

Adds automatic memory-based serve restart to mitigate the bmalloc native allocation leak (~4GB/hr under sustained multi-worker load, see bun#28318).

### What it does
- Polls `/proc/<serve_pid>/statm` on each health tick (every 60s by default)
- When RSS exceeds the threshold (default 20GB), gracefully stops the serve, restarts it, and re-creates all worker + controller sessions
- Logs the restart reason with the RSS value for operator visibility

### Configuration
```
OPENCODE_MAX_RSS_GB=20          # restart serve when RSS exceeds this (default: 20, 0 to disable)
OPENCODE_RSS_CHECK_INTERVAL=60  # seconds between RSS checks (default: 60)
```

### Implementation details
- `rss-monitor.ts` — reads `/proc/<pid>/statm` (not `process.memoryUsage()` which underreports by ~12x)
- `RuntimeAdapter.getPid()` — new method exposing the serve process PID (OpenCode returns real PID, ClaudeCode returns 0)
- Health tick restructured: unhealthy check and RSS check produce a `restartReason`, then a single restart block handles both cases (reduces code duplication)
- RSS-triggered restart calls `adapter.stop()` before `adapter.start()` (unlike unhealthy restart where the serve is already dead)
- `rssRestarts` counter added to telemetry gauges and feedback logs

### Tests
- 8 new unit tests for `readProcessRssBytes` (mock `readFile`, edge cases, real Linux integration)
- 4 new integration tests for RSS-triggered restart (stop+start verified on Linux, disabled check, PID=0, unhealthy-takes-priority)
- 7 new config tests for `OPENCODE_MAX_RSS_GB` and `OPENCODE_RSS_CHECK_INTERVAL` parsing
- All 656 daemon tests pass