### PR TITLE
feat: wire sentry label routing into worker workflows

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,3 +1,7 @@
 {
-  "mcpServers": {}
+  "mcpServers": {
+    "sentry": {
+      "url": "https://mcp.sentry.dev/mcp"
+    }
+  }
 }

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,21 +5,21 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "latest"
+        "@opencode-ai/plugin": "1.4.0"
       }
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.3.13.tgz",
-      "integrity": "sha512-zHgtWfdDz8Wu8srE8f8HUtPT9i6c3jTmgQKoFZUZ+RR5CMQF1kAlb1cxeEe9Xm2DRNFVJog9Cv/G1iUHYgXSUQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.0.tgz",
+      "integrity": "sha512-VFIff6LHp/RVaJdrK3EQ1ijx0K1tV5i1DY5YJ+pRqwC6trunPHbvqSN0GHSTZX39RdnSc+XuzCTZQCy1W2qNOg==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.3.13",
+        "@opencode-ai/sdk": "1.4.0",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.1.95",
-        "@opentui/solid": ">=0.1.95"
+        "@opentui/core": ">=0.1.97",
+        "@opentui/solid": ">=0.1.97"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
@@ -31,8 +31,78 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.3.13",
-      "license": "MIT"
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.0.tgz",
+      "integrity": "sha512-mfa3MzhqNM+Az4bgPDDXL3NdG+aYOHClXmT6/4qLxf2ulyfPpMNHqb9Dfmo4D8UfmrDsPuJHmbune73/nUQnuw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/zod": {
       "version": "4.1.8",

--- a/.opencode/skills/legion-controller/SKILL.md
+++ b/.opencode/skills/legion-controller/SKILL.md
@@ -523,6 +523,7 @@ Controller routes Triage issues directly (no worker needed):
 
 | Assessment | Route To |
 |------------|----------|
+| `sentry` label present | Todo (Sentry integration creates these directly in Todo — see below) |
 | Urgent AND clear requirements | Todo (dispatch planner) |
 | Bug label + clear reproduction steps + no architectural uncertainty | Todo (skip architect — dispatch planner directly) |
 | Clear requirements, any size | Backlog (architect breaks down if large) |
@@ -531,6 +532,32 @@ Controller routes Triage issues directly (no worker needed):
 The skip-architect rule only applies when ALL conditions are met: `bug` label present,
 description contains clear reproduction steps, and the change is scoped to a single
 component. When in doubt, route to Backlog.
+
+#### Sentry Issues
+
+Issues with the `sentry` label come from Sentry error tracking. The Sentry-Linear integration
+creates these directly in Todo, so they skip architect and triage automatically.
+
+**Dispatch:** When dispatching any worker for an issue with the `sentry` label, include
+`This issue has the sentry label.` in the dispatch prompt. The worker workflows have
+sentry-specific conditional sections that activate when they see this label on the issue.
+
+**Post-merge cleanup:** After a sentry issue reaches Done, resolve the Sentry issue via API:
+
+```bash
+# Extract Sentry issue URL from issue body
+SENTRY_URL=$(linear_linear(action="get", id=$LEGION_ISSUE_ID) | grep -oE 'https://[^/]+\.sentry\.io/issues/[0-9]+')
+SENTRY_ID=$(echo "$SENTRY_URL" | grep -oE '[0-9]+$')
+
+if [ -n "$SENTRY_ID" ]; then
+  curl -s -X PUT "https://us.sentry.io/api/0/organizations/metr-sh/issues/$SENTRY_ID/" \
+    -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"status": "resolved"}'
+fi
+```
+
+Add this to the Cleanup Done step (step 6) for issues with the `sentry` label.
 
 ### 5. Pull from Icebox
 

--- a/.opencode/skills/legion-worker/references/github-labels.md
+++ b/.opencode/skills/legion-worker/references/github-labels.md
@@ -14,6 +14,10 @@ gh issue edit $ISSUE_NUMBER --remove-label "worker-active" -R $OWNER/$REPO
 - `needs-approval` — Plan/architecture needs human approval
 - `human-approved` — Human approved the plan
 
+## Routing Labels
+- `sentry` — Issue originated from Sentry error tracking. Triggers sentry-specific fix workflow: skip architect, use targeted fix prompt with stack trace focus, production-only scope.
+- `bug` — General bug report. May skip architect if reproduction steps are clear.
+
 ## Architect-Review Labels (Opt-In)
 - `architect-continuity` — Opt-in: architect reviews plan before implementation (persistent, stays for issue lifetime)
 - `arch-review-approved` — Architect approved the plan (transient, cleaned up by controller after acting)

--- a/.opencode/skills/legion-worker/references/linear-labels.md
+++ b/.opencode/skills/legion-worker/references/linear-labels.md
@@ -22,6 +22,13 @@ linear_linear(action="update",
 )
 ```
 
+## Routing Labels
+
+| Label | Meaning | Added by | Removed by |
+|-------|---------|----------|------------|
+| `sentry` | Issue from Sentry error tracking, triggers sentry-specific fix workflow | Sentry integration / Human | N/A (persistent) |
+| `bug` | General bug report | Human | N/A (persistent) |
+
 ## GitHub PR Draft Status (Not Linear)
 
 Review outcomes signaled via **PR draft status**, not labels:

--- a/.opencode/skills/legion-worker/workflows/implement.md
+++ b/.opencode/skills/legion-worker/workflows/implement.md
@@ -67,6 +67,27 @@ Fetch issue and comments. The plan is in comments:
 - **GitHub:** `gh issue view $ISSUE_NUMBER --json title,body,labels,comments,state -R $OWNER/$REPO`
 - **Linear:** `linear_linear(action="get", id=$LEGION_ISSUE_ID)`
 
+#### If this issue has the `sentry` label
+
+This is a production error fix. Adjust your approach:
+
+1. **Write a failing test FIRST** that reproduces the error from the stack trace before implementing any fix
+2. **Keep the diff minimal** — fix the bug, nothing else. No refactoring, no cleanup, no unrelated improvements.
+3. **Run the full test suite** for the affected module after the fix — no regressions allowed
+
+After creating the PR (step 6), comment the PR URL on the Sentry issue:
+
+```bash
+SENTRY_ID=<numeric ID from Sentry URL in issue body>
+PR_URL=$(gh pr view "$LEGION_ISSUE_ID" --json url --jq '.url' -R $OWNER/$REPO 2>/dev/null)
+if [ -n "$SENTRY_ID" ] && [ -n "$PR_URL" ]; then
+  curl -s -X POST "https://us.sentry.io/api/0/organizations/metr-sh/issues/$SENTRY_ID/comments/" \
+    -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{\"text\": \"Fix PR: $PR_URL\"}"
+fi
+```
+
 ### 1.5. Check for Project-Specific Skills
 
 Before implementing, check if the repo has skills relevant to this work:

--- a/.opencode/skills/legion-worker/workflows/plan.md
+++ b/.opencode/skills/legion-worker/workflows/plan.md
@@ -59,6 +59,39 @@ Extract:
 - Comments with additional context
 - Acceptance criteria if present
 
+#### If this issue has the `sentry` label
+
+This is a production error from Sentry. Before standard planning, gather Sentry-specific context:
+
+1. **Fetch Sentry details** using the Sentry MCP tools:
+   - `get_sentry_resource(url=<sentry_issue_url>)` — full issue details, stack trace, tags
+   - `search_issue_events(issueUrl=..., naturalLanguageQuery=...)` — filter events by env/release/user
+   - `get_issue_tag_values(issueUrl=..., tagKey='url'|'environment'|'release'|...)` — distribution data
+   - `analyze_issue_with_seer(issueUrl=...)` — AI root cause analysis
+
+   The Sentry issue URL should be in the issue body. The org is `metr-sh`, region URL is `https://us.sentry.io`.
+
+2. **Assign the Sentry issue** to signal work has started:
+   ```bash
+   SENTRY_ID=<numeric ID from Sentry URL>
+   curl -s -X PUT "https://us.sentry.io/api/0/organizations/metr-sh/issues/$SENTRY_ID/" \
+     -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"assignedTo":"me"}'
+   curl -s -X POST "https://us.sentry.io/api/0/organizations/metr-sh/issues/$SENTRY_ID/comments/" \
+     -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"text": "Investigating — Legion worker assigned."}'
+   ```
+
+3. **Scope the plan tightly.** This is a targeted bug fix, not a feature:
+   - Identify root cause from the stack trace
+   - Keep changes minimal — fix the bug, nothing else
+   - Plan a regression test that reproduces the error condition
+   - Skip architectural analysis
+
+Include the Sentry MCP findings in the `/ce:plan` context (step 2) alongside Metis analysis.
+
 ### 1.3. Load Repo Config
 
 Read repo config from workspace root:

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -298,7 +298,11 @@ export async function startDaemon(
     daemon_rss_restarts: rssRestarts,
     daemon_role_serves: roleServeManager?.getEntries().length ?? 0,
   }));
-  const controllerWorkspace = config.paths.forLegion(legionId).legionStateDir;
+  // Both runtimes need the project directory:
+  // - claude-code: skills are discovered from the project root
+  // - opencode: MCP servers configured in opencode.json at the project root
+  const controllerWorkspace =
+    config.legionDir ?? config.paths.forLegion(legionId).legionStateDir;
   const hasIndexRoot = !!config.legionDir && existsSync(config.legionDir);
   if (config.legionDir && !hasIndexRoot) {
     console.warn(`Codebase index skipped: LEGION_DIR does not exist (${config.legionDir})`);

--- a/packages/daemon/src/daemon/runtime/claude-code.ts
+++ b/packages/daemon/src/daemon/runtime/claude-code.ts
@@ -1,3 +1,4 @@
+import { v5 as uuidv5 } from "uuid";
 import type { RuntimeAdapter, RuntimeStartOptions } from "./types";
 
 type SpawnResult = {
@@ -9,6 +10,21 @@ export type SpawnFn = (cmd: string[]) => SpawnResult;
 
 function shellEscape(s: string): string {
   return s.replace(/'/g, "'\\''");
+}
+
+/**
+ * Convert any session ID to a UUID suitable for `claude --session-id`.
+ * If it's already a UUID, return as-is. Otherwise, generate a deterministic
+ * UUID from the string (handles OpenCode's `ses_` format).
+ */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const CLAUDE_SESSION_NS = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+
+function toClaudeSessionId(sessionId: string): string {
+  if (UUID_RE.test(sessionId)) {
+    return sessionId;
+  }
+  return uuidv5(sessionId, CLAUDE_SESSION_NS);
 }
 
 // TECH DEBT: Using spawnSync blocks the event loop (~2ms per call).
@@ -103,16 +119,17 @@ export class ClaudeCodeAdapter implements RuntimeAdapter {
 
   async sendPrompt(sessionId: string, text: string): Promise<void> {
     const windowTarget = `${this.sessionName}:${sessionId}`;
+    const claudeId = toClaudeSessionId(sessionId);
     const alive = this.isProcessAlive(sessionId);
 
     let result: SpawnResult;
     if (alive === "running") {
       result = this.spawn(["tmux", "send-keys", "-t", windowTarget, text, "Enter"]);
     } else if (alive === "exited") {
-      const cmd = `claude --resume '${shellEscape(sessionId)}' -p '${shellEscape(text)}' --dangerously-skip-permissions`;
+      const cmd = `claude --resume '${shellEscape(claudeId)}' -p '${shellEscape(text)}' --dangerously-skip-permissions`;
       result = this.spawn(["tmux", "send-keys", "-t", windowTarget, cmd, "Enter"]);
     } else {
-      const cmd = `claude -p '${shellEscape(text)}' --session-id '${shellEscape(sessionId)}' --dangerously-skip-permissions`;
+      const cmd = `claude -p '${shellEscape(text)}' --session-id '${shellEscape(claudeId)}' --dangerously-skip-permissions`;
       result = this.spawn(["tmux", "send-keys", "-t", windowTarget, cmd, "Enter"]);
     }
     if (result.exitCode !== 0) {

--- a/packages/daemon/src/state/types.ts
+++ b/packages/daemon/src/state/types.ts
@@ -305,6 +305,7 @@ export interface ParsedIssue {
   readonly hasHumanApproved: boolean;
   readonly hasTestPassed: boolean;
   readonly hasTestFailed: boolean;
+  readonly hasSentry: boolean;
   readonly hasPr: boolean;
   readonly needsPrStatus: boolean;
   readonly needsCiStatus: boolean;
@@ -359,6 +360,10 @@ export function createParsedIssue(
 
     get hasTestFailed() {
       return this.labels.includes("test-failed");
+    },
+
+    get hasSentry() {
+      return this.labels.includes("sentry");
     },
 
     get hasPr() {


### PR DESCRIPTION
## Summary
- Add `hasSentry` flag to `ParsedIssue` and Sentry MCP server config
- Add sentry conditional sections to `plan.md` (Sentry MCP research, assign issue, scope guidance) and `implement.md` (failing test first, comment PR URL on Sentry issue)
- Trim controller SKILL.md: Sentry-Linear integration creates issues in Todo directly, workers self-detect the label via workflow conditionals, controller resolves Sentry issue post-merge
- Document `sentry`/`bug` as routing labels in label reference files
- Delete standalone `sentry-fix.md` — content distributed to existing workflows
- Fix controller workspace to use `LEGION_DIR` for skill/MCP discovery
- Add OpenCode `ses_` → UUID session ID conversion for claude-code runtime
- Bump `@opencode-ai/plugin` to 1.4.0

## Test plan
- [ ] Verify controller detects `sentry` label on Todo issues and includes label mention in dispatch prompt
- [ ] Verify planner workflow hits Sentry MCP conditional section when issue has `sentry` label
- [ ] Verify implementer posts PR URL to Sentry issue after PR creation
- [ ] Verify controller resolves Sentry issue in Cleanup Done step post-merge
- [ ] Verify non-sentry issues are unaffected (no conditional sections activate)