### PR TITLE
fix(envoy-plugin): remove duplicate repository field

### DIFF
--- a/packages/envoy-plugin/package.json
+++ b/packages/envoy-plugin/package.json
@@ -21,9 +21,5 @@
     "@biomejs/biome": "^2.3.14",
     "@types/bun": "latest",
     "typescript": "^5.3.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/sjawhar/legion"
   }
 }


### PR DESCRIPTION
PR#352 and #349 both added a repository field to package.json. Removes the duplicate that causes bun install to fail.