### PR TITLE
sjawhar-legion-325: fix undefined unsubscribeWorkerFromEnvoy calls in server.ts

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,34 +1,16 @@
 {
   "filesChanged": [
-    "packages/envoy/infra/machines.ts",
-    "packages/envoy/infra/nats.ts",
-    "packages/envoy/infra/services.ts",
-    "packages/envoy/infra/Pulumi.prod.yaml",
-    "packages/envoy/infra/README.md",
-    "packages/envoy/infra/__tests__/nats.test.ts",
-    "packages/envoy/infra/__tests__/services.test.ts",
-    "packages/envoy/deploy/compose/nats/peer.compose.yml",
-    "packages/envoy/deploy/compose/nats/compose.yml",
-    "packages/envoy/docs/constraints.md",
-    "docs/solutions/envoy/docker-tailscale-networking.md"
+    "packages/daemon/src/daemon/server.ts"
   ],
   "trickyParts": [
-    "Conflict resolution on .legion/architect.json after rebase — main had ghost-wispr architect data, our branch had #310 architect data",
-    "Empty intermediate commit from jj new needed to be rebased past to avoid push rejection"
+    "Issue description was inaccurate — it claimed ledger.test.ts was failing due to readPhaseHandoff throwing, but actual failures were in server.ts using an undefined function name unsubscribeWorkerFromEnvoy instead of the existing unsubscribeAllWorkerTopics"
   ],
   "deviations": [
-    "Added receivers.ghostwispr row to README.md Machine Configuration table — was missing, noticed while removing tailscaleIp row"
+    "Fixed server.ts instead of ledger.test.ts — the issue description was wrong about which file and tests were failing"
   ],
   "openQuestions": [],
   "subPlanningNeeded": false,
-  "learningsInjected": [
-    "docs/solutions/envoy/docker-tailscale-networking.md",
-    "docs/solutions/envoy/pulumi-remote-docker-patterns.md"
-  ],
-  "learningsHelpful": [
-    "docs/solutions/envoy/docker-tailscale-networking.md"
-  ],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-07T02:00:23.064Z"
+  "completed": "2026-04-07T17:55:09.982Z"
 }

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -739,7 +739,7 @@ export function startServer(opts: ServerOptions): {
           workers.delete(workerId);
           crashHistory.delete(workerId);
           await persistState();
-          unsubscribeWorkerFromEnvoy(entry.sessionId);
+          unsubscribeAllWorkerTopics(entry.sessionId);
 
           return jsonResponse({ status: "cleaned", workerRemoved: true });
         }
@@ -818,7 +818,7 @@ export function startServer(opts: ServerOptions): {
           }
 
           for (const sessionId of prunedSessionIds) {
-            unsubscribeWorkerFromEnvoy(sessionId);
+            unsubscribeAllWorkerTopics(sessionId);
           }
 
           return jsonResponse({


### PR DESCRIPTION
Closes #325

## Summary

PR#279 introduced `POST /workers/prune` and workspace cleanup endpoints that call `unsubscribeWorkerFromEnvoy()`, but this function was never defined. The existing function with the correct behavior is `unsubscribeAllWorkerTopics()` (line 195 of server.ts). This caused:

- **TypeScript compilation failure**: `Cannot find name 'unsubscribeWorkerFromEnvoy'` at lines 742 and 821
- **6 test failures**: All prune/workspace-cleanup tests fail at runtime due to the undefined reference

**Fix**: Replace both `unsubscribeWorkerFromEnvoy(sessionId)` calls with `unsubscribeAllWorkerTopics(sessionId)`.