### PR TITLE
fix(envoy): correct GitHub topic formats in skill docs and plugin tool descriptions

### DIFF
--- a/.opencode/skills/envoy/SKILL.md
+++ b/.opencode/skills/envoy/SKILL.md
@@ -27,33 +27,44 @@ Example:
 
 ### GitHub
 
-- PR events (all PRs):
-  - `notifications.github.<owner>.<repo>.pr`
-- PR events (specific PR):
+GitHub topics are **resource-scoped** — every event includes the resource type and number. There are no repo-wide event-type topics (except mentions and push).
+
+**Topic structure:** `notifications.github.<owner>.<repo>.<resource_type>.<number>.<event_kind>`
+
+- PR opened/closed/merged/ready:
   - `notifications.github.<owner>.<repo>.pr.<number>`
-- Issue events (all issues):
-  - `notifications.github.<owner>.<repo>.issue`
-- Issue events (specific issue):
+- Issue opened/closed/labeled:
   - `notifications.github.<owner>.<repo>.issue.<number>`
-- Comment events (all):
-  - `notifications.github.<owner>.<repo>.comment`
-- Comment events (specific PR/issue):
-  - `notifications.github.<owner>.<repo>.comment.<number>`
-- Mention events (all):
+- Comment on a PR:
+  - `notifications.github.<owner>.<repo>.pr.<number>.comment`
+- Comment on an issue:
+  - `notifications.github.<owner>.<repo>.issue.<number>.comment`
+- PR review submitted:
+  - `notifications.github.<owner>.<repo>.pr.<number>.review`
+- CI/check events (per-PR):
+  - `notifications.github.<owner>.<repo>.pr.<number>.ci`
+- Mention events (per-resource):
+  - `notifications.github.<owner>.<repo>.pr.<number>.mention`
+  - `notifications.github.<owner>.<repo>.issue.<number>.mention`
+- Mention events (repo-wide — catches all mentions):
   - `notifications.github.<owner>.<repo>.mention`
-- Mention events (specific PR/issue):
-  - `notifications.github.<owner>.<repo>.mention.<number>`
-- CI/check events:
-  - `notifications.github.<owner>.<repo>.ci`
 - Push events:
   - `notifications.github.<owner>.<repo>.push`
 
+**Using wildcards to subscribe broadly:**
+- All events in a repo: `notifications.github.<owner>.<repo>.>`
+- All PR events in a repo: `notifications.github.<owner>.<repo>.pr.>`
+- All events for a specific PR: `notifications.github.<owner>.<repo>.pr.<number>.>`
+- All issue events in a repo: `notifications.github.<owner>.<repo>.issue.>`
+- All events for a specific issue: `notifications.github.<owner>.<repo>.issue.<number>.>`
+
 Examples:
 
-- `notifications.github.trajectory-labs-pbc.agent-c.pr` (all PRs)
-- `notifications.github.trajectory-labs-pbc.agent-c.pr.7706` (PR #7706 only)
-- `notifications.github.sjawhar.legion.mention` (all mentions)
-- `notifications.github.sjawhar.legion.mention.171` (mentions on PR #171 only)
+- `notifications.github.trajectory-labs-pbc.agent-c.pr.9880` (PR #9880 state changes)
+- `notifications.github.trajectory-labs-pbc.agent-c.pr.9880.comment` (comments on PR #9880)
+- `notifications.github.trajectory-labs-pbc.agent-c.issue.9909.>` (all events on issue #9909)
+- `notifications.github.sjawhar.legion.pr.>` (all PR events across all PRs)
+- `notifications.github.sjawhar.legion.mention` (all @mentions repo-wide)
 
 ### Slack
 
@@ -170,11 +181,11 @@ envoy_subscribe([
 ])
 ```
 
-### Subscribe controller to all PR events for agent-c
+### Subscribe to all PR events for agent-c
 
 ```text
 envoy_subscribe([
-  "notifications.github.trajectory-labs-pbc.agent-c.pr"
+  "notifications.github.trajectory-labs-pbc.agent-c.pr.>"
 ])
 ```
 

--- a/packages/envoy-plugin/src/index.ts
+++ b/packages/envoy-plugin/src/index.ts
@@ -178,12 +178,12 @@ export default async (input: { serverUrl: URL }) => {
     tool: {
       envoy_subscribe: tool({
         description:
-          "Subscribe this session to Envoy notification topics. Use exact NATS-style topic strings such as notifications.agent.<session_id>, notifications.github.<owner>.<repo>.pr, notifications.github.<owner>.<repo>.issue, notifications.github.<owner>.<repo>.comment, notifications.github.<owner>.<repo>.ci, notifications.slack.<team_id>.<channel_id>.message, or notifications.slack.<team_id>.<channel_id>.mention. Use this when a session should RECEIVE future events.",
+          "Subscribe this session to Envoy notification topics. GitHub topics are resource-scoped: notifications.github.<owner>.<repo>.pr.<number>, notifications.github.<owner>.<repo>.issue.<number>.comment, etc. Use NATS wildcards for broad subscriptions: notifications.github.<owner>.<repo>.pr.> (all PR events). Other topics: notifications.agent.<session_id>, notifications.slack.<team_id>.<channel_id>.message, notifications.slack.<team_id>.<channel_id>.mention. Use this when a session should RECEIVE future events.",
         args: {
           topics: tool.schema
             .array(tool.schema.string())
             .describe(
-              "NATS-style topic patterns to subscribe to. Examples: notifications.agent.ses_123, notifications.github.trajectory-labs-pbc.agent-c.pr, notifications.slack.T09FRELLTS8.C0A0DHVU8HE.mention"
+              "NATS-style topic patterns to subscribe to. GitHub topics include resource number: notifications.github.owner.repo.pr.123 (PR state), notifications.github.owner.repo.pr.123.comment (PR comments), notifications.github.owner.repo.issue.456.> (all events on issue). Use > wildcard for broad matching. Other examples: notifications.agent.ses_123, notifications.slack.T09FRELLTS8.C0A0DHVU8HE.mention"
             ),
         },
         async execute(args, ctx) {


### PR DESCRIPTION
## Summary

Audit of the Envoy skill found **6 incorrect GitHub topic formats** that caused agents to subscribe to topics that don't exist:

| Old (wrong) | Correct |
|---|---|
| `...repo.pr` | `...repo.pr.<number>` |
| `...repo.issue` | `...repo.issue.<number>` |
| `...repo.comment` | `...repo.pr.<number>.comment` or `...repo.issue.<number>.comment` |
| `...repo.comment.<number>` | `...repo.<parent>.<number>.comment` |
| `...repo.ci` | `...repo.pr.<number>.ci` |
| `...repo.mention.<number>` | `...repo.<parent>.<number>.mention` |

GitHub topics are resource-scoped — every event includes the resource type and number. There are no repo-wide event-type topics (except mentions and push).

Added wildcard subscription guidance so agents can subscribe broadly when needed (`notifications.github.owner.repo.pr.>` for all PR events).

Updated both the skill SKILL.md and the envoy_subscribe tool description in the plugin source.