### PR TITLE
sjawhar-legion-328: add npm publish workflow for envoy-plugin following OMO recipe

### DIFF
--- a/.github/workflows/publish-envoy-plugin.yml
+++ b/.github/workflows/publish-envoy-plugin.yml
@@ -1,0 +1,135 @@
+name: Publish Envoy Plugin
+run-name: "publish envoy-plugin ${{ inputs.version || inputs.bump }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Bump major, minor, or patch"
+        required: true
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+      version:
+        description: "Override version (e.g., 1.2.3). Takes precedence over bump."
+        required: false
+        type: string
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: bun install
+        working-directory: packages/envoy-plugin
+
+      - name: Calculate version
+        id: calc
+        env:
+          RAW_VERSION: ${{ inputs.version }}
+          BUMP: ${{ inputs.bump }}
+        run: |
+          VERSION="$RAW_VERSION"
+          if [ -z "$VERSION" ]; then
+            PREV=$(curl -s "https://registry.npmjs.org/@sjawhar%2Fopencode-legion-envoy/latest" | jq -r '.version // "0.0.0"')
+            BASE="${PREV%%-*}"
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
+            case "$BUMP" in
+              major) VERSION="$((MAJOR+1)).0.0" ;;
+              minor) VERSION="${MAJOR}.$((MINOR+1)).0" ;;
+              *) VERSION="${MAJOR}.${MINOR}.$((PATCH+1))" ;;
+            esac
+          fi
+
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version: $VERSION"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION"
+
+      - name: Check if already published
+        id: check
+        env:
+          VERSION: ${{ steps.calc.outputs.version }}
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/@sjawhar%2Fopencode-legion-envoy/${VERSION}")
+          if [ "$STATUS" = "200" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "✓ @sjawhar/opencode-legion-envoy@${VERSION} already published"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update version
+        if: steps.check.outputs.skip != 'true'
+        env:
+          VERSION: ${{ steps.calc.outputs.version }}
+        run: |
+          jq --arg v "$VERSION" '.version = $v' packages/envoy-plugin/package.json > tmp.json
+          mv tmp.json packages/envoy-plugin/package.json
+
+      - name: Build
+        if: steps.check.outputs.skip != 'true'
+        run: bun run build
+        working-directory: packages/envoy-plugin
+
+      - name: Publish
+        if: steps.check.outputs.skip != 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+        run: npm publish --access public
+        working-directory: packages/envoy-plugin
+
+      - name: Commit version bump
+        if: steps.check.outputs.skip != 'true'
+        env:
+          VERSION: ${{ steps.calc.outputs.version }}
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add packages/envoy-plugin/package.json
+          git diff --cached --quiet || git commit -m "chore: release @sjawhar/opencode-legion-envoy v${VERSION} [skip ci]"
+
+      - name: Compute release tag
+        if: steps.check.outputs.skip != 'true'
+        id: version
+        uses: sjawhar/.github/.github/actions/sami-version@v1
+        with:
+          source: bun
+          manifest_path: packages/envoy-plugin/package.json
+
+      - name: Push release
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin HEAD --tags
+
+      - name: Create GitHub release
+        if: steps.check.outputs.skip != 'true'
+        uses: sjawhar/.github/.github/actions/sami-release@v1
+        with:
+          tag: ${{ steps.version.outputs.tag }}
+          body: "Release @sjawhar/opencode-legion-envoy v${{ steps.calc.outputs.version }}"

--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,41 +1,21 @@
 {
   "filesChanged": [
-    "packages/daemon/src/daemon/serve-manager.ts",
-    "packages/daemon/src/daemon/runtime/types.ts",
-    "packages/daemon/src/daemon/runtime/opencode.ts",
-    "packages/daemon/src/daemon/runtime/claude-code.ts",
-    "packages/daemon/src/daemon/server.ts",
-    "packages/daemon/src/daemon/__tests__/serve-manager.test.ts",
-    "packages/daemon/src/daemon/__tests__/server.test.ts",
-    "packages/daemon/src/daemon/__tests__/multi-serve.test.ts",
-    "packages/daemon/src/daemon/__tests__/index.test.ts",
-    "packages/daemon/src/daemon/__tests__/feedback.integration.test.ts",
-    "packages/daemon/src/daemon/__tests__/session-id-contract.test.ts",
-    "packages/daemon/src/__tests__/integration.test.ts"
+    ".github/workflows/publish-envoy-plugin.yml"
   ],
   "trickyParts": [
-    "Cross-family review caught that POST /workers/prune had a leak window: persistState() before deleteSession() meant a crash between them could orphan sessions. Fixed by moving deleteSession before persistState.",
-    "Cross-family review caught that POST /workers replacing dead workers never deleted the old session. Added deleteSession call before replacing dead worker entries."
+    "Cross-family review caught 3 issues: missing [skip ci] on release commit, brittle git push HEAD, and release job running when version already published. All addressed.",
+    "Branch was contaminated with unrelated changes from other workers — cleaned up to isolate only the workflow file."
   ],
   "deviations": [
-    "No formal plan existed in issue comments — implemented directly from the bug report description",
-    "Added deleteSession to POST /workers dead-worker-replacement path (not in original scope but identified by cross-family review as necessary)"
+    "Did not add declaration generation (bunx tsc --emitDeclarationOnly) — the package.json types field pointing to dist/index.d.ts is a pre-existing gap in the build script.",
+    "Did not add files field to package.json to control npm publish contents — matching existing OMO pattern."
   ],
   "openQuestions": [
-    "Pre-existing test failure: 'passes controller env vars to adapter.start on startup' in index.test.ts — fails on main, unrelated to this PR",
-    "ClaudeCodeAdapter.deleteSession is a no-op — tmux windows persist by design, but could accumulate if not cleaned up"
+    "NODE_AUTH_TOKEN secret must be added to the Legion repo before the workflow can run.",
+    "Pre-existing: packages/envoy-plugin/package.json declares types: dist/index.d.ts but the build script does not generate declarations."
   ],
   "subPlanningNeeded": false,
-  "learningsInjected": [
-    "docs/solutions/daemon/opencode-serve-lifecycle.md",
-    "docs/solutions/daemon/graceful-worker-shutdown.md",
-    "docs/solutions/daemon/shared-serve-retro.md"
-  ],
-  "learningsHelpful": [
-    "docs/solutions/daemon/opencode-serve-lifecycle.md",
-    "docs/solutions/daemon/graceful-worker-shutdown.md"
-  ],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-08T12:15:16.102Z"
+  "completed": "2026-04-08T12:12:25.878Z"
 }


### PR DESCRIPTION
Closes #328

## Summary

Adds `.github/workflows/publish-envoy-plugin.yml` — a `workflow_dispatch`-triggered npm publish workflow for `@sjawhar/opencode-legion-envoy`.

### Pattern followed
- **OMO publish.yml** for version calculation, OIDC provenance, and workflow structure
- **sami-build.yml** (sami branch) for `sami-version@v1` tag computation and `sami-release@v1` GitHub release creation

### Features
- **Manual semantic version bumps** via `workflow_dispatch` (patch/minor/major) or version override
- **OIDC provenance** — `id-token: write` + `NPM_CONFIG_PROVENANCE: true`
- **OIDC auth** — `actions/setup-node` with `registry-url` + `NODE_AUTH_TOKEN` secret
- **Version from npm registry** — fetches latest published version and bumps
- **Idempotent** — checks if version already published, skips all steps if so
- **Build before publish** — `bun install` + `bun run build` in `packages/envoy-plugin`
- **`npm publish --access public`** — no `--tag` flag (publishes to `latest`)
- **Version bump committed** back to repo with `[skip ci]`
- **sami-version@v1** computes release tag from updated `package.json`
- **sami-release@v1** creates GitHub release with the sami tag

### Prerequisite
`NODE_AUTH_TOKEN` secret must be added to the Legion repo before the workflow can run.