### PR TITLE
sjawhar-legion-358: deliver full payload body to agents, not just truncated payload_summary

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,14 +1,9 @@
 {
-  "filesChanged": [
-    ".github/workflows/release-envoy-and-plugin.yaml"
-  ],
-  "trickyParts": [
-    "The release job still bumps package.json with the Go tag version for the repo commit — this is intentional and separate from the npm publish version"
-  ],
-  "deviations": [],
-  "openQuestions": [],
-  "subPlanningNeeded": false,
+  "pr": 360,
+  "branch": "sjawhar-legion-358",
+  "status": "ready_for_review",
+  "summary": "Added Payload field to Envelope struct alongside PayloadSummary. githubPayload() in normalize.go builds full untruncated JSON for comment/review/PR/issue events. session.go Text() prefers Payload over PayloadSummary. Tests verify 600-char comment bodies delivered in full.",
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-08T22:05:55.312Z"
+  "completed": "2026-04-08T22:44:40.346Z"
 }

--- a/packages/contracts/schemas/envelope.schema.json
+++ b/packages/contracts/schemas/envelope.schema.json
@@ -26,6 +26,7 @@
     "expires_at": { "type": "integer" },
     "payload_summary": { "type": "string", "minLength": 1 },
     "payload_ref": { "type": "string" },
+    "payload": { "type": "string" },
     "trace_id": { "type": "string", "minLength": 1 }
   },
   "additionalProperties": false

--- a/packages/contracts/src/envelope.ts
+++ b/packages/contracts/src/envelope.ts
@@ -13,6 +13,7 @@ export const EnvelopeSchema = z.object({
   issued_at: z.number().int(),
   expires_at: z.number().int().optional(),
   payload_summary: z.string().min(1),
+  payload: z.string().optional(),
   payload_ref: z.string().optional(),
   trace_id: z.string().min(1),
 });

--- a/packages/envoy/internal/contracts/generated.go
+++ b/packages/envoy/internal/contracts/generated.go
@@ -17,6 +17,7 @@ type Envelope struct {
 	ExpiresAt      *int64 `json:"expires_at,omitempty"`
 	PayloadSummary string `json:"payload_summary"`
 	PayloadRef     string `json:"payload_ref,omitempty"`
+	Payload        string `json:"payload,omitempty"`
 	TraceID        string `json:"trace_id"`
 }
 

--- a/packages/envoy/internal/contracts/normalize.go
+++ b/packages/envoy/internal/contracts/normalize.go
@@ -25,6 +25,7 @@ func GithubEnvelope(input GithubEnvelopeInput) Envelope {
 		DedupeKey:      "github." + input.Delivery,
 		IssuedAt:       NowMillis(),
 		PayloadSummary: githubSummary(input.Event, input.Body),
+		Payload:        githubPayload(input.Event, input.Body),
 		TraceID:        input.TraceID,
 	}
 }
@@ -398,6 +399,80 @@ func githubSummary(event string, body map[string]any) string {
 			"action": action,
 			"repo":   repo,
 		}
+	}
+
+	return summaryJSON(data)
+}
+
+func githubPayload(event string, body map[string]any) string {
+	repo := nestedString(body, "repository", "full_name")
+	action := stringValue(body["action"])
+	num := githubNumber(event, body)
+
+	var data map[string]string
+
+	switch event {
+	case "issue_comment":
+		data = map[string]string{
+			"kind":        "comment",
+			"action":      action,
+			"repo":        repo,
+			"number":      num,
+			"title":       nestedString(body, "issue", "title"),
+			"parent_kind": githubParentKind(event, body),
+			"author":      nestedString(body, "comment", "user", "login"),
+			"body":        nestedString(body, "comment", "body"),
+			"url":         nestedString(body, "comment", "html_url"),
+		}
+	case "pull_request_review_comment":
+		data = map[string]string{
+			"kind":        "comment",
+			"action":      action,
+			"repo":        repo,
+			"number":      num,
+			"title":       nestedString(body, "pull_request", "title"),
+			"parent_kind": githubParentKind(event, body),
+			"author":      nestedString(body, "comment", "user", "login"),
+			"body":        nestedString(body, "comment", "body"),
+			"url":         nestedString(body, "comment", "html_url"),
+		}
+	case "pull_request_review":
+		data = map[string]string{
+			"kind":        "review",
+			"action":      action,
+			"repo":        repo,
+			"number":      num,
+			"title":       nestedString(body, "pull_request", "title"),
+			"parent_kind": "pr",
+			"author":      nestedString(body, "review", "user", "login"),
+			"body":        nestedString(body, "review", "body"),
+			"url":         nestedString(body, "review", "html_url"),
+			"state":       nestedString(body, "review", "state"),
+		}
+	case "pull_request":
+		data = map[string]string{
+			"kind":   "pr",
+			"action": action,
+			"repo":   repo,
+			"number": num,
+			"title":  nestedString(body, "pull_request", "title"),
+			"author": nestedString(body, "pull_request", "user", "login"),
+			"body":   nestedString(body, "pull_request", "body"),
+			"url":    nestedString(body, "pull_request", "html_url"),
+		}
+	case "issues":
+		data = map[string]string{
+			"kind":   "issue",
+			"action": action,
+			"repo":   repo,
+			"number": num,
+			"title":  nestedString(body, "issue", "title"),
+			"author": nestedString(body, "issue", "user", "login"),
+			"body":   nestedString(body, "issue", "body"),
+			"url":    nestedString(body, "issue", "html_url"),
+		}
+	default:
+		return ""
 	}
 
 	return summaryJSON(data)

--- a/packages/envoy/internal/contracts/normalize_test.go
+++ b/packages/envoy/internal/contracts/normalize_test.go
@@ -1326,3 +1326,134 @@ func TestGhostWisprSummaryTruncatesTitle(t *testing.T) {
 		t.Fatalf("unexpected truncated title length: %d", got)
 	}
 }
+
+func TestGithubPayloadNotTruncated(t *testing.T) {
+	longBody := strings.Repeat("a", 600)
+	input := GithubEnvelopeInput{
+		Event:    "issue_comment",
+		Delivery: "d1",
+		EventID:  "e1",
+		TraceID:  "t1",
+		Body: map[string]any{
+			"action":     "created",
+			"repository": map[string]any{"full_name": "sjawhar/legion", "name": "legion", "owner": map[string]any{"login": "sjawhar"}},
+			"issue":      map[string]any{"number": 42, "title": "Test issue"},
+			"comment": map[string]any{
+				"body":     longBody,
+				"html_url": "https://github.com/sjawhar/legion/issues/42#issuecomment-1",
+				"user":     map[string]any{"login": "commenter"},
+			},
+		},
+	}
+	env := GithubEnvelope(input)
+
+	// PayloadSummary should still be truncated to 500
+	summary := decodeSummary(t, env.PayloadSummary)
+	if runes := []rune(summary["body"]); len(runes) != 500 {
+		t.Fatalf("expected summary body truncated to 500 chars, got %d", len(runes))
+	}
+
+	// Payload should contain the full body (600 chars), not truncated
+	if env.Payload == "" {
+		t.Fatal("expected Payload to be populated")
+	}
+	payload := decodeSummary(t, env.Payload)
+	if runes := []rune(payload["body"]); len(runes) != 600 {
+		t.Fatalf("expected payload body to be full 600 chars, got %d", len(runes))
+	}
+	if payload["body"] != longBody {
+		t.Fatal("payload body does not match original")
+	}
+}
+
+func TestGithubPayloadAllEventTypes(t *testing.T) {
+	tests := []struct {
+		name      string
+		event     string
+		body      map[string]any
+		hasPayload bool
+	}{
+		{
+			name:  "issue_comment has payload",
+			event: "issue_comment",
+			body: map[string]any{
+				"action":     "created",
+				"repository": map[string]any{"full_name": "sjawhar/legion"},
+				"issue":      map[string]any{"number": 1, "title": "test"},
+				"comment":    map[string]any{"body": "hello", "user": map[string]any{"login": "u"}},
+			},
+			hasPayload: true,
+		},
+		{
+			name:  "pull_request has payload",
+			event: "pull_request",
+			body: map[string]any{
+				"action":       "opened",
+				"repository":   map[string]any{"full_name": "sjawhar/legion"},
+				"pull_request": map[string]any{"number": 1, "title": "test", "body": "pr body", "user": map[string]any{"login": "u"}},
+			},
+			hasPayload: true,
+		},
+		{
+			name:  "pull_request_review has payload",
+			event: "pull_request_review",
+			body: map[string]any{
+				"action":       "submitted",
+				"repository":   map[string]any{"full_name": "sjawhar/legion"},
+				"pull_request": map[string]any{"number": 1, "title": "test"},
+				"review":       map[string]any{"body": "review body", "state": "approved", "user": map[string]any{"login": "u"}},
+			},
+			hasPayload: true,
+		},
+		{
+			name:  "pull_request_review_comment has payload",
+			event: "pull_request_review_comment",
+			body: map[string]any{
+				"action":       "created",
+				"repository":   map[string]any{"full_name": "sjawhar/legion"},
+				"pull_request": map[string]any{"number": 1, "title": "test"},
+				"comment":      map[string]any{"body": "comment body", "user": map[string]any{"login": "u"}},
+			},
+			hasPayload: true,
+		},
+		{
+			name:  "issues has payload",
+			event: "issues",
+			body: map[string]any{
+				"action":     "opened",
+				"repository": map[string]any{"full_name": "sjawhar/legion"},
+				"issue":      map[string]any{"number": 1, "title": "test", "body": "issue body", "user": map[string]any{"login": "u"}},
+			},
+			hasPayload: true,
+		},
+		{
+			name:       "push has no payload",
+			event:      "push",
+			body:       map[string]any{"repository": map[string]any{"full_name": "sjawhar/legion"}, "ref": "refs/heads/main"},
+			hasPayload: false,
+		},
+		{
+			name:       "check_run has no payload",
+			event:      "check_run",
+			body:       map[string]any{"action": "completed", "repository": map[string]any{"full_name": "sjawhar/legion"}, "check_run": map[string]any{"name": "test", "status": "completed", "conclusion": "success", "pull_requests": []any{}}},
+			hasPayload: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := GithubEnvelope(GithubEnvelopeInput{
+				Event:    tt.event,
+				Delivery: "d1",
+				EventID:  "e1",
+				TraceID:  "t1",
+				Body:     tt.body,
+			})
+			if tt.hasPayload && env.Payload == "" {
+				t.Fatal("expected Payload to be populated")
+			}
+			if !tt.hasPayload && env.Payload != "" {
+				t.Fatalf("expected empty Payload for %s, got %s", tt.event, env.Payload)
+			}
+		})
+	}
+}

--- a/packages/envoy/internal/session/session.go
+++ b/packages/envoy/internal/session/session.go
@@ -85,7 +85,11 @@ func (d Deliverer) Text(item contracts.Envelope) string {
 	if item.SourceSession != "" {
 		header = fmt.Sprintf("[NOTIFICATION from %s (reply-to: %s)]", item.Source, item.SourceSession)
 	}
-	text := fmt.Sprintf("%s\n%s\n\nTopic: %s\nEvent ID: %s", header, item.PayloadSummary, item.Topic, item.EventID)
+	body := item.PayloadSummary
+	if item.Payload != "" {
+		body = item.Payload
+	}
+	text := fmt.Sprintf("%s\n%s\n\nTopic: %s\nEvent ID: %s", header, body, item.Topic, item.EventID)
 	if item.SourceSession != "" {
 		text += fmt.Sprintf("\nUse envoy_send(target_session=\"%s\", message=\"...\") to reply to this message.", item.SourceSession)
 	}

--- a/packages/envoy/internal/session/session_test.go
+++ b/packages/envoy/internal/session/session_test.go
@@ -190,6 +190,41 @@ func TestText_WithoutSourceSession(t *testing.T) {
 	}
 }
 
+func TestText_PrefersPayloadOverSummary(t *testing.T) {
+	deliverer := newDeliverer(t.TempDir())
+	item := contracts.Envelope{
+		EventID:        "evt-3",
+		Source:         "github",
+		SourceSession:  "",
+		Topic:          "notifications.github.sjawhar.legion.issue.42.comment",
+		PayloadSummary: "truncated summary",
+		Payload:        "full payload content that is much longer",
+	}
+	got := deliverer.Text(item)
+	if !strings.Contains(got, "full payload content that is much longer") {
+		t.Errorf("Text() should use Payload when set, got: %s", got)
+	}
+	if strings.Contains(got, "truncated summary") {
+		t.Errorf("Text() should NOT use PayloadSummary when Payload is set, got: %s", got)
+	}
+}
+
+func TestText_FallsBackToSummaryWhenPayloadEmpty(t *testing.T) {
+	deliverer := newDeliverer(t.TempDir())
+	item := contracts.Envelope{
+		EventID:        "evt-4",
+		Source:         "github",
+		SourceSession:  "",
+		Topic:          "notifications.github.sjawhar.legion.push",
+		PayloadSummary: "summary only",
+		Payload:        "",
+	}
+	got := deliverer.Text(item)
+	if !strings.Contains(got, "summary only") {
+		t.Errorf("Text() should fall back to PayloadSummary when Payload is empty, got: %s", got)
+	}
+}
+
 func TestDeliver_NoAgentField(t *testing.T) {
 	var receivedBody []byte
 


### PR DESCRIPTION
Closes #358

## Summary

Agents currently receive GitHub event bodies truncated to 500 chars because the delivery path (`session.go`) only includes `PayloadSummary`, which is intentionally truncated in `normalize.go` for dedupe purposes.

### Changes

- **Contract schema**: Added optional `payload` field to the Envelope struct (JSON Schema, Zod TS, generated Go)
- **normalize.go**: Added `githubPayload()` that builds the same JSON as `githubSummary()` but without truncation — populates `Payload` for comment, review, PR, and issue events
- **session.go**: `Text()` now uses `Payload` when available, falling back to `PayloadSummary` for backward compatibility (push, CI events, etc. that don't set Payload)
- **Tests**: Added `TestGithubPayloadNotTruncated` (600-char comment body delivered in full), `TestGithubPayloadAllEventTypes`, `TestText_PrefersPayloadOverSummary`, `TestText_FallsBackToSummaryWhenPayloadEmpty`

`PayloadSummary` is unchanged — it still serves its dedupe/matching purpose with 500-char truncation.