### PR TITLE
sjawhar-legion-314: Pipeline visibility: enhanced legion status with phase grouping

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,34 +1,31 @@
 {
   "filesChanged": [
-    "packages/envoy/infra/machines.ts",
-    "packages/envoy/infra/nats.ts",
-    "packages/envoy/infra/services.ts",
-    "packages/envoy/infra/Pulumi.prod.yaml",
-    "packages/envoy/infra/README.md",
-    "packages/envoy/infra/__tests__/nats.test.ts",
-    "packages/envoy/infra/__tests__/services.test.ts",
-    "packages/envoy/deploy/compose/nats/peer.compose.yml",
-    "packages/envoy/deploy/compose/nats/compose.yml",
-    "packages/envoy/docs/constraints.md",
-    "docs/solutions/envoy/docker-tailscale-networking.md"
+    "packages/daemon/src/state/types.ts",
+    "packages/daemon/src/state/backends/github.ts",
+    "packages/daemon/src/state/backends/linear.ts",
+    "packages/daemon/src/state/fetch.ts",
+    "packages/daemon/src/state/decision.ts",
+    "packages/daemon/src/cli/index.ts",
+    "packages/daemon/src/cli/pipeline.ts",
+    "packages/daemon/src/cli/__tests__/pipeline.test.ts"
   ],
   "trickyParts": [
-    "Conflict resolution on .legion/architect.json after rebase — main had ghost-wispr architect data, our branch had #310 architect data",
-    "Empty intermediate commit from jj new needed to be rebased past to avoid push rejection"
+    "Title field wasn't in the state pipeline - had to add it to ParsedIssue, FetchedIssueData, IssueState, IssueStateDict and carry through all layers (backends, enrichment, decision logic, serialization)",
+    "Used /state/fetch-and-collect endpoint (GitHub-only) rather than /state/collect since CLI doesn't have raw issue data to pass",
+    "Pipeline formatting separated into its own module (cli/pipeline.ts) for testability"
   ],
   "deviations": [
-    "Added receivers.ghostwispr row to README.md Machine Configuration table — was missing, noticed while removing tailscaleIp row"
+    "Added title field to state types - not in original spec but needed for 'each issue line shows title' acceptance criterion",
+    "Default to github backend when --backend not specified (fetch-and-collect only supports github currently)"
   ],
-  "openQuestions": [],
+  "openQuestions": [
+    "Linear backend support for pipeline view - currently defaults to github. Would need a separate endpoint or the controller to provide pre-fetched issue data.",
+    "The /state/fetch-and-collect endpoint requires GitHub Projects V2 read:project scope on the token"
+  ],
   "subPlanningNeeded": false,
-  "learningsInjected": [
-    "docs/solutions/envoy/docker-tailscale-networking.md",
-    "docs/solutions/envoy/pulumi-remote-docker-patterns.md"
-  ],
-  "learningsHelpful": [
-    "docs/solutions/envoy/docker-tailscale-networking.md"
-  ],
+  "learningsInjected": [],
+  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-07T02:00:23.064Z"
+  "completed": "2026-04-07T04:00:16.521Z"
 }

--- a/.legion/plan.json
+++ b/.legion/plan.json
@@ -1,28 +1,27 @@
 {
-  "taskCount": 6,
-  "independentTasks": 4,
+  "taskCount": 3,
+  "independentTasks": 1,
   "routingHints": {
     "complexity": "small",
     "estimatedImplementers": 1,
-    "skipRetro": false,
+    "skipRetro": true,
     "skipArchitect": true
   },
   "concerns": [
-    "MachineConfig.name must match MagicDNS hostname - assumption verified by existing sshHost usage but should be documented",
-    "Host networking exposes NATS ports directly - verify no port collisions during rollout",
-    "Live cluster verification (routez, JetStream persistence) requires Tailscale-connected host, not CI-testable"
+    "statusCommand.run() missing try/catch for proper non-zero exit code on CliError",
+    "No CLI-level integration tests exercising the full cmdStatus → fetch → format → output path",
+    "Error test must mock process.exit since Task 1 adds try/catch that catches CliError internally"
   ],
   "learningsInjected": [
-    "envoy/docker-tailscale-networking.md",
-    "envoy/pulumi-remote-docker-patterns.md",
-    "infra/mixed-runtime-type-boundaries.md"
+    "daemon/controller-observability.md",
+    "testing/bun-fetch-mocking-patterns.md",
+    "testing/github-backend-collect-test-payloads.md"
   ],
   "learningsHelpful": [
-    "envoy/docker-tailscale-networking.md",
-    "envoy/pulumi-remote-docker-patterns.md"
+    "testing/bun-fetch-mocking-patterns.md"
   ],
-  "workflowRecommendation": "Standard pipeline — all phases needed. Tasks 1/2/4/5 are independent and can be parallelized by the implementer.",
+  "workflowRecommendation": "Simple hardening — single implementer, skip retro. Core pipeline implementation already exists and passes 17 unit tests. Only error handling and CLI integration tests remain.",
   "schemaVersion": 1,
   "phase": "plan",
-  "completed": "2026-04-07T01:52:38.524Z"
+  "completed": "2026-04-07T04:10:30.071Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,29 +1,32 @@
 {
   "critical": 0,
   "important": 0,
-  "minor": 2,
+  "minor": 3,
   "verdict": "approved",
   "keyFindings": [
     {
       "severity": "P3",
-      "file": "packages/envoy/cmd/ghostwispr/main.go",
-      "description": "Duplicate normalizeGhostWisprEventType function also exists in internal/contracts/normalize.go:603. Could be exported and shared."
+      "file": "packages/daemon/src/daemon/server.ts",
+      "description": "Tangential cleanup: two stale unsubscribeWorkerFromEnvoy references fixed to unsubscribeAllWorkerTopics. Harmless, just tangential to pipeline feature."
     },
     {
       "severity": "P3",
-      "file": "packages/envoy/cmd/ghostwispr/main_test.go",
-      "description": "Handler tests only check wantPublished bool, don't verify envelope content (topic/source/dedupe_key). Partially mitigated by normalization tests."
+      "file": "packages/daemon/src/cli/index.ts",
+      "description": "Linear backend limitation: backend defaults to 'github' for /state/fetch-and-collect, running with -b linear gives generic error instead of user-friendly message."
+    },
+    {
+      "severity": "P3",
+      "file": "packages/daemon/src/cli/pipeline.ts",
+      "description": "Done/skip issues render without bracketed status indicator. Reasonable design choice for settled issues, but an implicit 5th badge state not covered by AC."
     }
   ],
   "learningsInjected": [
-    "docs/solutions/envoy/contracts-and-handler-patterns.md",
-    "docs/solutions/envoy/adding-resource-level-subject-helpers.md",
-    "docs/solutions/envoy/pulumi-remote-docker-patterns.md"
+    "daemon/controller-observability.md",
+    "testing/bun-fetch-mocking-patterns.md",
+    "testing/github-backend-collect-test-payloads.md"
   ],
-  "learningsHelpful": [
-    "docs/solutions/envoy/contracts-and-handler-patterns.md"
-  ],
+  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-07T01:28:49.487Z"
+  "completed": "2026-04-07T04:44:44.524Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,19 +1,23 @@
 {
-  "passed": 12,
-  "failed": 0,
-  "failures": [],
-  "documentationFeedback": "README Machine Configuration table is clear — name→MagicDNS contract explicit on line 104. constraints.md updates both required lines. docker-tailscale-networking.md preserves bridge networking rule while noting NATS exception. No gaps or confusion found.",
+  "passed": 9,
+  "failed": 1,
+  "failures": [
+    {
+      "criterion": "Error handling: print message + non-zero exit on failure",
+      "evidence": "statusCommand.run() at index.ts:849-851 has NO try/catch. cmdStatus correctly throws CliError on HTTP 500 and connection failure, but the error is never caught at the command level. Compare attachCommand at index.ts:866-874 which has the correct pattern. Errors propagate as unhandled rejections with stack traces instead of clean error messages."
+    }
+  ],
+  "documentationFeedback": "No project docs updated. No README.md exists. AGENTS.md mentions 'legion status' but doesn't describe pipeline output or --json flag. PR body is the only feature reference.",
   "observations": [
-    "P2: Tests are happy-path-only — no edge cases for empty machines, all nats:false, or special characters in names",
-    "P2: No integration test for createNatsPeer() full pipeline (MachineConfig→PeerInfo→routes→conf→container)",
-    "Deviation: receivers.ghostwispr row added to README (harmless, documents existing field)",
-    "Pre-existing TS5107 moduleResolution=node10 deprecation in infra tsconfig — unrelated to PR",
-    "deleteBeforeReplace: true correctly set on NATS container per pulumi-remote-docker-patterns learning",
-    "Criteria 13 (JetStream persistence) and 14 (cluster formation) are manual rollout verification — code supports both via named volumes and hostname-based routes"
+    "P2: No CLI-level integration tests for statusCommand pipeline path",
+    "P2: No error path tests (HTTP 500, timeout, connection refused)",
+    "P3: Done/skip issues render without bracketed status indicator",
+    "P3: /state/fetch-and-collect is GitHub-only but CLI advertises linear+github for --backend",
+    "P3: Pipeline includes Icebox in PHASE_ORDER which wasn't in AC#1 status list"
   ],
   "learningsInjected": [],
   "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-07T02:09:46.782Z"
+  "completed": "2026-04-07T04:22:04.282Z"
 }

--- a/packages/daemon/src/cli/__tests__/__snapshots__/pipeline.test.ts.snap
+++ b/packages/daemon/src/cli/__tests__/__snapshots__/pipeline.test.ts.snap
@@ -1,0 +1,125 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`formatPipelineView formats 10 issues across 5 phases correctly 1`] = `
+"
+Pipeline
+----------------------------------------
+
+Backlog (2)
+  sjawhar-legion-101 Set up authentication service with JWT tokens [IDLE]
+  sjawhar-legion-102 Add rate limiting to API endpoints [BLOCKED]
+
+Todo (1)
+  sjawhar-legion-103 Design database schema for user profiles [IDLE]
+
+In Progress (2)
+  sjawhar-legion-104 Implement webhook delivery system with retry logic [implement:running]
+  sjawhar-legion-105 Fix memory leak in event processor causing OOM cr… [NEEDS INPUT]
+
+Testing (2)
+  sjawhar-legion-106 Add OpenTelemetry tracing to all HTTP handlers [test:running]
+  sjawhar-legion-107 Refactor config loading to support environment-sp… [IDLE]
+
+Needs Review (2)
+  sjawhar-legion-108 Implement graceful shutdown for all background wo… [IDLE]
+  sjawhar-legion-109 Add comprehensive error handling to CLI commands [review:running]
+
+Done (1)
+  sjawhar-legion-110 Update deployment scripts for multi-region suppor…
+
+Total: 10 issues | Active: 3 workers | Blocked: 1 | Needs Input: 1 | Idle: 4"
+`;
+
+exports[`buildPipelineJson builds JSON for 10-issue fixture 1`] = `
+{
+  "phases": [
+    {
+      "issues": [
+        {
+          "id": "sjawhar-legion-101",
+          "status": "IDLE",
+          "title": "Set up authentication service with JWT tokens",
+        },
+        {
+          "id": "sjawhar-legion-102",
+          "status": "BLOCKED",
+          "title": "Add rate limiting to API endpoints",
+        },
+      ],
+      "name": "Backlog",
+    },
+    {
+      "issues": [
+        {
+          "id": "sjawhar-legion-103",
+          "status": "IDLE",
+          "title": "Design database schema for user profiles",
+        },
+      ],
+      "name": "Todo",
+    },
+    {
+      "issues": [
+        {
+          "id": "sjawhar-legion-104",
+          "status": "implement:running",
+          "title": "Implement webhook delivery system with retry logic",
+        },
+        {
+          "id": "sjawhar-legion-105",
+          "status": "NEEDS INPUT",
+          "title": "Fix memory leak in event processor causing OOM crashes",
+        },
+      ],
+      "name": "In Progress",
+    },
+    {
+      "issues": [
+        {
+          "id": "sjawhar-legion-106",
+          "status": "test:running",
+          "title": "Add OpenTelemetry tracing to all HTTP handlers",
+        },
+        {
+          "id": "sjawhar-legion-107",
+          "status": "IDLE",
+          "title": "Refactor config loading to support environment-specific overrides",
+        },
+      ],
+      "name": "Testing",
+    },
+    {
+      "issues": [
+        {
+          "id": "sjawhar-legion-108",
+          "status": "IDLE",
+          "title": "Implement graceful shutdown for all background workers",
+        },
+        {
+          "id": "sjawhar-legion-109",
+          "status": "review:running",
+          "title": "Add comprehensive error handling to CLI commands",
+        },
+      ],
+      "name": "Needs Review",
+    },
+    {
+      "issues": [
+        {
+          "id": "sjawhar-legion-110",
+          "status": "",
+          "title": "Update deployment scripts for multi-region support with automatic failover",
+        },
+      ],
+      "name": "Done",
+    },
+  ],
+  "summary": {
+    "active": 3,
+    "blocked": 1,
+    "idle": 4,
+    "needsInput": 1,
+    "total": 10,
+  },
+}
+`;

--- a/packages/daemon/src/cli/__tests__/index.test.ts
+++ b/packages/daemon/src/cli/__tests__/index.test.ts
@@ -1325,6 +1325,213 @@ describe("CLI XDG path migration", () => {
   });
 });
 
+describe("statusCommand pipeline integration", () => {
+  const legionId = "12345678-1234-1234-1234-123456789012";
+  const originalFetch = globalThis.fetch;
+  const originalLog = console.log;
+  const originalError = console.error;
+  let stateHome: string;
+  let originalStateHome: string | undefined;
+
+  beforeEach(() => {
+    stateHome = fs.mkdtempSync(path.join(os.tmpdir(), "legion-pipeline-"));
+    originalStateHome = process.env.XDG_STATE_HOME;
+    process.env.XDG_STATE_HOME = stateHome;
+
+    const legionStateDir = path.join(stateHome, "legion", "legions", legionId);
+    fs.mkdirSync(legionStateDir, { recursive: true });
+    fs.writeFileSync(path.join(legionStateDir, "workers.json"), "[]");
+
+    console.log = mock(() => {}) as typeof console.log;
+    console.error = mock(() => {}) as typeof console.error;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    console.log = originalLog;
+    console.error = originalError;
+    if (originalStateHome === undefined) {
+      delete process.env.XDG_STATE_HOME;
+    } else {
+      process.env.XDG_STATE_HOME = originalStateHome;
+    }
+    fs.rmSync(stateHome, { recursive: true, force: true });
+  });
+
+  test("displays pipeline view with grouped issues", async () => {
+    installFetchMock(async (input) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : (input as Request).url;
+      if (url.includes("/workers")) {
+        return new Response(JSON.stringify([{ id: "test-repo-1-implement", port: 13382 }]), {
+          status: 200,
+        });
+      }
+      if (url.includes("/state/fetch-and-collect")) {
+        return new Response(
+          JSON.stringify({
+            issues: {
+              "test-repo-1": {
+                status: "In Progress",
+                title: "Active feature work",
+                labels: ["worker-active"],
+                hasPr: true,
+                prIsDraft: false,
+                ciStatus: "passing",
+                mergeableStatus: "mergeable",
+                hasLiveWorker: true,
+                workerMode: "implement",
+                workerStatus: "running",
+                suggestedAction: "skip",
+                sessionId: "ses_000000000000xxxxxxxxxxxx",
+                hasUserFeedback: false,
+                isBlocked: false,
+                source: null,
+              },
+              "test-repo-2": {
+                status: "Todo",
+                title: "Planned work item",
+                labels: [],
+                hasPr: false,
+                prIsDraft: null,
+                ciStatus: null,
+                mergeableStatus: null,
+                hasLiveWorker: false,
+                workerMode: null,
+                workerStatus: null,
+                suggestedAction: "dispatch_planner",
+                sessionId: "ses_000000000000yyyyyyyyyyyy",
+                hasUserFeedback: false,
+                isBlocked: false,
+                source: null,
+              },
+            },
+          }),
+          { status: 200 }
+        );
+      }
+      return new Response("", { status: 404 });
+    });
+
+    await runCommand(statusCommand, { team: legionId });
+
+    const output = (console.log as ReturnType<typeof mock>).mock.calls.flat().join("\n");
+    expect(output).toContain("Pipeline");
+    expect(output).toContain("Todo (1)");
+    expect(output).toContain("In Progress (1)");
+    expect(output).toContain("[implement:running]");
+    expect(output).toContain("[IDLE]");
+    expect(output).toContain("Total: 2 issues");
+    expect(output).toContain("Active: 1 workers");
+    expect(output).toContain("Idle: 1");
+  });
+
+  test("outputs JSON when --json flag is set", async () => {
+    installFetchMock(async (input) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : (input as Request).url;
+      if (url.includes("/workers")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (url.includes("/state/fetch-and-collect")) {
+        return new Response(
+          JSON.stringify({
+            issues: {
+              "test-repo-1": {
+                status: "Todo",
+                title: "Some task",
+                labels: [],
+                hasPr: false,
+                prIsDraft: null,
+                ciStatus: null,
+                mergeableStatus: null,
+                hasLiveWorker: false,
+                workerMode: null,
+                workerStatus: null,
+                suggestedAction: "dispatch_planner",
+                sessionId: "ses_000000000000xxxxxxxxxxxx",
+                hasUserFeedback: false,
+                isBlocked: false,
+                source: null,
+              },
+            },
+          }),
+          { status: 200 }
+        );
+      }
+      return new Response("", { status: 404 });
+    });
+
+    await runCommand(statusCommand, { team: legionId, json: true });
+
+    const output = (console.log as ReturnType<typeof mock>).mock.calls.flat().join("");
+    const parsed = JSON.parse(output);
+    expect(parsed).toHaveProperty("phases");
+    expect(parsed).toHaveProperty("summary");
+    expect(parsed.summary.total).toBe(1);
+    expect(parsed.phases[0].name).toBe("Todo");
+  });
+
+  test("exits with non-zero code when pipeline fetch fails", async () => {
+    const originalExit = process.exit;
+    const exitMock = mock(() => {}) as unknown as typeof process.exit;
+    process.exit = exitMock;
+
+    try {
+      installFetchMock(async (input) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.href
+              : (input as Request).url;
+        if (url.includes("/workers")) {
+          return new Response(JSON.stringify([{ id: "test-1", port: 13382 }]), {
+            status: 200,
+          });
+        }
+        if (url.includes("/state/fetch-and-collect")) {
+          return new Response("collect_failed", { status: 500 });
+        }
+        return new Response("", { status: 404 });
+      });
+
+      // CliError is caught, process.exit called, then re-thrown (since mock doesn't actually exit)
+      try {
+        await runCommand(statusCommand, { team: legionId });
+      } catch (e) {
+        expect(e).toBeInstanceOf(CliError);
+      }
+
+      const errOutput = (console.error as ReturnType<typeof mock>).mock.calls.flat().join("");
+      expect(errOutput).toContain("Pipeline data unavailable");
+      expect(exitMock).toHaveBeenCalledWith(1);
+    } finally {
+      process.exit = originalExit;
+    }
+  });
+
+  test("handles daemon not running gracefully in JSON mode", async () => {
+    installFetchMock(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+
+    await runCommand(statusCommand, { team: legionId, json: true });
+
+    const output = (console.log as ReturnType<typeof mock>).mock.calls.flat().join("");
+    const parsed = JSON.parse(output);
+    expect(parsed.summary.total).toBe(0);
+  });
+});
+
 describe("parseEnvJson", () => {
   it("rejects invalid JSON", () => {
     expect(() => parseEnvJson("not json")).toThrow("Invalid --env value: must be valid JSON");

--- a/packages/daemon/src/cli/__tests__/pipeline.test.ts
+++ b/packages/daemon/src/cli/__tests__/pipeline.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildPipelineJson,
+  formatPipelineView,
+  getStatusIndicator,
+  type PipelineIssue,
+  type PipelineState,
+} from "../pipeline";
+
+function makePipelineIssue(overrides: Partial<PipelineIssue> = {}): PipelineIssue {
+  return {
+    title: "Default issue title",
+    status: "Todo",
+    labels: [],
+    hasLiveWorker: false,
+    workerMode: null,
+    workerStatus: null,
+    suggestedAction: "skip",
+    isBlocked: false,
+    ...overrides,
+  };
+}
+
+describe("getStatusIndicator", () => {
+  it("returns BLOCKED when isBlocked is true", () => {
+    const issue = makePipelineIssue({ isBlocked: true });
+    expect(getStatusIndicator(issue)).toBe("BLOCKED");
+  });
+
+  it("returns NEEDS INPUT when user-input-needed label present", () => {
+    const issue = makePipelineIssue({ labels: ["user-input-needed"] });
+    expect(getStatusIndicator(issue)).toBe("NEEDS INPUT");
+  });
+
+  it("returns worker mode:status when live worker exists", () => {
+    const issue = makePipelineIssue({
+      hasLiveWorker: true,
+      workerMode: "implement",
+      workerStatus: "running",
+    });
+    expect(getStatusIndicator(issue)).toBe("implement:running");
+  });
+
+  it("returns IDLE when no live worker and non-skip action", () => {
+    const issue = makePipelineIssue({ suggestedAction: "dispatch_planner" });
+    expect(getStatusIndicator(issue)).toBe("IDLE");
+  });
+
+  it("returns empty string when skip action and no worker", () => {
+    const issue = makePipelineIssue({ suggestedAction: "skip" });
+    expect(getStatusIndicator(issue)).toBe("");
+  });
+
+  it("BLOCKED takes priority over NEEDS INPUT", () => {
+    const issue = makePipelineIssue({
+      isBlocked: true,
+      labels: ["user-input-needed"],
+    });
+    expect(getStatusIndicator(issue)).toBe("BLOCKED");
+  });
+
+  it("NEEDS INPUT takes priority over worker status", () => {
+    const issue = makePipelineIssue({
+      labels: ["user-input-needed"],
+      hasLiveWorker: true,
+      workerMode: "implement",
+      workerStatus: "running",
+    });
+    expect(getStatusIndicator(issue)).toBe("NEEDS INPUT");
+  });
+});
+
+// Fixture: 10 issues across 5 phases for snapshot testing
+function buildTenIssueFixture(): PipelineState {
+  return {
+    issues: {
+      "sjawhar-legion-101": makePipelineIssue({
+        title: "Set up authentication service with JWT tokens",
+        status: "Backlog",
+        suggestedAction: "dispatch_architect",
+      }),
+      "sjawhar-legion-102": makePipelineIssue({
+        title: "Add rate limiting to API endpoints",
+        status: "Backlog",
+        isBlocked: true,
+        suggestedAction: "skip",
+      }),
+      "sjawhar-legion-103": makePipelineIssue({
+        title: "Design database schema for user profiles",
+        status: "Todo",
+        suggestedAction: "dispatch_planner",
+      }),
+      "sjawhar-legion-104": makePipelineIssue({
+        title: "Implement webhook delivery system with retry logic",
+        status: "In Progress",
+        hasLiveWorker: true,
+        workerMode: "implement",
+        workerStatus: "running",
+        labels: ["worker-active"],
+        suggestedAction: "skip",
+      }),
+      "sjawhar-legion-105": makePipelineIssue({
+        title: "Fix memory leak in event processor causing OOM crashes",
+        status: "In Progress",
+        labels: ["user-input-needed"],
+        suggestedAction: "skip",
+      }),
+      "sjawhar-legion-106": makePipelineIssue({
+        title: "Add OpenTelemetry tracing to all HTTP handlers",
+        status: "Testing",
+        hasLiveWorker: true,
+        workerMode: "test",
+        workerStatus: "running",
+        labels: ["worker-active"],
+        suggestedAction: "skip",
+      }),
+      "sjawhar-legion-107": makePipelineIssue({
+        title: "Refactor config loading to support environment-specific overrides",
+        status: "Testing",
+        suggestedAction: "dispatch_tester",
+      }),
+      "sjawhar-legion-108": makePipelineIssue({
+        title: "Implement graceful shutdown for all background workers",
+        status: "Needs Review",
+        labels: ["worker-done"],
+        suggestedAction: "dispatch_reviewer",
+      }),
+      "sjawhar-legion-109": makePipelineIssue({
+        title: "Add comprehensive error handling to CLI commands",
+        status: "Needs Review",
+        hasLiveWorker: true,
+        workerMode: "review",
+        workerStatus: "running",
+        labels: ["worker-active"],
+        suggestedAction: "skip",
+      }),
+      "sjawhar-legion-110": makePipelineIssue({
+        title: "Update deployment scripts for multi-region support with automatic failover",
+        status: "Done",
+        suggestedAction: "skip",
+      }),
+    },
+  };
+}
+
+describe("formatPipelineView", () => {
+  it("formats 10 issues across 5 phases correctly", () => {
+    const state = buildTenIssueFixture();
+    const output = formatPipelineView(state);
+    expect(output).toMatchSnapshot();
+  });
+
+  it("handles empty state", () => {
+    const state: PipelineState = { issues: {} };
+    const output = formatPipelineView(state);
+    expect(output).toContain("Pipeline");
+    expect(output).toContain("Total: 0 issues");
+  });
+
+  it("handles all issues in one phase", () => {
+    const state: PipelineState = {
+      issues: {
+        "issue-1": makePipelineIssue({ status: "In Progress", title: "First" }),
+        "issue-2": makePipelineIssue({ status: "In Progress", title: "Second" }),
+        "issue-3": makePipelineIssue({ status: "In Progress", title: "Third" }),
+      },
+    };
+    const output = formatPipelineView(state);
+    expect(output).toContain("In Progress (3)");
+    expect(output).not.toContain("Backlog");
+    expect(output).not.toContain("Todo");
+  });
+
+  it("handles all blocked issues", () => {
+    const state: PipelineState = {
+      issues: {
+        "issue-1": makePipelineIssue({
+          status: "Todo",
+          title: "Blocked 1",
+          isBlocked: true,
+        }),
+        "issue-2": makePipelineIssue({
+          status: "In Progress",
+          title: "Blocked 2",
+          isBlocked: true,
+        }),
+      },
+    };
+    const output = formatPipelineView(state);
+    expect(output).toContain("[BLOCKED]");
+    expect(output).toContain("Blocked: 2");
+  });
+
+  it("truncates titles longer than 50 characters", () => {
+    const state: PipelineState = {
+      issues: {
+        "issue-1": makePipelineIssue({
+          status: "Todo",
+          title: "This is a very long title that exceeds fifty characters in length definitely",
+        }),
+      },
+    };
+    const output = formatPipelineView(state);
+    // Truncated to 50 chars with ellipsis
+    expect(output).toContain("…");
+    expect(output).not.toContain("definitely");
+  });
+
+  it("handles no live workers", () => {
+    const state: PipelineState = {
+      issues: {
+        "issue-1": makePipelineIssue({
+          status: "Todo",
+          title: "Idle issue",
+          suggestedAction: "dispatch_planner",
+        }),
+      },
+    };
+    const output = formatPipelineView(state);
+    expect(output).toContain("[IDLE]");
+    expect(output).toContain("Active: 0 workers");
+    expect(output).toContain("Idle: 1");
+  });
+});
+
+describe("buildPipelineJson", () => {
+  it("builds JSON for 10-issue fixture", () => {
+    const state = buildTenIssueFixture();
+    const json = buildPipelineJson(state);
+    expect(json).toMatchSnapshot();
+  });
+
+  it("includes correct summary counts", () => {
+    const state = buildTenIssueFixture();
+    const json = buildPipelineJson(state);
+    expect(json.summary.total).toBe(10);
+    expect(json.summary.active).toBe(3); // 104, 106, 109 have live workers
+    expect(json.summary.blocked).toBe(1); // 102
+    expect(json.summary.needsInput).toBe(1); // 105
+    expect(json.summary.idle).toBe(4); // 101, 103, 107, 108 have non-skip actions
+  });
+
+  it("groups issues by phase", () => {
+    const state = buildTenIssueFixture();
+    const json = buildPipelineJson(state);
+    const phaseNames = json.phases.map((p) => p.name);
+    expect(phaseNames).toContain("Backlog");
+    expect(phaseNames).toContain("Todo");
+    expect(phaseNames).toContain("In Progress");
+    expect(phaseNames).toContain("Testing");
+    expect(phaseNames).toContain("Needs Review");
+    expect(phaseNames).toContain("Done");
+    // Empty phases are excluded
+    expect(phaseNames).not.toContain("Triage");
+    expect(phaseNames).not.toContain("Retro");
+  });
+
+  it("handles empty state", () => {
+    const state: PipelineState = { issues: {} };
+    const json = buildPipelineJson(state);
+    expect(json.phases).toEqual([]);
+    expect(json.summary).toEqual({
+      total: 0,
+      active: 0,
+      blocked: 0,
+      needsInput: 0,
+      idle: 0,
+    });
+  });
+});

--- a/packages/daemon/src/cli/index.ts
+++ b/packages/daemon/src/cli/index.ts
@@ -18,6 +18,7 @@ import {
 import { HANDOFF_PHASES, isHandoffPhase } from "../handoff/schema";
 import type { HandoffPhase } from "../handoff/types";
 import { resolveLegionId } from "./legion-resolver";
+import { buildPipelineJson, formatPipelineView, type PipelineState } from "./pipeline";
 
 export class CliError extends Error {
   constructor(
@@ -225,38 +226,102 @@ async function cmdStop(team: string, _stateDir?: string, backend?: string): Prom
   }
 }
 
-async function cmdStatus(team: string, _stateDir?: string, backend?: string): Promise<void> {
+async function cmdStatus(
+  team: string,
+  _stateDir?: string,
+  backend?: string,
+  json?: boolean
+): Promise<void> {
   const legionId = await resolveLegionId(team, { backend });
   const instancePaths = resolveLegionPaths(process.env, os.homedir()).forLegion(legionId);
 
-  console.log(`Legion Status: ${legionId}`);
-  console.log("=".repeat(40));
+  if (!json) {
+    console.log(`Legion Status: ${legionId}`);
+    console.log("=".repeat(40));
+  }
 
   const daemonPort = await getDaemonPort(legionId);
+  let daemonRunning = false;
   try {
     const response = await fetch(`http://127.0.0.1:${daemonPort}/workers`);
     if (response.ok) {
       const workers = (await response.json()) as WorkerInfo[];
-      console.log(`Daemon: RUNNING (port ${daemonPort})`);
-      console.log(`Workers: ${workers.length}`);
-      for (const worker of workers) {
-        console.log(`  - ${worker.id} (port ${worker.port})`);
+      daemonRunning = true;
+      if (!json) {
+        console.log(`Daemon: RUNNING (port ${daemonPort})`);
+        console.log(`Workers: ${workers.length}`);
+        for (const worker of workers) {
+          console.log(`  - ${worker.id} (port ${worker.port})`);
+        }
       }
-    } else {
+    } else if (!json) {
       console.log("Daemon: NOT RUNNING");
     }
   } catch (_error) {
-    console.log("Daemon: NOT RUNNING");
+    if (!json) {
+      console.log("Daemon: NOT RUNNING");
+    }
   }
 
-  const stateFilePath = instancePaths.workersFile;
-  if (fs.existsSync(stateFilePath)) {
-    const stat = fs.statSync(stateFilePath);
-    const age = Math.floor((Date.now() - stat.mtimeMs) / 1000);
-    console.log(`\nState file: ${stateFilePath}`);
-    console.log(`Last updated: ${age}s ago`);
-  } else {
-    console.log(`\nState file: NOT FOUND`);
+  if (!json) {
+    const stateFilePath = instancePaths.workersFile;
+    if (fs.existsSync(stateFilePath)) {
+      const stat = fs.statSync(stateFilePath);
+      const age = Math.floor((Date.now() - stat.mtimeMs) / 1000);
+      console.log(`\nState file: ${stateFilePath}`);
+      console.log(`Last updated: ${age}s ago`);
+    } else {
+      console.log(`\nState file: NOT FOUND`);
+    }
+  }
+
+  // Pipeline view: fetch collected state from daemon
+  if (daemonRunning) {
+    try {
+      const collectResponse = await fetch(
+        `http://127.0.0.1:${daemonPort}/state/fetch-and-collect`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ backend: backend ?? "github" }),
+          signal: AbortSignal.timeout(30_000),
+        }
+      );
+
+      if (!collectResponse.ok) {
+        const body = await collectResponse.text();
+        throw new CliError(`Pipeline data unavailable: ${collectResponse.status} ${body}`);
+      }
+
+      const collected = (await collectResponse.json()) as {
+        issues: Record<string, PipelineState["issues"][string]>;
+      };
+      const pipelineState: PipelineState = { issues: collected.issues };
+
+      if (json) {
+        console.log(JSON.stringify(buildPipelineJson(pipelineState), null, 2));
+      } else {
+        console.log(formatPipelineView(pipelineState));
+      }
+    } catch (error) {
+      if (error instanceof CliError) {
+        throw error;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      throw new CliError(`Failed to fetch pipeline data: ${message}`);
+    }
+  } else if (json) {
+    // Daemon not running — emit empty JSON structure
+    console.log(
+      JSON.stringify(
+        {
+          phases: [],
+          summary: { total: 0, active: 0, blocked: 0, needsInput: 0, idle: 0 },
+        },
+        null,
+        2
+      )
+    );
   }
 }
 
@@ -775,9 +840,22 @@ export const statusCommand = defineCommand({
       alias: "b",
       description: "Issue tracker backend (linear or github)",
     },
+    json: {
+      type: "boolean",
+      description: "Output pipeline data as machine-readable JSON",
+      default: false,
+    },
   },
   async run({ args }) {
-    await cmdStatus(args.team, args["state-dir"], args.backend);
+    try {
+      await cmdStatus(args.team, args["state-dir"], args.backend, args.json);
+    } catch (e) {
+      if (e instanceof CliError) {
+        console.error(e.message);
+        process.exit(e.code);
+      }
+      throw e;
+    }
   },
 });
 

--- a/packages/daemon/src/cli/pipeline.ts
+++ b/packages/daemon/src/cli/pipeline.ts
@@ -1,0 +1,210 @@
+/**
+ * Pipeline view formatting for `legion status`.
+ *
+ * Groups issues by phase and shows worker state, blocked items, and idle issues.
+ * Supports both human-readable text and machine-readable JSON output.
+ */
+
+import type { IssueStatusLiteral } from "../state/types";
+
+/**
+ * Subset of IssueState fields needed for pipeline display.
+ * Avoids importing the full IssueState type to keep the CLI layer decoupled.
+ */
+export interface PipelineIssue {
+  title?: string;
+  status: string;
+  labels: string[];
+  hasLiveWorker: boolean;
+  workerMode: string | null;
+  workerStatus: string | null;
+  suggestedAction: string;
+  isBlocked: boolean;
+}
+
+/**
+ * Pipeline state: issues keyed by issue ID.
+ */
+export interface PipelineState {
+  issues: Record<string, PipelineIssue>;
+}
+
+/**
+ * Phase display order matching the issue lifecycle.
+ */
+const PHASE_ORDER: IssueStatusLiteral[] = [
+  "Triage",
+  "Icebox",
+  "Backlog",
+  "Todo",
+  "In Progress",
+  "Testing",
+  "Needs Review",
+  "Retro",
+  "Done",
+];
+
+/**
+ * Determine the display status indicator for an issue.
+ *
+ * Priority:
+ *  1. BLOCKED (isBlocked === true)
+ *  2. NEEDS INPUT (labels include user-input-needed)
+ *  3. Worker mode:status (hasLiveWorker === true)
+ *  4. IDLE (no live worker and non-skip suggested action)
+ *  5. (empty) — nothing actionable
+ */
+export function getStatusIndicator(issue: PipelineIssue): string {
+  if (issue.isBlocked) {
+    return "BLOCKED";
+  }
+  if (issue.labels.includes("user-input-needed")) {
+    return "NEEDS INPUT";
+  }
+  if (issue.hasLiveWorker && issue.workerMode && issue.workerStatus) {
+    return `${issue.workerMode}:${issue.workerStatus}`;
+  }
+  if (!issue.hasLiveWorker && issue.suggestedAction !== "skip") {
+    return "IDLE";
+  }
+  return "";
+}
+
+/**
+ * Truncate a string to maxLen, appending "…" if truncated.
+ */
+function truncate(text: string, maxLen: number): string {
+  if (text.length <= maxLen) {
+    return text;
+  }
+  return `${text.slice(0, maxLen - 1)}…`;
+}
+
+/**
+ * JSON output shape for --json flag.
+ */
+export interface PipelineJsonOutput {
+  phases: Array<{
+    name: string;
+    issues: Array<{
+      id: string;
+      title: string;
+      status: string;
+    }>;
+  }>;
+  summary: {
+    total: number;
+    active: number;
+    blocked: number;
+    needsInput: number;
+    idle: number;
+  };
+}
+
+/**
+ * Build structured JSON output for the pipeline view.
+ */
+export function buildPipelineJson(state: PipelineState): PipelineJsonOutput {
+  // Group issues by phase
+  const grouped = new Map<string, Array<{ id: string; title: string; status: string }>>();
+  for (const phase of PHASE_ORDER) {
+    grouped.set(phase, []);
+  }
+
+  let total = 0;
+  let active = 0;
+  let blocked = 0;
+  let needsInput = 0;
+  let idle = 0;
+
+  for (const [issueId, issue] of Object.entries(state.issues)) {
+    total++;
+    const indicator = getStatusIndicator(issue);
+
+    if (issue.isBlocked) blocked++;
+    if (issue.labels.includes("user-input-needed")) needsInput++;
+    if (issue.hasLiveWorker) active++;
+    if (!issue.hasLiveWorker && issue.suggestedAction !== "skip") idle++;
+
+    const phase = issue.status;
+    const bucket = grouped.get(phase);
+    if (bucket) {
+      bucket.push({ id: issueId, title: issue.title ?? "", status: indicator });
+    } else {
+      // Unknown phase — create a bucket
+      grouped.set(phase, [{ id: issueId, title: issue.title ?? "", status: indicator }]);
+    }
+  }
+
+  const phases: PipelineJsonOutput["phases"] = [];
+  for (const [name, issues] of grouped) {
+    if (issues.length > 0) {
+      phases.push({ name, issues });
+    }
+  }
+
+  return {
+    phases,
+    summary: { total, active, blocked, needsInput, idle },
+  };
+}
+
+/**
+ * Format the pipeline view as human-readable text.
+ */
+export function formatPipelineView(state: PipelineState): string {
+  const lines: string[] = [];
+
+  // Group issues by phase
+  const grouped = new Map<string, Array<[string, PipelineIssue]>>();
+  for (const phase of PHASE_ORDER) {
+    grouped.set(phase, []);
+  }
+
+  let total = 0;
+  let active = 0;
+  let blocked = 0;
+  let needsInput = 0;
+  let idle = 0;
+
+  for (const [issueId, issue] of Object.entries(state.issues)) {
+    total++;
+
+    if (issue.isBlocked) blocked++;
+    if (issue.labels.includes("user-input-needed")) needsInput++;
+    if (issue.hasLiveWorker) active++;
+    if (!issue.hasLiveWorker && issue.suggestedAction !== "skip") idle++;
+
+    const phase = issue.status;
+    const bucket = grouped.get(phase);
+    if (bucket) {
+      bucket.push([issueId, issue]);
+    } else {
+      grouped.set(phase, [[issueId, issue]]);
+    }
+  }
+
+  // Render phases
+  lines.push("\nPipeline");
+  lines.push("-".repeat(40));
+
+  for (const [phase, issues] of grouped) {
+    if (issues.length === 0) continue;
+
+    lines.push(`\n${phase} (${issues.length})`);
+    for (const [issueId, issue] of issues) {
+      const indicator = getStatusIndicator(issue);
+      const title = truncate(issue.title ?? "", 50);
+      const statusPart = indicator ? ` [${indicator}]` : "";
+      lines.push(`  ${issueId} ${title}${statusPart}`);
+    }
+  }
+
+  // Summary line
+  lines.push("");
+  lines.push(
+    `Total: ${total} issues | Active: ${active} workers | Blocked: ${blocked} | Needs Input: ${needsInput} | Idle: ${idle}`
+  );
+
+  return lines.join("\n");
+}

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -739,7 +739,7 @@ export function startServer(opts: ServerOptions): {
           workers.delete(workerId);
           crashHistory.delete(workerId);
           await persistState();
-          unsubscribeWorkerFromEnvoy(entry.sessionId);
+          unsubscribeAllWorkerTopics(entry.sessionId);
 
           return jsonResponse({ status: "cleaned", workerRemoved: true });
         }
@@ -818,7 +818,7 @@ export function startServer(opts: ServerOptions): {
           }
 
           for (const sessionId of prunedSessionIds) {
-            unsubscribeWorkerFromEnvoy(sessionId);
+            unsubscribeAllWorkerTopics(sessionId);
           }
 
           return jsonResponse({

--- a/packages/daemon/src/state/backends/github.ts
+++ b/packages/daemon/src/state/backends/github.ts
@@ -12,6 +12,7 @@ interface GitHubProjectItem {
   id?: string;
   content?: {
     number?: number;
+    title?: string;
     repository?: string;
     url?: string;
     type?: string;
@@ -118,7 +119,8 @@ export class GitHubTracker implements IssueTracker {
       };
       const isBlocked = typedItem.isBlocked === true;
 
-      parsed.push(createParsedIssue(issueId, status, labels, prRef, source, isBlocked));
+      const title = typeof content.title === "string" ? content.title : "";
+      parsed.push(createParsedIssue(issueId, status, labels, prRef, source, isBlocked, title));
     }
 
     return parsed;

--- a/packages/daemon/src/state/backends/linear.ts
+++ b/packages/daemon/src/state/backends/linear.ts
@@ -35,6 +35,7 @@ export interface LinearIssueRaw {
   state?: LinearStateDict;
   labels?: string[] | LinearLabelsContainer;
   attachments?: LinearAttachment[] | { nodes: LinearAttachment[] };
+  title?: string;
 }
 
 export class LinearTracker implements IssueTracker {
@@ -109,7 +110,8 @@ export class LinearTracker implements IssueTracker {
         }
       }
 
-      parsed.push(createParsedIssue(issueId, status, labels, prRef));
+      const title = typeof issue.title === "string" ? issue.title : "";
+      parsed.push(createParsedIssue(issueId, status, labels, prRef, null, false, title));
     }
 
     return parsed;

--- a/packages/daemon/src/state/decision.ts
+++ b/packages/daemon/src/state/decision.ts
@@ -307,6 +307,7 @@ export function buildIssueState(data: FetchedIssueData, legionId: string): Issue
   const sessionId = computeSessionId(legionId, data.issueId, mode);
 
   return {
+    title: data.title,
     status: data.status,
     labels: data.labels,
     hasPr: data.hasPr,

--- a/packages/daemon/src/state/fetch.ts
+++ b/packages/daemon/src/state/fetch.ts
@@ -571,6 +571,7 @@ export async function enrichParsedIssues(
     const workerInfo = liveWorkers[issue.issueId.toUpperCase()] ?? null;
     return {
       issueId: issue.issueId,
+      title: issue.title,
       status: issue.status,
       labels: issue.labels,
       hasPr: issue.hasPr,

--- a/packages/daemon/src/state/types.ts
+++ b/packages/daemon/src/state/types.ts
@@ -290,6 +290,7 @@ export interface IssueSource {
  */
 export interface ParsedIssue {
   issueId: string;
+  title: string;
   status: IssueStatusLiteral | string; // Canonical status or unknown raw value
   labels: string[];
   prRef: GitHubPRRef | null;
@@ -319,10 +320,12 @@ export function createParsedIssue(
   labels: string[],
   prRef: GitHubPRRef | null,
   source: IssueSource | null = null,
-  isBlocked: boolean = false
+  isBlocked: boolean = false,
+  title: string = ""
 ): ParsedIssue {
   return {
     issueId,
+    title,
     status,
     labels,
     prRef,
@@ -389,6 +392,7 @@ export function createParsedIssue(
  */
 export interface FetchedIssueData {
   issueId: string;
+  title?: string;
   status: IssueStatusLiteral | string; // Canonical status or unknown raw value
   labels: string[];
   hasPr: boolean; // True if issue has a linked PR
@@ -413,6 +417,7 @@ export interface FetchedIssueData {
  */
 interface IssueStateDict {
   status: IssueStatusLiteral | string;
+  title?: string;
   labels: string[];
   hasPr: boolean;
   prIsDraft: boolean | null;
@@ -440,6 +445,7 @@ interface CollectedStateDict {
  */
 export interface IssueState {
   status: IssueStatusLiteral | string; // Canonical status or unknown raw value
+  title?: string;
   labels: string[];
   hasPr: boolean; // Whether issue has a linked PR
   prIsDraft: boolean | null; // null if couldn't check status, true if draft, false if ready
@@ -461,6 +467,7 @@ export const IssueState = {
    */
   toDict(state: IssueState): IssueStateDict {
     const dict: IssueStateDict = {
+      title: state.title,
       status: state.status,
       labels: state.labels,
       hasPr: state.hasPr,


### PR DESCRIPTION
Closes #314

## Summary

Enhance `legion status` to show a structured pipeline view grouping issues by their lifecycle phase (Triage → Done), with worker status indicators, blocked/idle detection, and a summary line.

### Changes

**State pipeline (`packages/daemon/src/state/`):**
- Add `title` field to `ParsedIssue`, `FetchedIssueData`, `IssueState`, `IssueStateDict` — carried through all layers (backends → enrichment → decision → serialization)
- GitHub backend extracts `title` from GraphQL project items (already fetched but previously discarded)
- Linear backend extracts `title` from raw issue data

**CLI (`packages/daemon/src/cli/`):**
- New `pipeline.ts` module with formatting/grouping logic, decoupled from CLI for testability
- Enhanced `cmdStatus` calls `/state/fetch-and-collect` to get pipeline data
- `--json` flag outputs machine-readable JSON (for future dashboard integrations)
- Error handling: graceful failure when daemon unreachable or `/state/collect` fails

**Tests (`packages/daemon/src/cli/__tests__/pipeline.test.ts`):**
- 10-issue fixture across 5 phases for snapshot testing
- Edge cases: empty state, all-in-one-phase, all-blocked, no-workers, title truncation
- Status indicator priority tests (BLOCKED > NEEDS INPUT > worker:status > IDLE)

### Output format

```
Legion Status: sjawhar/2
========================================
Daemon: RUNNING (port 13370)
Workers: 3

Pipeline
----------------------------------------

Backlog (2)
  sjawhar-legion-101 Set up authentication service with JWT tok… [IDLE]
  sjawhar-legion-102 Add rate limiting to API endpoints [BLOCKED]

In Progress (2)
  sjawhar-legion-104 Implement webhook delivery system with ret… [implement:running]
  sjawhar-legion-105 Fix memory leak in event processor causing… [NEEDS INPUT]

...

Total: 10 issues | Active: 3 workers | Blocked: 1 | Needs Input: 1 | Idle: 4
```