### PR TITLE
sjawhar-legion-177: use real Slack team_id in controller skill and plans

### DIFF
--- a/.opencode/skills/legion-controller/SKILL.md
+++ b/.opencode/skills/legion-controller/SKILL.md
@@ -100,6 +100,8 @@ The daemon subscribes the controller to these topics:
 
 **No board-wide issue/PR subscriptions.** The controller does NOT subscribe to all issue or PR events. Polling handles board-level state adequately on its ~30s cycle. Only CI events (time-sensitive for pipeline progression) get Envoy subscriptions.
 
+> **Slack topic format:** Slack topics use the real `team_id` (e.g., `T09FRELLTS8`), not the human-readable workspace slug (e.g., `trajectorylabs`). The Slack receiver publishes with the actual team ID from the Slack API. If you manually subscribe to specific Slack channels, use `notifications.slack.<team_id>.<channel_id>.mention` — see the Envoy skill for full topic format reference.
+
 ### CI Event Handling
 
 When a CI event is received (via `notifications.github.{owner}.{repo}.ci`), it indicates a `check_run` or `check_suite` status change on a PR in that repo. The controller should:

--- a/docs/plans/slack-push-to-controller.md
+++ b/docs/plans/slack-push-to-controller.md
@@ -125,7 +125,7 @@ Direct-to-serve can exist as a fallback path if daemon endpointing is temporaril
 
 ### Filter rules (default deny, explicit allow)
 
-- **Workspace allowlist:** only `trajectorylabs` workspace/team ID.
+- **Team allowlist:** only team ID `T09FRELLTS8` (use real Slack `team_id`, not workspace slug like `trajectorylabs`).
 - **Channel allowlist:** explicit list including `#engineering` channel ID(s).
 - **User allowlist/priority:** `@sami` and optional trusted operators.
 - **Bot/self suppression:** drop events from bot users including self.


### PR DESCRIPTION
Fixes #177 — updates controller skill and docs to use real Slack team_id (T09FRELLTS8) instead of workspace slug (trajectorylabs). Small docs-only change.