### PR TITLE
sjawhar-legion-356: compute npm plugin version from registry, not Go tags

### DIFF
--- a/.github/workflows/release-envoy-and-plugin.yaml
+++ b/.github/workflows/release-envoy-and-plugin.yaml
@@ -111,8 +111,15 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Set release version
+        id: plugin_version
         run: |
-          jq --arg v "${{ needs.version.outputs.version }}" '.version = $v' \
+          PREV=$(curl -s https://registry.npmjs.org/@sjawhar%2Fopencode-legion-envoy/latest | jq -r '.version // "0.0.0"')
+          BASE="${PREV%%-*}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
+          PLUGIN_VERSION="${MAJOR}.${MINOR}.$((PATCH+1))"
+          echo "version=$PLUGIN_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Bumping npm $PREV → $PLUGIN_VERSION"
+          jq --arg v "$PLUGIN_VERSION" '.version = $v' \
             packages/envoy-plugin/package.json > tmp.json \
             && mv tmp.json packages/envoy-plugin/package.json
       - name: Build plugin
@@ -121,7 +128,7 @@ jobs:
       - name: Check if already published
         id: check
         env:
-          VERSION: ${{ needs.version.outputs.version }}
+          VERSION: ${{ steps.plugin_version.outputs.version }}
         run: |
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/@sjawhar%2Fopencode-legion-envoy/${VERSION}")
           if [ "$STATUS" = "200" ]; then

--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,21 +1,14 @@
 {
   "filesChanged": [
-    ".github/workflows/release-envoy-and-plugin.yaml",
-    ".github/workflows/publish-envoy-plugin.yml"
+    ".github/workflows/release-envoy-and-plugin.yaml"
   ],
   "trickyParts": [
-    "npm OIDC trusted publishing must be configured on npmjs.com for @sjawhar/opencode-legion-envoy — without it the first real publish will fail with auth error. This is a one-time npm.js config, not a workflow issue."
+    "The release job still bumps package.json with the Go tag version for the repo commit — this is intentional and separate from the npm publish version"
   ],
-  "deviations": [
-    "Removed redundant NPM_CONFIG_PROVENANCE env var since --provenance flag already enables it"
-  ],
-  "openQuestions": [
-    "npm trusted publishing config needed on npmjs.com before first real publish via unified workflow"
-  ],
+  "deviations": [],
+  "openQuestions": [],
   "subPlanningNeeded": false,
-  "learningsInjected": [],
-  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-08T19:59:07.158Z"
+  "completed": "2026-04-08T22:05:55.312Z"
 }


### PR DESCRIPTION
Closes #356

## Summary

The `plugin` job in `release-envoy-and-plugin.yaml` was using the Go envoy tag version (`legion-envoy-vX.Y.Z`) to set the npm package version. This caused version jumps that don't match the npm lineage (`0.1.0` → `0.1.1`).

**Fix:** The plugin job now computes its version independently by:
1. Fetching the current latest version from the npm registry
2. Bumping the patch version
3. Using that version to patch `package.json` and publish

The Go tag version continues to drive binary/image/GitHub release versioning — unchanged.

Next publish will produce `0.1.2` (patch bump from current npm latest `0.1.1`).

### Reference
- OMO pattern: `sjawhar/oh-my-opencode` `.github/workflows/publish.yml` — `Calculate version` step