### PR TITLE
sjawhar-legion-295: fix MCP bridge dedupe_key to use event_id instead of fixed URI

### DIFF
--- a/packages/envoy/internal/mcpbridge/envelope.go
+++ b/packages/envoy/internal/mcpbridge/envelope.go
@@ -16,11 +16,12 @@ func BuildEnvelope(cfg *ServerConfig, notifyURI string, contents []resourceConte
 	}
 
 	now := contracts.NowMillis()
+	eventID := id.New()
 	summary := buildSummary(cfg, notifyURI, contents)
-	dedupeKey := buildDedupeKey(cfg.Source, notifyURI)
+	dedupeKey := buildDedupeKey(cfg.Source, eventID)
 
 	return contracts.Envelope{
-		EventID:        id.New(),
+		EventID:        eventID,
 		Source:         cfg.Source,
 		SourceEventID:  notifyURI,
 		Topic:          topic,
@@ -43,8 +44,8 @@ func buildSummary(cfg *ServerConfig, uri string, contents []resourceContent) str
 	return fmt.Sprintf("%s event from %s", cfg.Source, uri)
 }
 
-func buildDedupeKey(source string, uri string) string {
-	return source + "." + uri
+func buildDedupeKey(source string, eventID string) string {
+	return source + "." + eventID
 }
 
 func truncateSummary(s string, maxChars int) string {

--- a/packages/envoy/internal/mcpbridge/envelope_test.go
+++ b/packages/envoy/internal/mcpbridge/envelope_test.go
@@ -125,4 +125,7 @@ func TestBuildEnvelope_UniqueIDs(t *testing.T) {
 	if env1.TraceID == env2.TraceID {
 		t.Fatal("trace_id should be unique")
 	}
+	if env1.DedupeKey == env2.DedupeKey {
+		t.Fatal("dedupe_key should be unique across calls with the same URI")
+	}
 }


### PR DESCRIPTION
Closes #295

## Summary

The MCP bridge `BuildEnvelope()` was constructing `dedupe_key` from the notification URI, which for WhatsApp is always `whatsapp://messages/new` (fixed). This caused the Envoy listener's dedupe window to drop all subsequent WhatsApp messages as duplicates.

Fixed by using the unique `event_id` (already generated per notification) for the dedupe key instead of the URI. Added test assertion verifying dedupe keys are unique across calls with the same URI.