### PR TITLE
sjawhar-legion-330: delete sessions from serve on worker removal to fix SQLite FD leak

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,26 +1,41 @@
 {
   "filesChanged": [
-    "packages/envoy/go.mod",
-    "packages/envoy/go.sum",
-    "packages/envoy/internal/bus/nats.go",
-    "packages/envoy/internal/store/kv.go",
-    "packages/envoy/internal/store/kv_test.go",
-    "packages/envoy/internal/session/registry.go"
+    "packages/daemon/src/daemon/serve-manager.ts",
+    "packages/daemon/src/daemon/runtime/types.ts",
+    "packages/daemon/src/daemon/runtime/opencode.ts",
+    "packages/daemon/src/daemon/runtime/claude-code.ts",
+    "packages/daemon/src/daemon/server.ts",
+    "packages/daemon/src/daemon/__tests__/serve-manager.test.ts",
+    "packages/daemon/src/daemon/__tests__/server.test.ts",
+    "packages/daemon/src/daemon/__tests__/multi-serve.test.ts",
+    "packages/daemon/src/daemon/__tests__/index.test.ts",
+    "packages/daemon/src/daemon/__tests__/feedback.integration.test.ts",
+    "packages/daemon/src/daemon/__tests__/session-id-contract.test.ts",
+    "packages/daemon/src/__tests__/integration.test.ts"
   ],
   "trickyParts": [
-    "Removing load() introduces a theoretical startup race window where Match() returns empty until watch() populates the cache. Analysis shows this is safe: Get() has a KV fallback for agent-targeted messages, the consumer uses DeliverNew() so no historical messages are at risk, and WatchAll() initial delivery is faster than the old N sequential Gets approach."
+    "Cross-family review caught that POST /workers/prune had a leak window: persistState() before deleteSession() meant a crash between them could orphan sessions. Fixed by moving deleteSession before persistState.",
+    "Cross-family review caught that POST /workers replacing dead workers never deleted the old session. Added deleteSession call before replacing dead worker entries."
   ],
   "deviations": [
-    "Removed the entire load() function rather than just skipping the call — it was dead code after removing the call site, so clean removal is better than leaving it"
+    "No formal plan existed in issue comments — implemented directly from the bug report description",
+    "Added deleteSession to POST /workers dead-worker-replacement path (not in original scope but identified by cross-family review as necessary)"
   ],
-  "openQuestions": [],
+  "openQuestions": [
+    "Pre-existing test failure: 'passes controller env vars to adapter.start on startup' in index.test.ts — fails on main, unrelated to this PR",
+    "ClaudeCodeAdapter.deleteSession is a no-op — tmux windows persist by design, but could accumulate if not cleaned up"
+  ],
   "subPlanningNeeded": false,
   "learningsInjected": [
-    "docs/solutions/architecture-patterns/nats-kv-graceful-degradation.md",
-    "docs/solutions/envoy/async-health-startup-pattern.md"
+    "docs/solutions/daemon/opencode-serve-lifecycle.md",
+    "docs/solutions/daemon/graceful-worker-shutdown.md",
+    "docs/solutions/daemon/shared-serve-retro.md"
   ],
-  "learningsHelpful": ["docs/solutions/envoy/async-health-startup-pattern.md"],
+  "learningsHelpful": [
+    "docs/solutions/daemon/opencode-serve-lifecycle.md",
+    "docs/solutions/daemon/graceful-worker-shutdown.md"
+  ],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-08T12:08:54.859Z"
+  "completed": "2026-04-08T12:15:16.102Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -2,16 +2,25 @@
   "passed": 4,
   "failed": 0,
   "failures": [],
-  "documentationFeedback": "README does not mention internal behavior changes — appropriate for a bugfix. Code comments at kv.go:50-52 clearly explain the rationale for removing load() and switching to async watch(). No user-facing documentation updates needed.",
+  "documentationFeedback": "PR body is clear and well-structured. JSDoc on deleteSession is accurate. Minor gap: AGENTS.md doesn't mention deleteSession in serve-manager description — not blocking.",
   "observations": [
-    "P2: Happy-path-only test coverage for error paths — no test for watch() goroutine failure (kv.WatchAll() error) or Get() cache-miss fallback blocking on remote KV leader",
-    "P2: No negative test verifying Open() with MaxWait properly returns error if JetStream unreachable within 10s",
-    "Get() fallback to direct kv.Get() on cache miss (kv.go:120-139) is a latent risk — single-key Get could block on remote leader before watch() delivers initial values, though window is very short and blast radius is 1 key not 1492",
-    "All 12 Go test packages pass including internal/integration (115s) — comprehensive end-to-end coverage"
+    "P2: No test assertion for deleteSessionCalls in workspace deletion path (cleans worker workspace by repo)",
+    "P2: No test assertion for deleteSessionCalls in dead worker replacement path (allows respawn for dead workers)",
+    "P2: No ordering test for prune path deleteSession-before-persistState constraint",
+    "P2: Happy-path-only integration tests — no slow/blocked deleteSession coverage",
+    "ClaudeCodeAdapter.deleteSession is a no-op — tmux windows can accumulate",
+    "Pre-existing test failure: passes controller env vars to adapter.start on startup — fails on main, unrelated"
   ],
-  "learningsInjected": [],
-  "learningsHelpful": [],
+  "learningsInjected": [
+    "docs/solutions/daemon/opencode-serve-lifecycle.md",
+    "docs/solutions/daemon/graceful-worker-shutdown.md",
+    "docs/solutions/daemon/shared-serve-retro.md"
+  ],
+  "learningsHelpful": [
+    "docs/solutions/daemon/opencode-serve-lifecycle.md",
+    "docs/solutions/daemon/graceful-worker-shutdown.md"
+  ],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-08T12:11:22.239Z"
+  "completed": "2026-04-08T12:25:24.762Z"
 }

--- a/packages/daemon/src/__tests__/integration.test.ts
+++ b/packages/daemon/src/__tests__/integration.test.ts
@@ -37,6 +37,7 @@ async function withTestServer(run: (ctx: TestServerContext) => Promise<void>): P
     getSessionStatus: async (): Promise<{ data?: unknown; error?: unknown }> => ({
       data: undefined,
     }),
+    deleteSession: async () => {},
   };
   const { server, stop } = startServer({
     port: randomPort(),

--- a/packages/daemon/src/daemon/__tests__/feedback.integration.test.ts
+++ b/packages/daemon/src/daemon/__tests__/feedback.integration.test.ts
@@ -19,6 +19,7 @@ function makeAdapter(): RuntimeAdapter {
     createSession: async (sessionId) => sessionId,
     sendPrompt: async () => {},
     getSessionStatus: async () => ({ data: undefined }),
+    deleteSession: async () => {},
   };
 }
 

--- a/packages/daemon/src/daemon/__tests__/index.test.ts
+++ b/packages/daemon/src/daemon/__tests__/index.test.ts
@@ -112,6 +112,7 @@ function makeAdapter(overrides?: {
     },
     healthy: overrides?.healthy ?? (async () => true),
     getPort: () => 13381,
+    getServePid: overrides?.getServePid ?? (() => 0),
     createSession: async (sessionId: string, workspace: string) => {
       createSessionCalls.push({ sessionId, workspace });
       return sessionId;
@@ -124,7 +125,7 @@ function makeAdapter(overrides?: {
       promptAsyncCalls.push({ sessionID: sessionId, parts: [{ type: "text", text }] });
     },
     getSessionStatus: async () => ({ data: undefined }),
-    getServePid: overrides?.getServePid ?? (() => 0),
+    deleteSession: async () => {},
   };
 }
 

--- a/packages/daemon/src/daemon/__tests__/multi-serve.test.ts
+++ b/packages/daemon/src/daemon/__tests__/multi-serve.test.ts
@@ -38,6 +38,7 @@ function createMockAdapter(port: number): RuntimeAdapter & {
     async getSessionStatus() {
       return { data: { type: "idle" } };
     },
+    async deleteSession() {},
   };
 }
 

--- a/packages/daemon/src/daemon/__tests__/serve-manager.test.ts
+++ b/packages/daemon/src/daemon/__tests__/serve-manager.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, mock } from "bun:test";
 import {
   createSession,
   createWorkerClient,
+  deleteSession,
   healthCheck,
   killStaleServe,
   spawnSharedServe,
@@ -387,6 +388,36 @@ describe("serve-manager", () => {
       expect(client).toBeDefined();
       expect(client.session).toBeDefined();
     });
+  });
+});
+
+describe("deleteSession", () => {
+  it("sends DELETE to /session/{sessionID}", async () => {
+    let deletedUrl = "";
+    globalThis.fetch = (async (input: string, init?: RequestInit) => {
+      deletedUrl = input;
+      expect(init?.method).toBe("DELETE");
+      return new Response(null, { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await deleteSession(13381, "ses_abc123");
+    expect(deletedUrl).toBe("http://127.0.0.1:13381/session/ses_abc123");
+  });
+
+  it("does not throw on fetch failure", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("connection refused");
+    }) as unknown as typeof fetch;
+
+    await expect(deleteSession(13381, "ses_abc123")).resolves.toBeUndefined();
+  });
+
+  it("does not throw on non-2xx response", async () => {
+    globalThis.fetch = (async () => {
+      return new Response(null, { status: 500 });
+    }) as unknown as typeof fetch;
+
+    await expect(deleteSession(13381, "ses_abc123")).resolves.toBeUndefined();
   });
 });
 

--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -18,6 +18,7 @@ describe("daemon server", () => {
   let stopServer: (() => void) | null = null;
   let baseUrl = "";
   let createSessionCalls: Array<{ sessionId: string; workspace: string }> = [];
+  let deleteSessionCalls: string[] = [];
   let sessionStatusHandler:
     | ((sessionId: string) => Promise<{ data?: unknown; error?: unknown }>)
     | null = null;
@@ -56,6 +57,9 @@ describe("daemon server", () => {
         }
         return { data: undefined };
       },
+      deleteSession: async (sessionId: string) => {
+        deleteSessionCalls.push(sessionId);
+      },
     };
   }
 
@@ -70,6 +74,7 @@ describe("daemon server", () => {
     getControllerState?: () => { sessionId: string; port?: number } | undefined;
   }) {
     createSessionCalls = [];
+    deleteSessionCalls = [];
     let adapter = makeAdapter();
     if (options?.adapterOverrides) {
       adapter = { ...adapter, ...options.adapterOverrides };
@@ -647,9 +652,13 @@ describe("daemon server", () => {
     });
     const created = (await createResponse.json()) as { id: string; port: number };
 
+    const sessionId = createSessionCalls[0].sessionId;
     const deleteResponse = await requestJson(`/workers/${created.id}`, { method: "DELETE" });
     expect(deleteResponse.status).toBe(200);
     expect(await deleteResponse.json()).toEqual({ status: "stopped" });
+
+    // Session should be deleted from serve to release SQLite FDs
+    expect(deleteSessionCalls).toEqual([sessionId]);
 
     const listResponse = await requestJson("/workers");
     const listBody = (await listResponse.json()) as WorkerEntry[];
@@ -2733,6 +2742,10 @@ describe("daemon server", () => {
       const workers = (await listResponse.json()) as WorkerEntry[];
       expect(workers).toHaveLength(1);
       expect(workers[0].id).toBe("eng-200-implement");
+
+      // Sessions should be deleted from serve to release SQLite FDs
+      // ENG-100 had 2 workers (implement + review), ENG-200 was not pruned
+      expect(deleteSessionCalls).toHaveLength(2);
     });
 
     it("prunes crash history for matching workers", async () => {

--- a/packages/daemon/src/daemon/__tests__/session-id-contract.test.ts
+++ b/packages/daemon/src/daemon/__tests__/session-id-contract.test.ts
@@ -40,6 +40,7 @@ describe("sessionId contract (daemon vs state)", () => {
       },
       sendPrompt: async () => {},
       getSessionStatus: async () => ({ data: undefined }),
+      deleteSession: async () => {},
     };
 
     tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-session-contract-"));
@@ -86,6 +87,7 @@ describe("sessionId contract (daemon vs state)", () => {
       },
       sendPrompt: async () => {},
       getSessionStatus: async () => ({ data: undefined }),
+      deleteSession: async () => {},
     };
 
     tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-session-contract-"));
@@ -138,6 +140,7 @@ describe("sessionId contract (daemon vs state)", () => {
         sendPromptCalls.push({ sessionId, text });
       },
       getSessionStatus: async () => ({ data: undefined }),
+      deleteSession: async () => {},
     };
 
     tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-session-contract-"));

--- a/packages/daemon/src/daemon/runtime/claude-code.ts
+++ b/packages/daemon/src/daemon/runtime/claude-code.ts
@@ -125,6 +125,8 @@ export class ClaudeCodeAdapter implements RuntimeAdapter {
     return { data: { status: alive === "running" ? "running" : "idle" } };
   }
 
+  async deleteSession(): Promise<void> {}
+
   private isProcessAlive(sessionId: string): "running" | "exited" | "none" {
     const windowTarget = `${this.sessionName}:${sessionId}`;
     const result = this.spawn([

--- a/packages/daemon/src/daemon/runtime/opencode.ts
+++ b/packages/daemon/src/daemon/runtime/opencode.ts
@@ -1,6 +1,7 @@
 import {
   createSession,
   createWorkerClient,
+  deleteSession,
   healthCheck,
   spawnSharedServe,
   stopServe,
@@ -69,6 +70,11 @@ export class OpenCodeAdapter implements RuntimeAdapter {
     const actualId = await createSession(this.port, sessionId, workspace);
     this.workspaces.set(actualId, workspace);
     return actualId;
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    await deleteSession(this.port, sessionId);
+    this.workspaces.delete(sessionId);
   }
 
   async sendPrompt(sessionId: string, text: string): Promise<void> {

--- a/packages/daemon/src/daemon/runtime/types.ts
+++ b/packages/daemon/src/daemon/runtime/types.ts
@@ -17,6 +17,9 @@ export interface RuntimeAdapter {
   /** Create a session for a worker or controller */
   createSession(sessionId: string, workspace: string): Promise<string>;
 
+  /** Delete a session from the runtime, releasing its resources. Best-effort. */
+  deleteSession(sessionId: string): Promise<void>;
+
   /** Send a prompt to an existing session */
   sendPrompt(sessionId: string, text: string): Promise<void>;
 

--- a/packages/daemon/src/daemon/serve-manager.ts
+++ b/packages/daemon/src/daemon/serve-manager.ts
@@ -130,6 +130,24 @@ export async function createSession(
   throw new Error(`Failed to create session ${sessionId}: ${JSON.stringify(body)}`);
 }
 
+/**
+ * Delete a session from the shared serve, releasing its resources (SQLite FDs, memory).
+ * Best-effort: failures are logged but never propagated to callers.
+ */
+export async function deleteSession(port: number, sessionId: string): Promise<void> {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/session/${sessionId}`, {
+      method: "DELETE",
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      console.warn(`deleteSession: non-OK response for ${sessionId}: ${res.status}`);
+    }
+  } catch (error) {
+    console.warn(`deleteSession: failed for ${sessionId}:`, error);
+  }
+}
+
 export async function stopServe(
   port: number,
   pid: number,

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -505,6 +505,8 @@ export function startServer(opts: ServerOptions): {
               );
             }
             if (existing) {
+              // Delete old session from serve to release SQLite FDs before replacing
+              await opts.adapter.deleteSession(existing.sessionId);
               workers.delete(workerId);
             }
 
@@ -743,6 +745,9 @@ export function startServer(opts: ServerOptions): {
             return serverError(`Failed to cleanup workspace: ${(error as Error).message}`);
           }
 
+          // Delete session from serve to release SQLite FDs and memory
+          await opts.adapter.deleteSession(entry.sessionId);
+
           // Also remove the worker entry — workspace deletion means the issue is done
           workers.delete(workerId);
           crashHistory.delete(workerId);
@@ -819,6 +824,12 @@ export function startServer(opts: ServerOptions): {
 
           for (const issueId of normalizedIssueIds) {
             issueStateCache.delete(issueId);
+          }
+
+          // Delete sessions from serve BEFORE persisting state removal,
+          // so a crash between persist and delete can't orphan sessions.
+          for (const sessionId of prunedSessionIds) {
+            await opts.adapter.deleteSession(sessionId);
           }
 
           if (prunedWorkers.length > 0 || prunedCrashHistory.length > 0) {
@@ -910,6 +921,8 @@ export function startServer(opts: ServerOptions): {
             return jsonResponse(safeUpdated);
           }
           if (method === "DELETE") {
+            // Delete session from serve to release SQLite FDs and memory
+            await opts.adapter.deleteSession(entry.sessionId);
             crashHistory.set(id, {
               crashCount: entry.crashCount,
               lastCrashAt: entry.lastCrashAt,


### PR DESCRIPTION
Closes #330

## Summary

When workers are removed from the daemon (via DELETE, prune, or workspace cleanup), the daemon removed its internal tracking but never called `session.delete()` on the serve process. Sessions accumulated indefinitely in the serve's SQLite database, each holding file descriptors — 12,542 FDs observed before the 98.8GB RSS crash.

## Changes

- **`serve-manager.ts`**: Added `deleteSession(port, sessionId)` — calls `DELETE /session/{sessionID}` on the shared serve. Best-effort: errors are logged but never propagated.
- **`runtime/types.ts`**: Added `deleteSession(sessionId)` to the `RuntimeAdapter` interface.
- **`runtime/opencode.ts`**: Implemented `deleteSession()` for the OpenCode adapter — deletes session and cleans up workspace tracking.
- **`runtime/claude-code.ts`**: No-op implementation (tmux-based adapter has no serve-side sessions).
- **`server.ts`**: Added `adapter.deleteSession()` calls in **4 paths**:
  1. `DELETE /workers/:id` — before removing tracking
  2. `POST /workers/prune` — before persisting state removal (prevents orphan window on crash)
  3. `DELETE /workers/:id/workspace` — before removing tracking
  4. `POST /workers` — when replacing a dead worker entry (prevents orphaning the old session)