### PR TITLE
sjawhar-legion-299: use content-hash dedupe key in MCP bridge

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,29 +1,21 @@
 {
   "filesChanged": [
-    "packages/envoy-plugin/src/port.ts",
-    "packages/envoy-plugin/src/index.ts",
-    "packages/envoy-plugin/src/__tests__/port.test.ts",
-    "packages/envoy-plugin/src/__tests__/index.test.ts"
+    "packages/envoy/internal/mcpbridge/envelope.go",
+    "packages/envoy/internal/mcpbridge/envelope_test.go"
   ],
   "trickyParts": [
-    "resolvePort was sync (execFileSync) — changed to async with callback-based execFile wrapped in Promise. DI pattern preserved: ExecFn type accepts string | Promise<string> so test mocks work with both sync and async returns.",
-    "Port resolution split into refreshPort (async, does I/O + caching) and currentPort (sync, returns cached value) — tools need synchronous port access but resolution must be async.",
-    "Port retry timer needs unref() to avoid preventing graceful shutdown, and must be cleared in the exit handler alongside the heartbeat interval."
+    "Included URI in the SHA-256 hash alongside payloadSummary to prevent false deduplication when different resources produce identical text (e.g., two contacts both send 'Hello'). The null byte separator prevents ambiguous concatenation."
   ],
   "deviations": [
-    "No formal plan existed (issue had no comments with plan). Implemented directly from issue description and non-blocking infrastructure principle documented in docs/solutions/."
+    "Issue specified sha256(payloadSummary) only, but implementation uses sha256(uri + payloadSummary) to prevent cross-resource collisions. This is stricter than requested but prevents false positives."
   ],
   "openQuestions": [
-    "currentPort() returns null before async resolution completes — tools send port:0 to Envoy during this window. This is pre-existing behavior (old sync resolvePort could also return null). The heartbeat re-subscribes with correct port when available.",
-    "_activeFile variable is declared but never read — pre-existing dead code, not introduced by this PR."
+    "Summary truncation to 200 chars means two messages differing only after char 200 from the same URI would collide within the 10-minute dedupe window. Unlikely in practice but worth noting."
   ],
   "subPlanningNeeded": false,
-  "learningsInjected": [
-    "docs/solutions/daemon/envoy-auto-subscription-patterns.md",
-    "docs/solutions/envoy/async-health-startup-pattern.md"
-  ],
-  "learningsHelpful": ["docs/solutions/daemon/envoy-auto-subscription-patterns.md"],
+  "learningsInjected": [],
+  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-08T12:58:29.210Z"
+  "completed": "2026-04-08T15:37:22.725Z"
 }

--- a/packages/envoy/internal/mcpbridge/envelope.go
+++ b/packages/envoy/internal/mcpbridge/envelope.go
@@ -1,6 +1,8 @@
 package mcpbridge
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"unicode/utf8"
 
@@ -18,7 +20,7 @@ func BuildEnvelope(cfg *ServerConfig, notifyURI string, contents []resourceConte
 	now := contracts.NowMillis()
 	eventID := id.New()
 	summary := buildSummary(cfg, notifyURI, contents)
-	dedupeKey := buildDedupeKey(cfg.Source, eventID)
+	dedupeKey := buildDedupeKey(cfg.Source, notifyURI, summary)
 
 	return contracts.Envelope{
 		EventID:        eventID,
@@ -44,8 +46,9 @@ func buildSummary(cfg *ServerConfig, uri string, contents []resourceContent) str
 	return fmt.Sprintf("%s event from %s", cfg.Source, uri)
 }
 
-func buildDedupeKey(source string, eventID string) string {
-	return source + "." + eventID
+func buildDedupeKey(source, uri, summary string) string {
+	h := sha256.Sum256([]byte(uri + "\x00" + summary))
+	return source + "." + hex.EncodeToString(h[:])
 }
 
 func truncateSummary(s string, maxChars int) string {

--- a/packages/envoy/internal/mcpbridge/envelope_test.go
+++ b/packages/envoy/internal/mcpbridge/envelope_test.go
@@ -112,7 +112,7 @@ func TestBuildEnvelope_SummaryTruncation(t *testing.T) {
 	}
 }
 
-func TestBuildEnvelope_UniqueIDs(t *testing.T) {
+func TestBuildEnvelope_DedupeKeySameContent(t *testing.T) {
 	cfg := loadTestConfig(t)
 	uri := "whatsapp://messages/15551234567/5551234567@s.whatsapp.net"
 
@@ -125,7 +125,49 @@ func TestBuildEnvelope_UniqueIDs(t *testing.T) {
 	if env1.TraceID == env2.TraceID {
 		t.Fatal("trace_id should be unique")
 	}
+	if env1.DedupeKey != env2.DedupeKey {
+		t.Fatalf("dedupe_key should be identical for same URI and content: %s != %s", env1.DedupeKey, env2.DedupeKey)
+	}
+}
+
+func TestBuildEnvelope_DedupeKeyDifferentContent(t *testing.T) {
+	cfg := loadTestConfig(t)
+	uri := "whatsapp://messages/15551234567/5551234567@s.whatsapp.net"
+
+	env1, _ := BuildEnvelope(cfg, uri, []resourceContent{{URI: uri, Text: "Hello"}})
+	env2, _ := BuildEnvelope(cfg, uri, []resourceContent{{URI: uri, Text: "Goodbye"}})
+
 	if env1.DedupeKey == env2.DedupeKey {
-		t.Fatal("dedupe_key should be unique across calls with the same URI")
+		t.Fatal("dedupe_key should differ for different content")
+	}
+}
+
+func TestBuildEnvelope_DedupeKeyDifferentURI(t *testing.T) {
+	cfg := loadTestConfig(t)
+	uri1 := "whatsapp://messages/15551234567/5551234567@s.whatsapp.net"
+	uri2 := "whatsapp://messages/15559999999/9999999999@s.whatsapp.net"
+
+	env1, _ := BuildEnvelope(cfg, uri1, []resourceContent{{URI: uri1, Text: "Hello"}})
+	env2, _ := BuildEnvelope(cfg, uri2, []resourceContent{{URI: uri2, Text: "Hello"}})
+
+	if env1.DedupeKey == env2.DedupeKey {
+		t.Fatal("dedupe_key should differ for different URIs even with same content")
+	}
+}
+
+func TestBuildEnvelope_DedupeKeyIsContentHash(t *testing.T) {
+	cfg := loadTestConfig(t)
+	uri := "whatsapp://messages/15551234567/5551234567@s.whatsapp.net"
+	contents := []resourceContent{{URI: uri, Text: "Hello from WhatsApp"}}
+
+	env, _ := BuildEnvelope(cfg, uri, contents)
+
+	// Dedupe key should start with source prefix
+	if !strings.HasPrefix(env.DedupeKey, "whatsapp.") {
+		t.Fatalf("dedupe_key should start with source prefix, got: %s", env.DedupeKey)
+	}
+	// Dedupe key should NOT contain the event ID (which is a UUID)
+	if strings.Contains(env.DedupeKey, env.EventID) {
+		t.Fatal("dedupe_key should not contain event_id — it should be content-based")
 	}
 }


### PR DESCRIPTION
Closes #299

## Summary

Changes `buildDedupeKey` in the MCP bridge to use `sha256(uri + summary)` instead of the per-call UUID `eventID`. When MCP servers fire `sendResourceUpdated` multiple times for the same message (6x observed with WhatsApp), all envelopes now produce the same dedupe key and the listener's dedupe cache suppresses the duplicates.

### What changed

- **`envelope.go`**: `buildDedupeKey(source, uri, summary)` hashes the notification URI and payload summary with SHA-256. The `eventID` (UUID) remains as the envelope's `EventID` field for tracing.
- **`envelope_test.go`**: Replaced the `UniqueIDs` test (which asserted keys were always different) with four content-based dedupe tests:
  - Same URI + same content → same key (deduped)
  - Same URI + different content → different key (delivered)
  - Different URI + same text → different key (prevents false collision across contacts)
  - Key format validation (source prefix, no eventID leakage)

### Design notes

The URI is included in the hash alongside the summary to prevent false deduplication when different resources produce identical text (e.g., two contacts both send "Hello"). The null byte separator prevents ambiguous concatenation.
