### PR TITLE
sjawhar-legion-316: add domain routing for reviewer auto-assignment by file path

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,34 +1,40 @@
 {
   "filesChanged": [
-    "packages/envoy/infra/machines.ts",
-    "packages/envoy/infra/nats.ts",
-    "packages/envoy/infra/services.ts",
-    "packages/envoy/infra/Pulumi.prod.yaml",
-    "packages/envoy/infra/README.md",
-    "packages/envoy/infra/__tests__/nats.test.ts",
-    "packages/envoy/infra/__tests__/services.test.ts",
-    "packages/envoy/deploy/compose/nats/peer.compose.yml",
-    "packages/envoy/deploy/compose/nats/compose.yml",
-    "packages/envoy/docs/constraints.md",
-    "docs/solutions/envoy/docker-tailscale-networking.md"
+    "packages/daemon/src/routing/schema.ts",
+    "packages/daemon/src/routing/config.ts",
+    "packages/daemon/src/routing/match.ts",
+    "packages/daemon/src/routing/index.ts",
+    "packages/daemon/src/routing/__tests__/schema.test.ts",
+    "packages/daemon/src/routing/__tests__/config.test.ts",
+    "packages/daemon/src/routing/__tests__/match.test.ts",
+    "packages/daemon/src/routing/__tests__/server-endpoint.test.ts",
+    "packages/daemon/src/daemon/feedback.ts",
+    "packages/daemon/src/daemon/server.ts",
+    "packages/daemon/src/daemon/AGENTS.md",
+    ".opencode/skills/legion-controller/SKILL.md",
+    "packages/daemon/package.json",
+    "bun.lock"
   ],
   "trickyParts": [
-    "Conflict resolution on .legion/architect.json after rebase — main had ghost-wispr architect data, our branch had #310 architect data",
-    "Empty intermediate commit from jj new needed to be rebased past to avoid push rejection"
+    "Rebase onto main brought in unsubscribeWorkerFromEnvoy references from the prune endpoint PR that needed fixing to unsubscribeAllWorkerTopics",
+    "Auto-generated plan file from planner phase used different architecture than implementation — removed from PR"
   ],
   "deviations": [
-    "Added receivers.ghostwispr row to README.md Machine Configuration table — was missing, noticed while removing tailscaleIp row"
+    "Used .legion/routing.yml instead of repo root legion.routing.yml — consistent with existing .legion/config.yml pattern",
+    "Used separate routing/ module directory instead of single routing.ts file in daemon/ — cleaner separation of concerns",
+    "Added yaml npm dependency for YAML parsing instead of using plan's suggestion of Bun built-in"
   ],
   "openQuestions": [],
   "subPlanningNeeded": false,
   "learningsInjected": [
-    "docs/solutions/envoy/docker-tailscale-networking.md",
-    "docs/solutions/envoy/pulumi-remote-docker-patterns.md"
+    "daemon/handoff-schema-migration-patterns.md",
+    "delegation/hardening-patterns.md",
+    "testing/bun-fetch-mocking-patterns.md"
   ],
   "learningsHelpful": [
-    "docs/solutions/envoy/docker-tailscale-networking.md"
+    "daemon/handoff-schema-migration-patterns.md"
   ],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-07T02:00:23.064Z"
+  "completed": "2026-04-07T04:09:02.514Z"
 }

--- a/.legion/plan.json
+++ b/.legion/plan.json
@@ -1,28 +1,26 @@
 {
-  "taskCount": 6,
-  "independentTasks": 4,
+  "taskCount": 2,
+  "independentTasks": 1,
   "routingHints": {
-    "complexity": "small",
+    "complexity": "trivial",
     "estimatedImplementers": 1,
-    "skipRetro": false,
+    "skipRetro": true,
     "skipArchitect": true
   },
   "concerns": [
-    "MachineConfig.name must match MagicDNS hostname - assumption verified by existing sshHost usage but should be documented",
-    "Host networking exposes NATS ports directly - verify no port collisions during rollout",
-    "Live cluster verification (routez, JetStream persistence) requires Tailscale-connected host, not CI-testable"
+    "Implementation already exists on main — all 38 routing tests pass. Plan is verification-only.",
+    "PR author filtering is handled by gh pr edit error catching (|| true), not server-side filtering"
   ],
+  "workflowRecommendation": "Verification-only — implementation already on main. Single implementer verifies tests pass and AC are met. Skip retro (trivial verification).",
   "learningsInjected": [
-    "envoy/docker-tailscale-networking.md",
-    "envoy/pulumi-remote-docker-patterns.md",
-    "infra/mixed-runtime-type-boundaries.md"
+    "daemon/server-side-dispatch-validation.md",
+    "testing/bun-fetch-mocking-patterns.md",
+    "integration-patterns/controller-worker-protocol.md"
   ],
   "learningsHelpful": [
-    "envoy/docker-tailscale-networking.md",
-    "envoy/pulumi-remote-docker-patterns.md"
+    "integration-patterns/controller-worker-protocol.md"
   ],
-  "workflowRecommendation": "Standard pipeline — all phases needed. Tasks 1/2/4/5 are independent and can be parallelized by the implementer.",
   "schemaVersion": 1,
   "phase": "plan",
-  "completed": "2026-04-07T01:52:38.524Z"
+  "completed": "2026-04-07T04:04:59.234Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,29 +1,33 @@
 {
   "critical": 0,
-  "important": 0,
+  "important": 1,
   "minor": 2,
   "verdict": "approved",
   "keyFindings": [
     {
-      "severity": "P3",
-      "file": "packages/envoy/cmd/ghostwispr/main.go",
-      "description": "Duplicate normalizeGhostWisprEventType function also exists in internal/contracts/normalize.go:603. Could be exported and shared."
+      "severity": "P2",
+      "file": "packages/daemon/src/daemon/server.ts",
+      "description": "Dead code: console.warn block at lines 1132-1134 can never execute — loadRoutingConfig() returns warning=null when config is non-null. Warning is correctly surfaced via API response and feedback events."
     },
     {
       "severity": "P3",
-      "file": "packages/envoy/cmd/ghostwispr/main_test.go",
-      "description": "Handler tests only check wantPublished bool, don't verify envelope content (topic/source/dedupe_key). Partially mitigated by normalization tests."
+      "file": "packages/daemon/src/routing/__tests__/match.test.ts",
+      "description": "Missing partial path prefix edge case test (packages/envoy-plugin/ vs packages/envoy/**). Bun.Glob handles correctly but no test covers this glob gotcha."
+    },
+    {
+      "severity": "P3",
+      "file": "docs/",
+      "description": "No standalone user-facing documentation for .legion/routing.yml config format. Documented in issue, PR, and controller skill but not in docs/."
     }
   ],
   "learningsInjected": [
-    "docs/solutions/envoy/contracts-and-handler-patterns.md",
-    "docs/solutions/envoy/adding-resource-level-subject-helpers.md",
-    "docs/solutions/envoy/pulumi-remote-docker-patterns.md"
+    "daemon/server-side-dispatch-validation.md",
+    "integration-patterns/controller-worker-protocol.md"
   ],
   "learningsHelpful": [
-    "docs/solutions/envoy/contracts-and-handler-patterns.md"
+    "integration-patterns/controller-worker-protocol.md"
   ],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-07T01:28:49.487Z"
+  "completed": "2026-04-07T04:31:40.387Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,19 +1,24 @@
 {
-  "passed": 12,
+  "passed": 9,
   "failed": 0,
   "failures": [],
-  "documentationFeedback": "README Machine Configuration table is clear — name→MagicDNS contract explicit on line 104. constraints.md updates both required lines. docker-tailscale-networking.md preserves bridge networking rule while noting NATS exception. No gaps or confusion found.",
+  "documentationFeedback": "AGENTS.md includes /routing/match endpoint. PR description documents design decisions clearly. Controller skill has detailed integration steps with graceful degradation. Missing: no standalone user-facing doc for .legion/routing.yml config format.",
   "observations": [
-    "P2: Tests are happy-path-only — no edge cases for empty machines, all nats:false, or special characters in names",
-    "P2: No integration test for createNatsPeer() full pipeline (MachineConfig→PeerInfo→routes→conf→container)",
-    "Deviation: receivers.ghostwispr row added to README (harmless, documents existing field)",
-    "Pre-existing TS5107 moduleResolution=node10 deprecation in infra tsconfig — unrelated to PR",
-    "deleteBeforeReplace: true correctly set on NATS container per pulumi-remote-docker-patterns learning",
-    "Criteria 13 (JetStream persistence) and 14 (cluster formation) are manual rollout verification — code supports both via named volumes and hostname-based routes"
+    "P2: console.warn at server.ts:1132-1134 is dead code — placed after early return for !config. Warning is surfaced via API response and feedback events but not to console/stderr.",
+    "P2: Missing edge case test for partial path prefix (packages/envoy-plugin/ vs packages/envoy/**) — Bun.Glob handles correctly but no unit test covers it.",
+    "P2: No concurrent request tests for /routing/match endpoint.",
+    "P2: No test for file permission errors on config read.",
+    "Pre-existing: 1 test failure in daemon/index.test.ts (passes controller env vars to adapter.start) — unrelated to routing."
   ],
-  "learningsInjected": [],
-  "learningsHelpful": [],
+  "learningsInjected": [
+    "testing/bun-fetch-mocking-patterns.md",
+    "integration-patterns/controller-worker-protocol.md",
+    "daemon/server-side-dispatch-validation.md"
+  ],
+  "learningsHelpful": [
+    "integration-patterns/controller-worker-protocol.md"
+  ],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-07T02:09:46.782Z"
+  "completed": "2026-04-07T04:22:32.640Z"
 }

--- a/.opencode/skills/legion-controller/SKILL.md
+++ b/.opencode/skills/legion-controller/SKILL.md
@@ -287,6 +287,51 @@ After the tester runs:
 - **Test passed** (`test-passed` label): Controller removes `worker-done` and `test-passed` labels, transitions to Needs Review, dispatches reviewer (no additional quality gate needed)
 - **Test failed** (`test-failed` label): Controller removes `test-failed` and `worker-done` labels, transitions back to In Progress, resumes implementer session with test failure report from the PR comment
 
+### Domain-Based Reviewer Auto-Assignment
+
+When the controller processes `dispatch_reviewer` (i.e., about to dispatch a review worker),
+it MUST first run domain-based reviewer routing. This auto-assigns PR reviewers based on
+which files were changed, using configuration from `.legion/routing.yml` in the workspace.
+
+**Steps (before dispatching the review worker):**
+
+1. Get the PR's changed files and the worker workspace:
+   ```bash
+   PR_FILES=$(gh pr view "$ISSUE_IDENTIFIER" --json files --jq '[.files[].path]' -R $OWNER/$REPO)
+   WORKSPACE=$(curl -fsS "http://127.0.0.1:$LEGION_DAEMON_PORT/workers/${ISSUE_IDENTIFIER}-implement" 2>/dev/null | jq -r '.workspace // empty')
+   ```
+
+2. Call the daemon's routing endpoint:
+   ```bash
+   ROUTING_RESULT=$(curl -fsS -X POST "http://127.0.0.1:$LEGION_DAEMON_PORT/routing/match" \
+     -H 'Content-Type: application/json' \
+     -d "{\"workspace\": \"$WORKSPACE\", \"files\": $PR_FILES, \"issueId\": \"$ISSUE_IDENTIFIER\"}")
+   ```
+
+3. If reviewers are returned, add them to the PR:
+   ```bash
+   REVIEWERS=$(echo "$ROUTING_RESULT" | jq -r '.reviewers[]')
+   if [ -n "$REVIEWERS" ]; then
+     for reviewer in $REVIEWERS; do
+       gh pr edit "$ISSUE_IDENTIFIER" --add-reviewer "$reviewer" -R $OWNER/$REPO 2>/dev/null || true
+     done
+   fi
+   ```
+
+4. Log the result (for debugging):
+   ```bash
+   MATCHED=$(echo "$ROUTING_RESULT" | jq -r '.matchedDomains | length')
+   echo "[routing] Matched $MATCHED domains, added reviewers: $(echo "$ROUTING_RESULT" | jq -r '.reviewers | join(", ")')"
+   ```
+
+5. Proceed with normal review worker dispatch.
+
+**Graceful degradation:**
+- If `.legion/routing.yml` is missing: no reviewers added (silent, no error)
+- If the routing endpoint fails: log warning and proceed with dispatch (routing is advisory)
+- If `gh pr edit --add-reviewer` fails for a reviewer: skip that reviewer, continue with others
+- If the implement worker's workspace is unavailable: skip routing, proceed with dispatch
+
 ### Review → Re-implementation → Testing Loop
 
 When the reviewer requests changes, the implementer's fixes **must go through testing again**:

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "packages/daemon": {
       "name": "legion",
-      "version": "0.10.1",
+      "version": "0.13.5",
       "bin": {
         "legion": "src/cli/index.ts",
       },
@@ -27,6 +27,7 @@
         "@opencode-ai/sdk": "https://github.com/sjawhar/opencode/releases/download/v1.2.4-post.2/opencode-ai-sdk-1.2.4-post.1.tgz",
         "citty": "^0.2.0",
         "uuid": "^9.0.0",
+        "yaml": "^2.8.3",
         "zod": "^3.24.4",
       },
       "devDependencies": {
@@ -37,7 +38,7 @@
     },
     "packages/envoy-plugin": {
       "name": "@sjawhar/opencode-legion-envoy",
-      "version": "0.1.0-alpha.0",
+      "version": "0.1.0",
       "dependencies": {
         "@opencode-ai/plugin": "^1.1.19",
       },
@@ -49,7 +50,7 @@
     },
     "packages/opencode-plugin": {
       "name": "opencode-legion",
-      "version": "0.10.1",
+      "version": "0.13.5",
       "bin": {
         "opencode-legion": "./src/cli/index.ts",
       },
@@ -119,13 +120,13 @@
 
     "vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
 
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@opencode-ai/plugin/@opencode-ai/sdk": ["@opencode-ai/sdk@1.2.27", "", {}, "sha512-Wk0o/I+Fo+wE3zgvlJDs8Fb67KlKqX0PrV8dK5adSDkANq6r4Z25zXJg2iOir+a8ntg3rAcpel1OY4FV/TwRUA=="],
 
     "@opencode-ai/plugin/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
-
-    "legion/@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
 
     "legion/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -134,8 +135,6 @@
     "opencode-legion/@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
 
     "vscode-languageserver-protocol/vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
-
-    "legion/@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "opencode-legion/@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
   }

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -17,6 +17,7 @@
     "@opencode-ai/sdk": "https://github.com/sjawhar/opencode/releases/download/v1.2.4-post.2/opencode-ai-sdk-1.2.4-post.1.tgz",
     "citty": "^0.2.0",
     "uuid": "^9.0.0",
+    "yaml": "^2.8.3",
     "zod": "^3.24.4"
   },
   "devDependencies": {

--- a/packages/daemon/src/daemon/AGENTS.md
+++ b/packages/daemon/src/daemon/AGENTS.md
@@ -15,6 +15,7 @@ HTTP server + shared `opencode serve` instance. One long-lived serve process han
 | `GET` | `/workers/:id/status` | Proxy to worker's OpenCode `/session/status` |
 | `POST` | `/workers/prune` | Bulk-remove workers + crash history by issue ID — `{issueIds: string[]}` → `{pruned, crashHistoryPruned}` |
 | `POST` | `/shutdown` | Graceful shutdown — stop shared serve, persist state |
+| `POST` | `/routing/match` | Domain-based reviewer routing — `{workspace, files, issueId?}` → `{reviewers, matchedDomains, configWarning}` |
 
 **Worker ID format:** `{issueId}-{mode}` lowercase (e.g., `eng-21-implement`)
 

--- a/packages/daemon/src/daemon/feedback.ts
+++ b/packages/daemon/src/daemon/feedback.ts
@@ -59,11 +59,27 @@ export const HealthTickEventSchema = FeedbackEventBase.extend({
   rssRestarts: z.number().int().nonnegative(),
 });
 
+export const RoutingMatchedEventSchema = FeedbackEventBase.extend({
+  event: z.literal("routing.matched"),
+  issueId: z.string(),
+  workspace: z.string(),
+  fileCount: z.number().int().nonnegative(),
+  matchedDomains: z.array(
+    z.object({
+      name: z.string(),
+      reviewers: z.array(z.string()),
+    })
+  ),
+  reviewersAdded: z.array(z.string()),
+  configWarning: z.string().nullable(),
+});
+
 export const FeedbackEventSchema = z.discriminatedUnion("event", [
   WorkerDispatchedEventSchema,
   WorkerStatusChangedEventSchema,
   StateCollectedEventSchema,
   HealthTickEventSchema,
+  RoutingMatchedEventSchema,
 ]);
 
 type WorkerDispatchedEvent = z.infer<typeof WorkerDispatchedEventSchema>;
@@ -72,12 +88,14 @@ type StateCollectedEvent = z.infer<typeof StateCollectedEventSchema>;
 type HealthTickEvent = z.infer<typeof HealthTickEventSchema> & {
   issueId?: undefined;
 };
+type RoutingMatchedEvent = z.infer<typeof RoutingMatchedEventSchema>;
 
 export type FeedbackEvent =
   | WorkerDispatchedEvent
   | WorkerStatusChangedEvent
   | StateCollectedEvent
-  | HealthTickEvent;
+  | HealthTickEvent
+  | RoutingMatchedEvent;
 
 type OmitFeedbackBase<TEvent> = TEvent extends unknown
   ? Omit<TEvent, "schemaVersion" | "timestamp" | "legionId">

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -1,5 +1,6 @@
 import { isAbsolute } from "node:path";
 import type { CodebaseIndexResponse } from "../index/types";
+import { loadRoutingConfig, matchRouting } from "../routing";
 import { getBackend, isBackendName } from "../state/backends/index";
 import { buildCollectedState, canDispatchMode } from "../state/decision";
 import { enrichParsedIssues } from "../state/fetch";
@@ -739,7 +740,7 @@ export function startServer(opts: ServerOptions): {
           workers.delete(workerId);
           crashHistory.delete(workerId);
           await persistState();
-          unsubscribeWorkerFromEnvoy(entry.sessionId);
+          unsubscribeAllWorkerTopics(entry.sessionId);
 
           return jsonResponse({ status: "cleaned", workerRemoved: true });
         }
@@ -818,7 +819,7 @@ export function startServer(opts: ServerOptions): {
           }
 
           for (const sessionId of prunedSessionIds) {
-            unsubscribeWorkerFromEnvoy(sessionId);
+            unsubscribeAllWorkerTopics(sessionId);
           }
 
           return jsonResponse({
@@ -1085,6 +1086,71 @@ export function startServer(opts: ServerOptions): {
             console.error(`[fetch-and-collect] backend=${backend} error=${message}`);
             return serverError(`fetch_and_collect_failed: ${message}`);
           }
+        }
+
+        if (method === "POST" && url.pathname === "/routing/match") {
+          let payload: Record<string, unknown>;
+          try {
+            payload = await parseJson(request);
+          } catch {
+            return badRequest("invalid_json");
+          }
+
+          const workspace = payload.workspace;
+          const files = payload.files;
+          const issueId = typeof payload.issueId === "string" ? payload.issueId : undefined;
+          if (typeof workspace !== "string" || !isAbsolute(workspace)) {
+            return badRequest("workspace must be an absolute path");
+          }
+          if (!Array.isArray(files) || !files.every((f) => typeof f === "string")) {
+            return badRequest("files must be an array of strings");
+          }
+
+          const { config, warning } = loadRoutingConfig(workspace);
+          if (!config) {
+            const result = {
+              reviewers: [] as string[],
+              matchedDomains: [] as { name: string; reviewers: string[] }[],
+              configWarning: warning,
+            };
+
+            if (opts.feedbackLogger && issueId) {
+              opts.feedbackLogger.log({
+                event: "routing.matched",
+                issueId,
+                workspace,
+                fileCount: files.length,
+                matchedDomains: [],
+                reviewersAdded: [],
+                configWarning: warning,
+              });
+            }
+
+            return jsonResponse(result);
+          }
+
+          if (warning) {
+            console.warn(`[routing] ${warning}`);
+          }
+
+          const matchResult = matchRouting(config, files as string[]);
+
+          if (opts.feedbackLogger && issueId) {
+            opts.feedbackLogger.log({
+              event: "routing.matched",
+              issueId,
+              workspace,
+              fileCount: files.length,
+              matchedDomains: matchResult.matchedDomains,
+              reviewersAdded: matchResult.reviewers,
+              configWarning: warning,
+            });
+          }
+
+          return jsonResponse({
+            ...matchResult,
+            configWarning: warning,
+          });
         }
 
         if (method === "POST" && url.pathname === "/shutdown") {

--- a/packages/daemon/src/routing/__tests__/config.test.ts
+++ b/packages/daemon/src/routing/__tests__/config.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { loadRoutingConfig } from "../config";
+import { ROUTING_CONFIG_PATH } from "../schema";
+
+function createTempWorkspace(): string {
+  return mkdtempSync(path.join(os.tmpdir(), "routing-config-test-"));
+}
+
+function writeConfig(workspace: string, content: string): void {
+  const configDir = path.dirname(path.join(workspace, ROUTING_CONFIG_PATH));
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(path.join(workspace, ROUTING_CONFIG_PATH), content, "utf-8");
+}
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.length = 0;
+});
+
+describe("loadRoutingConfig", () => {
+  it("returns null config with no warning when file is missing", () => {
+    const workspace = createTempWorkspace();
+    tempDirs.push(workspace);
+
+    const result = loadRoutingConfig(workspace);
+    expect(result.config).toBeNull();
+    expect(result.warning).toBeNull();
+  });
+
+  it("loads a valid YAML config", () => {
+    const workspace = createTempWorkspace();
+    tempDirs.push(workspace);
+
+    writeConfig(
+      workspace,
+      `
+domains:
+  - name: envoy
+    paths:
+      - "packages/envoy/**"
+      - "packages/contracts/**"
+    reviewers:
+      - envoy-expert
+  - name: daemon
+    paths:
+      - "packages/daemon/**"
+    reviewers:
+      - daemon-expert
+`
+    );
+
+    const result = loadRoutingConfig(workspace);
+    expect(result.config).not.toBeNull();
+    expect(result.warning).toBeNull();
+    expect(result.config?.domains).toHaveLength(2);
+    expect(result.config?.domains[0].name).toBe("envoy");
+    expect(result.config?.domains[0].paths).toEqual(["packages/envoy/**", "packages/contracts/**"]);
+    expect(result.config?.domains[0].reviewers).toEqual(["envoy-expert"]);
+  });
+
+  it("returns warning for invalid YAML", () => {
+    const workspace = createTempWorkspace();
+    tempDirs.push(workspace);
+
+    writeConfig(workspace, "{{invalid yaml:::}}}");
+
+    const result = loadRoutingConfig(workspace);
+    expect(result.config).toBeNull();
+    expect(result.warning).toContain("Invalid YAML");
+  });
+
+  it("returns warning for valid YAML but invalid schema", () => {
+    const workspace = createTempWorkspace();
+    tempDirs.push(workspace);
+
+    writeConfig(
+      workspace,
+      `
+domains:
+  - name: envoy
+    paths: []
+    reviewers:
+      - alice
+`
+    );
+
+    const result = loadRoutingConfig(workspace);
+    expect(result.config).toBeNull();
+    expect(result.warning).toContain("Invalid routing config");
+  });
+
+  it("returns warning when domains key is missing", () => {
+    const workspace = createTempWorkspace();
+    tempDirs.push(workspace);
+
+    writeConfig(workspace, "something_else: true");
+
+    const result = loadRoutingConfig(workspace);
+    expect(result.config).toBeNull();
+    expect(result.warning).toContain("Invalid routing config");
+  });
+
+  it("returns warning for empty domains array", () => {
+    const workspace = createTempWorkspace();
+    tempDirs.push(workspace);
+
+    writeConfig(workspace, "domains: []");
+
+    const result = loadRoutingConfig(workspace);
+    expect(result.config).toBeNull();
+    expect(result.warning).toContain("Invalid routing config");
+  });
+});

--- a/packages/daemon/src/routing/__tests__/match.test.ts
+++ b/packages/daemon/src/routing/__tests__/match.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "bun:test";
+import { matchRouting } from "../match";
+import type { RoutingConfig } from "../schema";
+
+const testConfig: RoutingConfig = {
+  domains: [
+    {
+      name: "envoy",
+      paths: ["packages/envoy/**", "packages/contracts/**"],
+      reviewers: ["envoy-expert"],
+    },
+    {
+      name: "daemon",
+      paths: ["packages/daemon/**"],
+      reviewers: ["daemon-expert"],
+    },
+    {
+      name: "skills",
+      paths: [".opencode/skills/**"],
+      reviewers: ["skills-expert", "daemon-expert"],
+    },
+  ],
+};
+
+describe("matchRouting", () => {
+  it("matches a single domain by glob pattern", () => {
+    const result = matchRouting(testConfig, ["packages/envoy/src/foo.ts"]);
+    expect(result.reviewers).toEqual(["envoy-expert"]);
+    expect(result.matchedDomains).toEqual([{ name: "envoy", reviewers: ["envoy-expert"] }]);
+  });
+
+  it("matches nested files within a glob pattern", () => {
+    const result = matchRouting(testConfig, ["packages/daemon/src/state/decision.ts"]);
+    expect(result.reviewers).toEqual(["daemon-expert"]);
+    expect(result.matchedDomains).toHaveLength(1);
+    expect(result.matchedDomains[0].name).toBe("daemon");
+  });
+
+  it("returns no matches when no files match any domain", () => {
+    const result = matchRouting(testConfig, ["README.md", "package.json"]);
+    expect(result.reviewers).toEqual([]);
+    expect(result.matchedDomains).toEqual([]);
+  });
+
+  it("matches multiple domains when files span domains", () => {
+    const result = matchRouting(testConfig, [
+      "packages/envoy/src/foo.ts",
+      "packages/daemon/src/bar.ts",
+    ]);
+    expect(result.reviewers).toContain("envoy-expert");
+    expect(result.reviewers).toContain("daemon-expert");
+    expect(result.matchedDomains).toHaveLength(2);
+  });
+
+  it("deduplicates reviewers across domains", () => {
+    // daemon-expert appears in both "daemon" and "skills" domains
+    const result = matchRouting(testConfig, [
+      "packages/daemon/src/bar.ts",
+      ".opencode/skills/legion-worker/SKILL.md",
+    ]);
+    expect(result.reviewers).toContain("daemon-expert");
+    expect(result.reviewers).toContain("skills-expert");
+    // daemon-expert should appear only once
+    const daemonCount = result.reviewers.filter((r) => r === "daemon-expert").length;
+    expect(daemonCount).toBe(1);
+  });
+
+  it("matches when any file in the list matches a domain", () => {
+    const result = matchRouting(testConfig, [
+      "README.md",
+      "packages/envoy/src/deep/nested/file.ts",
+      "docs/plan.md",
+    ]);
+    expect(result.reviewers).toEqual(["envoy-expert"]);
+  });
+
+  it("matches contracts path under envoy domain", () => {
+    const result = matchRouting(testConfig, ["packages/contracts/src/types.ts"]);
+    expect(result.reviewers).toEqual(["envoy-expert"]);
+    expect(result.matchedDomains[0].name).toBe("envoy");
+  });
+
+  it("handles empty file list", () => {
+    const result = matchRouting(testConfig, []);
+    expect(result.reviewers).toEqual([]);
+    expect(result.matchedDomains).toEqual([]);
+  });
+
+  it("matches all three domains when files span all of them", () => {
+    const result = matchRouting(testConfig, [
+      "packages/envoy/src/foo.ts",
+      "packages/daemon/src/bar.ts",
+      ".opencode/skills/legion-controller/SKILL.md",
+    ]);
+    expect(result.matchedDomains).toHaveLength(3);
+    expect(result.reviewers).toContain("envoy-expert");
+    expect(result.reviewers).toContain("daemon-expert");
+    expect(result.reviewers).toContain("skills-expert");
+  });
+});

--- a/packages/daemon/src/routing/__tests__/schema.test.ts
+++ b/packages/daemon/src/routing/__tests__/schema.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "bun:test";
+import { DomainSchema, RoutingConfigSchema } from "../schema";
+
+describe("DomainSchema", () => {
+  it("validates a valid domain", () => {
+    const result = DomainSchema.safeParse({
+      name: "envoy",
+      paths: ["packages/envoy/**"],
+      reviewers: ["alice"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates domain with multiple paths and reviewers", () => {
+    const result = DomainSchema.safeParse({
+      name: "envoy",
+      paths: ["packages/envoy/**", "packages/contracts/**"],
+      reviewers: ["alice", "bob"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty name", () => {
+    const result = DomainSchema.safeParse({
+      name: "",
+      paths: ["packages/envoy/**"],
+      reviewers: ["alice"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty paths array", () => {
+    const result = DomainSchema.safeParse({
+      name: "envoy",
+      paths: [],
+      reviewers: ["alice"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty reviewers array", () => {
+    const result = DomainSchema.safeParse({
+      name: "envoy",
+      paths: ["packages/envoy/**"],
+      reviewers: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing fields", () => {
+    expect(DomainSchema.safeParse({}).success).toBe(false);
+    expect(DomainSchema.safeParse({ name: "x" }).success).toBe(false);
+    expect(DomainSchema.safeParse({ name: "x", paths: ["a"] }).success).toBe(false);
+  });
+
+  it("rejects empty string in paths", () => {
+    const result = DomainSchema.safeParse({
+      name: "envoy",
+      paths: [""],
+      reviewers: ["alice"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty string in reviewers", () => {
+    const result = DomainSchema.safeParse({
+      name: "envoy",
+      paths: ["packages/envoy/**"],
+      reviewers: [""],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("RoutingConfigSchema", () => {
+  it("validates a valid config", () => {
+    const result = RoutingConfigSchema.safeParse({
+      domains: [
+        {
+          name: "envoy",
+          paths: ["packages/envoy/**", "packages/contracts/**"],
+          reviewers: ["envoy-expert"],
+        },
+        {
+          name: "daemon",
+          paths: ["packages/daemon/**"],
+          reviewers: ["daemon-expert"],
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.domains).toHaveLength(2);
+    }
+  });
+
+  it("rejects empty domains array", () => {
+    const result = RoutingConfigSchema.safeParse({ domains: [] });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing domains key", () => {
+    const result = RoutingConfigSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-object input", () => {
+    expect(RoutingConfigSchema.safeParse(null).success).toBe(false);
+    expect(RoutingConfigSchema.safeParse("string").success).toBe(false);
+    expect(RoutingConfigSchema.safeParse(42).success).toBe(false);
+  });
+});

--- a/packages/daemon/src/routing/__tests__/server-endpoint.test.ts
+++ b/packages/daemon/src/routing/__tests__/server-endpoint.test.ts
@@ -1,0 +1,296 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { FeedbackLogger, type FeedbackWriter } from "../../daemon/feedback";
+import type { RuntimeAdapter } from "../../daemon/runtime/types";
+import { startServer } from "../../daemon/server";
+import { writeStateFile } from "../../daemon/state-file";
+import { ROUTING_CONFIG_PATH } from "../schema";
+
+const legionId = "test-routing-endpoint";
+
+class RecordingFeedbackWriter implements FeedbackWriter {
+  lines: string[] = [];
+
+  async append(line: string): Promise<void> {
+    this.lines.push(line);
+  }
+
+  async flush(): Promise<void> {}
+}
+
+function makeAdapter(): RuntimeAdapter {
+  return {
+    start: async () => {},
+    stop: async () => {},
+    healthy: async () => true,
+    getPort: () => 15600,
+    getServePid: () => 0,
+    createSession: async (sessionId: string) => sessionId,
+    sendPrompt: async () => {},
+    getSessionStatus: async () => ({ data: undefined }),
+  };
+}
+
+function writeConfig(workspace: string, content: string): void {
+  const configDir = path.dirname(path.join(workspace, ROUTING_CONFIG_PATH));
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(path.join(workspace, ROUTING_CONFIG_PATH), content, "utf-8");
+}
+
+const VALID_CONFIG = `
+domains:
+  - name: envoy
+    paths:
+      - "packages/envoy/**"
+      - "packages/contracts/**"
+    reviewers:
+      - envoy-expert
+  - name: daemon
+    paths:
+      - "packages/daemon/**"
+    reviewers:
+      - daemon-expert
+`;
+
+describe("POST /routing/match", () => {
+  let tempDir: string | null = null;
+  let stopServer: (() => void) | null = null;
+  let baseUrl = "";
+  const originalFetch = globalThis.fetch;
+
+  async function startTestServer(options?: { feedbackLogger?: FeedbackLogger }) {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "routing-endpoint-"));
+    const stateFilePath = path.join(tempDir, "workers.json");
+    await writeStateFile(stateFilePath, { workers: {}, crashHistory: {} });
+
+    const { server, stop } = startServer({
+      port: 0,
+      hostname: "127.0.0.1",
+      legionId,
+      legionDir: tempDir,
+      adapter: makeAdapter(),
+      stateFilePath,
+      feedbackLogger: options?.feedbackLogger,
+    });
+    stopServer = stop;
+    baseUrl = `http://127.0.0.1:${server.port}`;
+  }
+
+  async function postRouting(body: unknown) {
+    return originalFetch(`${baseUrl}/routing/match`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    if (stopServer) {
+      stopServer();
+      stopServer = null;
+    }
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  it("returns matched reviewers for files matching a domain", async () => {
+    await startTestServer();
+    const workspace = mkdtempSync(path.join(os.tmpdir(), "routing-ws-"));
+    writeConfig(workspace, VALID_CONFIG);
+
+    try {
+      const response = await postRouting({
+        workspace,
+        files: ["packages/envoy/src/foo.ts"],
+      });
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        reviewers: string[];
+        matchedDomains: { name: string; reviewers: string[] }[];
+        configWarning: string | null;
+      };
+      expect(body.reviewers).toEqual(["envoy-expert"]);
+      expect(body.matchedDomains).toHaveLength(1);
+      expect(body.matchedDomains[0].name).toBe("envoy");
+      expect(body.configWarning).toBeNull();
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty result when no config file exists", async () => {
+    await startTestServer();
+    const workspace = mkdtempSync(path.join(os.tmpdir(), "routing-ws-"));
+
+    try {
+      const response = await postRouting({
+        workspace,
+        files: ["packages/envoy/src/foo.ts"],
+      });
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        reviewers: string[];
+        matchedDomains: unknown[];
+        configWarning: string | null;
+      };
+      expect(body.reviewers).toEqual([]);
+      expect(body.matchedDomains).toEqual([]);
+      expect(body.configWarning).toBeNull();
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty result with warning for invalid config", async () => {
+    await startTestServer();
+    const workspace = mkdtempSync(path.join(os.tmpdir(), "routing-ws-"));
+    writeConfig(workspace, "domains: []");
+
+    try {
+      const response = await postRouting({
+        workspace,
+        files: ["packages/envoy/src/foo.ts"],
+      });
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        reviewers: string[];
+        matchedDomains: unknown[];
+        configWarning: string | null;
+      };
+      expect(body.reviewers).toEqual([]);
+      expect(body.matchedDomains).toEqual([]);
+      expect(body.configWarning).toContain("Invalid routing config");
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty reviewers when no files match", async () => {
+    await startTestServer();
+    const workspace = mkdtempSync(path.join(os.tmpdir(), "routing-ws-"));
+    writeConfig(workspace, VALID_CONFIG);
+
+    try {
+      const response = await postRouting({
+        workspace,
+        files: ["README.md", "package.json"],
+      });
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        reviewers: string[];
+        matchedDomains: unknown[];
+      };
+      expect(body.reviewers).toEqual([]);
+      expect(body.matchedDomains).toEqual([]);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("returns 400 for missing workspace", async () => {
+    await startTestServer();
+    const response = await postRouting({ files: ["foo.ts"] });
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for non-absolute workspace", async () => {
+    await startTestServer();
+    const response = await postRouting({
+      workspace: "relative/path",
+      files: ["foo.ts"],
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for missing files array", async () => {
+    await startTestServer();
+    const response = await postRouting({ workspace: "/tmp/ws" });
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for non-string files", async () => {
+    await startTestServer();
+    const response = await postRouting({
+      workspace: "/tmp/ws",
+      files: [123, 456],
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it("logs feedback event when issueId is provided", async () => {
+    const writer = new RecordingFeedbackWriter();
+    const logger = new FeedbackLogger(writer, legionId);
+    await startTestServer({ feedbackLogger: logger });
+
+    const workspace = mkdtempSync(path.join(os.tmpdir(), "routing-ws-"));
+    writeConfig(workspace, VALID_CONFIG);
+
+    try {
+      const response = await postRouting({
+        workspace,
+        files: ["packages/envoy/src/foo.ts"],
+        issueId: "sjawhar-legion-316",
+      });
+      expect(response.status).toBe(200);
+
+      await logger.flush();
+      expect(writer.lines.length).toBeGreaterThanOrEqual(1);
+      const event = JSON.parse(writer.lines[0]);
+      expect(event.event).toBe("routing.matched");
+      expect(event.issueId).toBe("sjawhar-legion-316");
+      expect(event.reviewersAdded).toEqual(["envoy-expert"]);
+      expect(event.matchedDomains).toHaveLength(1);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("does not log feedback when issueId is not provided", async () => {
+    const writer = new RecordingFeedbackWriter();
+    const logger = new FeedbackLogger(writer, legionId);
+    await startTestServer({ feedbackLogger: logger });
+
+    const workspace = mkdtempSync(path.join(os.tmpdir(), "routing-ws-"));
+    writeConfig(workspace, VALID_CONFIG);
+
+    try {
+      await postRouting({
+        workspace,
+        files: ["packages/envoy/src/foo.ts"],
+      });
+
+      await logger.flush();
+      expect(writer.lines).toHaveLength(0);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("matches multiple domains and deduplicates reviewers", async () => {
+    await startTestServer();
+    const workspace = mkdtempSync(path.join(os.tmpdir(), "routing-ws-"));
+    writeConfig(workspace, VALID_CONFIG);
+
+    try {
+      const response = await postRouting({
+        workspace,
+        files: ["packages/envoy/src/foo.ts", "packages/daemon/src/bar.ts"],
+      });
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        reviewers: string[];
+        matchedDomains: { name: string; reviewers: string[] }[];
+      };
+      expect(body.reviewers).toContain("envoy-expert");
+      expect(body.reviewers).toContain("daemon-expert");
+      expect(body.matchedDomains).toHaveLength(2);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/daemon/src/routing/config.ts
+++ b/packages/daemon/src/routing/config.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { ROUTING_CONFIG_PATH, type RoutingConfig, RoutingConfigSchema } from "./schema";
+
+export interface LoadRoutingConfigResult {
+  config: RoutingConfig | null;
+  /** Non-null when config was invalid (parse or validation error). */
+  warning: string | null;
+}
+
+/**
+ * Load and validate the routing config from a workspace.
+ *
+ * - Missing file → returns null config, no warning (silent disable).
+ * - Invalid YAML or schema → returns null config with warning message.
+ * - Valid config → returns parsed config.
+ */
+export function loadRoutingConfig(workspace: string): LoadRoutingConfigResult {
+  const configPath = join(workspace, ROUTING_CONFIG_PATH);
+
+  let raw: string;
+  try {
+    raw = readFileSync(configPath, "utf-8");
+  } catch {
+    // Missing file silently disables routing (AC: "Missing config file disables routing silently")
+    return { config: null, warning: null };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch (error) {
+    return {
+      config: null,
+      warning: `Invalid YAML in ${ROUTING_CONFIG_PATH}: ${(error as Error).message}`,
+    };
+  }
+
+  const result = RoutingConfigSchema.safeParse(parsed);
+  if (!result.success) {
+    return {
+      config: null,
+      warning: `Invalid routing config in ${ROUTING_CONFIG_PATH}: ${result.error.message}`,
+    };
+  }
+
+  return { config: result.data, warning: null };
+}

--- a/packages/daemon/src/routing/index.ts
+++ b/packages/daemon/src/routing/index.ts
@@ -1,0 +1,9 @@
+export { type LoadRoutingConfigResult, loadRoutingConfig } from "./config";
+export { type MatchedDomain, matchRouting, type RoutingMatchResult } from "./match";
+export {
+  type Domain,
+  DomainSchema,
+  ROUTING_CONFIG_PATH,
+  type RoutingConfig,
+  RoutingConfigSchema,
+} from "./schema";

--- a/packages/daemon/src/routing/match.ts
+++ b/packages/daemon/src/routing/match.ts
@@ -1,0 +1,68 @@
+import type { Domain, RoutingConfig } from "./schema";
+
+/**
+ * A matched domain with its name and the reviewers to assign.
+ */
+export interface MatchedDomain {
+  name: string;
+  reviewers: string[];
+}
+
+/**
+ * Result of matching PR files against routing config.
+ */
+export interface RoutingMatchResult {
+  /** Deduplicated list of all reviewers to assign. */
+  reviewers: string[];
+  /** Domains that matched, with their individual reviewer lists. */
+  matchedDomains: MatchedDomain[];
+}
+
+/**
+ * Check if a file path matches any of the domain's glob patterns.
+ *
+ * Uses Bun.Glob for pattern matching. Each pattern is tested
+ * against the file path independently.
+ */
+function fileMatchesDomain(filePath: string, domain: Domain): boolean {
+  for (const pattern of domain.paths) {
+    const glob = new Bun.Glob(pattern);
+    if (glob.match(filePath)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Match a list of PR changed files against the routing config.
+ *
+ * For each domain, if ANY changed file matches ANY of the domain's
+ * path patterns, the domain's reviewers are included in the result.
+ *
+ * All matched reviewers are collected (union of all matching domains).
+ * Reviewers are deduplicated in the final list.
+ *
+ * @param config - The validated routing configuration
+ * @param files - List of changed file paths from the PR
+ * @returns Matched reviewers and domain details
+ */
+export function matchRouting(config: RoutingConfig, files: string[]): RoutingMatchResult {
+  const matchedDomains: MatchedDomain[] = [];
+  const reviewerSet = new Set<string>();
+
+  for (const domain of config.domains) {
+    const domainMatched = files.some((file) => fileMatchesDomain(file, domain));
+    if (domainMatched) {
+      matchedDomains.push({ name: domain.name, reviewers: domain.reviewers });
+      for (const reviewer of domain.reviewers) {
+        reviewerSet.add(reviewer);
+      }
+    }
+  }
+
+  return {
+    reviewers: Array.from(reviewerSet),
+    matchedDomains,
+  };
+}

--- a/packages/daemon/src/routing/schema.ts
+++ b/packages/daemon/src/routing/schema.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+/**
+ * A single domain routing rule.
+ *
+ * Maps a set of file path glob patterns to a list of reviewers
+ * who should be assigned when PR files match those patterns.
+ */
+export const DomainSchema = z.object({
+  name: z.string().min(1),
+  paths: z.array(z.string().min(1)).min(1),
+  reviewers: z.array(z.string().min(1)).min(1),
+});
+
+export type Domain = z.infer<typeof DomainSchema>;
+
+/**
+ * Top-level routing configuration.
+ *
+ * Loaded from `.legion/routing.yml` in the workspace root.
+ * Defines domain-to-path mappings for reviewer auto-assignment.
+ */
+export const RoutingConfigSchema = z.object({
+  domains: z.array(DomainSchema).min(1),
+});
+
+export type RoutingConfig = z.infer<typeof RoutingConfigSchema>;
+
+/** File path for the routing config relative to workspace root. */
+export const ROUTING_CONFIG_PATH = ".legion/routing.yml";


### PR DESCRIPTION
Closes #316

## Summary

Adds a configuration-driven domain routing system for automatic reviewer assignment. When the controller dispatches a review worker, it matches the PR's changed files against glob patterns in `.legion/routing.yml` and adds matched domain reviewers to the PR.

### What's new

- **Routing module** (`packages/daemon/src/routing/`) — Zod-validated config loading from `.legion/routing.yml`, glob-based file matching via `Bun.Glob`, reviewer resolution with deduplication
- **HTTP endpoint** (`POST /routing/match`) — accepts workspace path + file list, returns matched reviewers and domains
- **Feedback event** (`routing.matched`) — logs routing results (matched domains, reviewers added, config warnings)
- **Controller integration** — updated controller skill to call routing endpoint before dispatching review workers, with graceful degradation for all failure modes

### Design decisions

- **Multi-match**: All matched reviewers are added (union across domains, deduplicated)
- **No match → no changes**: PR touching no configured paths results in no reviewer changes
- **Config location**: `.legion/routing.yml` (consistent with existing `.legion/config.yml`)
- **Glob engine**: `Bun.Glob` (zero new dependencies for pattern matching)
- **Phase 1 scope**: Reviewer assignment only at review dispatch time

### Example config

```yaml
domains:
  - name: envoy
    paths:
      - "packages/envoy/**"
      - "packages/contracts/**"
    reviewers:
      - envoy-expert-username
  - name: daemon
    paths:
      - "packages/daemon/**"
    reviewers:
      - daemon-expert-username
```

### Test coverage

38 tests across 4 files covering schema validation, config loading (missing/invalid/valid), match logic (single/nested/multi-domain/dedup/no-match), and server endpoint integration.