### PR TITLE
sjawhar-legion-322: make jj git fetch non-blocking in worker dispatch

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,16 +1,25 @@
 {
   "filesChanged": [
-    "packages/daemon/src/daemon/server.ts"
+    "packages/daemon/src/daemon/repo-manager.ts",
+    "packages/daemon/src/daemon/server.ts",
+    "packages/daemon/src/daemon/__tests__/repo-manager.test.ts",
+    "packages/daemon/src/daemon/__tests__/server.test.ts"
   ],
   "trickyParts": [
-    "Issue description was inaccurate — it claimed ledger.test.ts was failing due to readPhaseHandoff throwing, but actual failures were in server.ts using an undefined function name unsubscribeWorkerFromEnvoy instead of the existing unsubscribeAllWorkerTopics"
+    "Cross-family review identified that default runJj uses Bun.spawnSync which blocks the event loop even in async wrapper — added spawnJjAsync field to RepoManagerDeps with truly async Bun.spawn default",
+    "startBackgroundFetch needed to reject on non-zero exit codes for .catch() logging to work — resolved promises with exitCode!=0 were silently swallowed"
   ],
   "deviations": [
-    "Fixed server.ts instead of ledger.test.ts — the issue description was wrong about which file and tests were failing"
+    "Added spawnJjAsync optional field to RepoManagerDeps interface (not in original issue spec but required for correctness)",
+    "Background fetch fires even after fresh clone (slightly redundant but harmless — fetch is a no-op immediately after clone)"
   ],
-  "openQuestions": [],
+  "openQuestions": [
+    "Pre-existing CI failures on main: unsubscribeWorkerFromEnvoy typecheck errors at server.ts lines 750/829, and 6 prune/workspace cleanup test failures — all unrelated to this PR"
+  ],
   "subPlanningNeeded": false,
+  "learningsInjected": [],
+  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-07T17:55:09.982Z"
+  "completed": "2026-04-07T17:26:28.444Z"
 }

--- a/packages/daemon/src/daemon/__tests__/repo-manager.test.ts
+++ b/packages/daemon/src/daemon/__tests__/repo-manager.test.ts
@@ -7,6 +7,7 @@ import {
   parseIssueRepo,
   type RepoManagerDeps,
   resolveWorkspacePath,
+  startBackgroundFetch,
 } from "../repo-manager";
 
 describe("parseIssueRepo", () => {
@@ -57,7 +58,7 @@ describe("ensureRepoClone", () => {
     expect(commands[0]).toContain("https://github.com/acme/widgets");
   });
 
-  it("fetches when directory already exists", async () => {
+  it("skips fetch when directory already exists", async () => {
     const commands: string[][] = [];
     const deps: RepoManagerDeps = {
       runJj: async (args) => {
@@ -69,14 +70,18 @@ describe("ensureRepoClone", () => {
       symlink: async () => {},
     };
     const paths = resolveLegionPaths({}, "/home/test");
-    await ensureRepoClone(paths, { host: "github.com", owner: "acme", repo: "widgets" }, deps);
+    const clonePath = await ensureRepoClone(
+      paths,
+      { host: "github.com", owner: "acme", repo: "widgets" },
+      deps
+    );
 
-    expect(commands[0]).toContain("git");
-    expect(commands[0]).toContain("fetch");
+    expect(clonePath).toBe("/home/test/.local/share/legion/repos/github.com/acme/widgets");
+    expect(commands).toEqual([]);
   });
 
   describe("characterization: ensureRepoClone", () => {
-    it("returns clone path when directory exists and fetch succeeds", async () => {
+    it("returns clone path without fetching when directory exists", async () => {
       const commands: string[][] = [];
       const deps: RepoManagerDeps = {
         runJj: async (args) => {
@@ -96,9 +101,7 @@ describe("ensureRepoClone", () => {
       );
 
       expect(clonePath).toBe("/home/test/.local/share/legion/repos/github.com/acme/widgets");
-      expect(commands).toEqual([
-        ["git", "fetch", "-R", "/home/test/.local/share/legion/repos/github.com/acme/widgets"],
-      ]);
+      expect(commands).toEqual([]);
     });
 
     it("clones and returns clone path when directory does not exist", async () => {
@@ -132,15 +135,15 @@ describe("ensureRepoClone", () => {
     });
   });
 
-  describe("fetch failure propagation", () => {
-    it("throws when jj git fetch fails", async () => {
+  describe("clone failure propagation", () => {
+    it("throws when jj git clone fails", async () => {
       const deps: RepoManagerDeps = {
         runJj: async () => ({
           exitCode: 1,
           stdout: "",
           stderr: "fatal: could not read from remote",
         }),
-        exists: async () => true,
+        exists: async () => false,
         rmDir: async () => {},
         symlink: async () => {},
       };
@@ -148,13 +151,17 @@ describe("ensureRepoClone", () => {
 
       await expect(
         ensureRepoClone(paths, { host: "github.com", owner: "acme", repo: "widgets" }, deps)
-      ).rejects.toThrow("jj git fetch failed");
+      ).rejects.toThrow("Failed to clone");
     });
 
     it("includes stderr in error message", async () => {
       const deps: RepoManagerDeps = {
-        runJj: async () => ({ exitCode: 128, stdout: "", stderr: "Permission denied (publickey)" }),
-        exists: async () => true,
+        runJj: async () => ({
+          exitCode: 128,
+          stdout: "",
+          stderr: "Permission denied (publickey)",
+        }),
+        exists: async () => false,
         rmDir: async () => {},
         symlink: async () => {},
       };
@@ -323,5 +330,50 @@ describe("cleanupWorkspace", () => {
     expect(removedPaths).toContain(
       "/home/test/.local/share/legion/workspaces/sjawhar/42/acme-widgets-7"
     );
+  });
+});
+
+describe("startBackgroundFetch", () => {
+  it("fires jj git fetch with the correct clone path", async () => {
+    const commands: string[][] = [];
+    const deps: RepoManagerDeps = {
+      runJj: async (args) => {
+        commands.push(args);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      exists: async () => true,
+      rmDir: async () => {},
+      symlink: async () => {},
+    };
+    const paths = resolveLegionPaths({}, "/home/test");
+
+    const result = await startBackgroundFetch(
+      paths,
+      { host: "github.com", owner: "acme", repo: "widgets" },
+      deps
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(commands).toEqual([
+      ["git", "fetch", "-R", "/home/test/.local/share/legion/repos/github.com/acme/widgets"],
+    ]);
+  });
+
+  it("rejects on non-zero exit code so .catch() fires", async () => {
+    const deps: RepoManagerDeps = {
+      runJj: async () => ({
+        exitCode: 128,
+        stdout: "",
+        stderr: "Permission denied (publickey)",
+      }),
+      exists: async () => true,
+      rmDir: async () => {},
+      symlink: async () => {},
+    };
+    const paths = resolveLegionPaths({}, "/home/test");
+
+    await expect(
+      startBackgroundFetch(paths, { host: "github.com", owner: "acme", repo: "widgets" }, deps)
+    ).rejects.toThrow("Permission denied");
   });
 });

--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -271,7 +271,8 @@ describe("daemon server", () => {
     expect(createSessionCalls[0].workspace).toBe(
       "/tmp/legion-data/workspaces/123e4567-e89b-12d3-a456-426614174000/acme-widgets-77"
     );
-    expect(runJjCalls).toEqual([
+    // Blocking calls: clone + workspace add. Background fetch follows.
+    expect(runJjCalls.slice(0, 2)).toEqual([
       [
         "git",
         "clone",
@@ -289,6 +290,13 @@ describe("daemon server", () => {
         "-R",
         "/tmp/legion-data/repos/github.com/acme/widgets",
       ],
+    ]);
+    // Background fetch fires after workspace creation (non-blocking)
+    expect(runJjCalls[2]).toEqual([
+      "git",
+      "fetch",
+      "-R",
+      "/tmp/legion-data/repos/github.com/acme/widgets",
     ]);
   });
 
@@ -380,7 +388,49 @@ describe("daemon server", () => {
     });
   });
 
-  it("returns 500 when repo fetch fails", async () => {
+  it("succeeds when clone exists even if background fetch would fail", async () => {
+    const paths: LegionPaths = {
+      dataDir: "/tmp/legion-data",
+      stateDir: "/tmp/legion-state",
+      reposDir: "/tmp/legion-data/repos",
+      workspacesDir: "/tmp/legion-data/workspaces",
+      legionsFile: "/tmp/legion-state/legions.json",
+      forLegion: (projectId: string) => ({
+        legionStateDir: `/tmp/legion-state/legions/${projectId}`,
+        workersFile: `/tmp/legion-state/legions/${projectId}/workers.json`,
+        feedbackFile: `/tmp/legion-state/legions/${projectId}/feedback.jsonl`,
+        logDir: `/tmp/legion-state/legions/${projectId}/logs`,
+        workspacesDir: `/tmp/legion-data/workspaces/${projectId}`,
+      }),
+      repoClonePath: (host: string, owner: string, repo: string) =>
+        `/tmp/legion-data/repos/${host}/${owner}/${repo}`,
+    };
+    const repoManagerDeps: RepoManagerDeps = {
+      // runJj would fail if called — but ensureRepoClone skips fetch for existing clones
+      runJj: async () => ({ exitCode: 128, stdout: "", stderr: "Permission denied (publickey)" }),
+      exists: async () => true,
+      rmDir: async () => {},
+      symlink: async () => {},
+    };
+    await startTestServer({ paths, repoManagerDeps });
+
+    const response = await requestJson("/workers", {
+      method: "POST",
+      body: JSON.stringify({
+        issueId: "acme-widgets-99",
+        mode: "implement",
+        repo: "acme/widgets",
+      }),
+    });
+
+    // Worker created successfully — background fetch failure is non-blocking
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toHaveProperty("id", "acme-widgets-99-implement");
+    expect(body).toHaveProperty("sessionId");
+  });
+
+  it("returns 500 when repo clone fails", async () => {
     const paths: LegionPaths = {
       dataDir: "/tmp/legion-data",
       stateDir: "/tmp/legion-state",
@@ -399,7 +449,7 @@ describe("daemon server", () => {
     };
     const repoManagerDeps: RepoManagerDeps = {
       runJj: async () => ({ exitCode: 128, stdout: "", stderr: "Permission denied (publickey)" }),
-      exists: async () => true,
+      exists: async () => false, // clone does not exist — clone will fail
       rmDir: async () => {},
       symlink: async () => {},
     };

--- a/packages/daemon/src/daemon/repo-manager.ts
+++ b/packages/daemon/src/daemon/repo-manager.ts
@@ -15,6 +15,8 @@ export interface JjResult {
 
 export interface RepoManagerDeps {
   runJj: (args: string[]) => Promise<JjResult>;
+  /** Truly async subprocess runner for non-blocking operations. Falls back to runJj if absent. */
+  spawnJjAsync?: (args: string[]) => Promise<JjResult>;
   exists: (path: string) => Promise<boolean>;
   rmDir: (path: string) => Promise<void>;
   symlink: (target: string, linkPath: string) => Promise<void>;
@@ -31,6 +33,15 @@ const defaultDeps: RepoManagerDeps = {
       stdout: result.stdout.toString(),
       stderr: result.stderr.toString(),
     };
+  },
+  spawnJjAsync: async (args) => {
+    const proc = Bun.spawn(["jj", ...args], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    return { exitCode, stdout, stderr };
   },
   exists: async (p) => {
     const { existsSync } = await import("node:fs");
@@ -86,16 +97,15 @@ export async function ensureRepoClone(
   const clonePath = paths.repoClonePath(repo.host, repo.owner, repo.repo);
 
   if (await deps.exists(clonePath)) {
-    const result = await deps.runJj(["git", "fetch", "-R", clonePath]);
-    if (result.exitCode !== 0) {
-      throw new Error(`jj git fetch failed for ${clonePath}: ${result.stderr}`);
-    }
-  } else {
-    const url = `https://${repo.host}/${repo.owner}/${repo.repo}`;
-    const result = await deps.runJj(["git", "clone", url, clonePath]);
-    if (result.exitCode !== 0) {
-      throw new Error(`Failed to clone ${url}: ${result.stderr}`);
-    }
+    // Clone exists — skip fetch here, caller fires background fetch separately.
+    // Workers fetch again on startup, so a slightly stale clone is fine.
+    return clonePath;
+  }
+
+  const url = `https://${repo.host}/${repo.owner}/${repo.repo}`;
+  const result = await deps.runJj(["git", "clone", url, clonePath]);
+  if (result.exitCode !== 0) {
+    throw new Error(`Failed to clone ${url}: ${result.stderr}`);
   }
 
   return clonePath;
@@ -140,6 +150,27 @@ export async function ensureWorkspace(
   }
 
   return workspacePath;
+}
+
+/**
+ * Fire a non-blocking `jj git fetch` on an existing clone.
+ *
+ * Uses `spawnJjAsync` (truly non-blocking) when available, falling back to
+ * `runJj` for tests. Rejects on non-zero exit codes so callers can log
+ * failures via `.catch()`.
+ */
+export async function startBackgroundFetch(
+  paths: LegionPaths,
+  repo: RepoRef,
+  deps: RepoManagerDeps = defaultDeps
+): Promise<JjResult> {
+  const clonePath = paths.repoClonePath(repo.host, repo.owner, repo.repo);
+  const runner = deps.spawnJjAsync ?? deps.runJj;
+  const result = await runner(["git", "fetch", "-R", clonePath]);
+  if (result.exitCode !== 0) {
+    throw new Error(`Background fetch failed for ${clonePath}: ${result.stderr}`);
+  }
+  return result;
 }
 
 export async function cleanupWorkspace(

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -20,6 +20,7 @@ import {
   ensureWorkspace,
   parseIssueRepo,
   type RepoManagerDeps,
+  startBackgroundFetch,
 } from "./repo-manager";
 import type { RuntimeAdapter } from "./runtime/types";
 import type { WorkerEntry as BaseWorkerEntry } from "./serve-manager";
@@ -473,6 +474,13 @@ export function startServer(opts: ServerOptions): {
               } catch (error) {
                 return serverError(`Failed to resolve workspace: ${(error as Error).message}`);
               }
+              // Fire background fetch (non-blocking) — pre-warms the clone for the
+              // worker's own `jj git fetch` during startup.
+              startBackgroundFetch(opts.paths, repoRef, opts.repoManagerDeps).catch((err) => {
+                console.error(
+                  `[dispatch] Background fetch failed for ${repoRef.owner}/${repoRef.repo}: ${err instanceof Error ? err.message : String(err)}`
+                );
+              });
             } else if (typeof workspace === "string") {
               if (!isAbsolute(workspace)) {
                 return badRequest("workspace must be an absolute path");


### PR DESCRIPTION
Closes #322

## Summary

`POST /workers` blocked on `jj git fetch` in `ensureWorkspace()` for 0.5-2s per dispatch. This made batch dispatches slow (4 workers = 4-8s serial blocking).

**Fix:** Skip the synchronous fetch when the repo clone already exists. Fire `jj git fetch` in the background after the workspace is created, returning the worker entry immediately. Workers fetch again during their startup phase, so a slightly stale clone is safe.

### Changes
- **`repo-manager.ts`**: `ensureRepoClone()` no longer fetches when the clone directory exists — just returns the path. Added `startBackgroundFetch()` for non-blocking fetch with fire-and-forget semantics.
- **`server.ts`**: After `ensureWorkspace()`, fires `startBackgroundFetch()` as fire-and-forget with error logging.
- **Tests**: Updated to reflect new behavior (no blocking fetch on existing clones, background fetch is non-fatal).