### PR TITLE
feat(workflows): mandate skill discovery + PR evidence checklist in test/plan workflows

### DIFF
--- a/.opencode/skills/legion-worker/workflows/plan.md
+++ b/.opencode/skills/legion-worker/workflows/plan.md
@@ -274,6 +274,25 @@ For each acceptance criterion:
 - Verification steps should be specific enough that a fresh agent with no implementation context can follow them
 - If infrastructure doesn't exist yet (architect flagged gaps), note what the implementer needs to create
 
+**Skill Discovery for Testers (MANDATORY):**
+
+The tester is a fresh agent with no knowledge of repo conventions. You MUST explicitly list all repo-specific skills the tester should invoke in the Testing Plan. Check `.opencode/skills/`, `.claude/skills/`, and equivalent directories for:
+
+- **Testing skills** (e.g., `smoke-testing`, `testing`) — define how to verify changes in this specific project
+- **Evidence skills** (e.g., `pr-screenshots`) — define how to capture and upload test evidence
+- **Domain skills** (e.g., environment-specific, framework-specific) — define domain-specific verification steps
+
+Add a `### Skills to Invoke` section to every Testing Plan:
+
+```
+### Skills to Invoke
+- `/smoke-testing` — [why this skill is needed for this PR]
+- `/pr-screenshots` — [why visual evidence is needed]
+- `/testing` — [why repo-specific test conventions apply]
+```
+
+Do not assume the tester will discover these on their own. Without explicit skill references, testers default to generic local testing that misses repo-specific evidence requirements (e.g., Taiga URLs, uploaded screenshots).
+
 ### 4. Review with /plan-review
 
 After creating the executable plan, invoke `/plan-review` with the plan file path.

--- a/.opencode/skills/legion-worker/workflows/test.md
+++ b/.opencode/skills/legion-worker/workflows/test.md
@@ -55,7 +55,15 @@ Extract:
 - Testing plan from issue comments (look for `## Testing Plan` section posted by planner)
 - PR number from issue comments or linked PRs
 
-Also check for repo-specific skills that may define domain-specific testing procedures. If the issue domain has a dedicated skill (e.g., frontend, backend, security, performance), invoke it — it may require additional verification steps beyond functional testing.
+**Mandatory: Discover and invoke repo-specific skills.**
+
+You MUST list all available skills in the project's skill directories (`.opencode/skills/`, `.claude/skills/`, or equivalent) and invoke any that match the domain of your test. Specifically look for:
+
+- **`smoke-testing`** — Required when changes touch environments, infrastructure, or eval pipeline. Runs the real system on the deployment platform, not just local tests.
+- **`testing`** — May define repo-specific test conventions, fixtures, and verification requirements beyond what this generic workflow covers.
+- **`pr-screenshots`** — Required for uploading visual evidence. Screenshots saved to local paths (`/tmp/...`) are NOT acceptable in PR comments — upload them and use the resulting URLs.
+
+Do not skip this step. You are a fresh agent with no prior knowledge of repo conventions. These skills contain critical domain-specific requirements that you will miss without reading them. If the testing plan from the planner lists specific skills to invoke, follow that list.
 
 **Skill loading from plan handoff:** Read the plan handoff for pre-identified testing skills:
 
@@ -266,6 +274,18 @@ gh pr comment $PR_NUMBER --body "## Behavioral Test Results
 - require_specific_task: [true/false] — [evidence]
 - require_taiga_evidence: [true/false] — [Taiga URL or not required]" -R $OWNER/$REPO
 ```
+
+### PR Evidence Checklist
+
+Before posting your results comment, verify it meets these evidence standards:
+
+- [ ] **No local file paths** — PR comment contains zero references to `/tmp/`, local filesystem paths, or non-URL screenshot references. All evidence must be accessible to remote reviewers.
+- [ ] **Uploaded screenshots** — If visual evidence was captured, screenshots were uploaded via the repo's screenshot/evidence skill (e.g., `/pr-screenshots`) and referenced by durable URL, not local path.
+- [ ] **Smoke test / CI URLs** — If smoke tests or deployment-platform runs were executed, include the job URLs in the comment.
+- [ ] **Eval pipeline output** — If the repo has an eval pipeline (e.g., `tl run`) and it was exercised, include the command and score output.
+- [ ] **Local evidence is supplementary** — Local test output (Playwright, headless Chrome, pytest) supplements but does not replace deployment-platform evidence when the repo has a smoke-testing skill.
+
+If any checklist item is not met, fix the comment before posting. Evidence that reviewers cannot access is not evidence.
 
 ### 6.5. Write Handoff Data
 


### PR DESCRIPTION
## Summary

- **test.md**: Replace vague suggestion to check repo-specific skills with **mandatory** skill discovery and invocation (smoke-testing, testing, pr-screenshots). Add a **PR Evidence Checklist** requiring uploaded URLs, no local file paths, smoke test/CI URLs, and eval pipeline output.
- **plan.md**: Add mandatory **Skill Discovery for Testers** section to the Testing Plan template, requiring planners to explicitly list repo-specific skills so testers don't miss domain-specific evidence requirements.

Part of trajectory-labs-pbc/agent-c#6672.