### PR TITLE
sjawhar-legion-380: switch worker completion notifications from envoy_send to envoy_publish

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,17 +1,20 @@
 {
   "filesChanged": [
-    "packages/daemon/src/daemon/server.ts",
-    "packages/daemon/src/daemon/index.ts",
-    "packages/daemon/src/daemon/__tests__/server.test.ts",
-    "docs/solutions/daemon/envoy-auto-subscription-patterns.md"
+    ".opencode/skills/legion-worker/SKILL.md",
+    ".opencode/skills/legion-worker/workflows/architect.md",
+    ".opencode/skills/legion-worker/workflows/plan.md",
+    ".opencode/skills/legion-worker/workflows/implement.md",
+    ".opencode/skills/legion-worker/workflows/test.md",
+    ".opencode/skills/legion-worker/workflows/review.md",
+    ".opencode/skills/legion-worker/workflows/merge.md"
   ],
   "trickyParts": [
-    "index.ts had its own local subscribeControllerToCiEnvoy function (not imported from server.ts), so both files needed independent removal"
+    "merge.md had no notification at all — added new block after step 7's worker-active removal, before the Note"
   ],
   "deviations": [],
   "openQuestions": [],
   "subPlanningNeeded": false,
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-09T21:58:30.760Z"
+  "completed": "2026-04-09T22:42:47.106Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,20 +1,16 @@
 {
-  "passed": 2,
+  "passed": 4,
   "failed": 0,
   "failures": [],
-  "documentationFeedback": "PR body is clear and accurate. README doesn't list envoy_publish tool (pre-existing gap). No docs updated about non-blocking behavior (reasonable — internal change).",
+  "documentationFeedback": "PR description and issue body clearly explain the problem and solution. All 7 changed files listed accurately.",
   "observations": [
-    "P2: index.test.ts init test sets OC_REGISTRY=undefined, skipping the registryDir code path where all non-blocking changes live. Test proves init is fast when feature path is disabled.",
-    "P2: index.test.ts timeout test targets ECONNREFUSED (fast error), not an actual timeout. Doesn't prove AbortSignal.timeout works.",
-    "_activeFile variable is declared but never read — pre-existing dead code.",
-    "currentPort() returns null before async resolution — tools send port:0 during startup window. Pre-existing behavior, heartbeat re-subscribes with correct port."
+    "implement.md correctly has two notification points (fresh + address-comments)",
+    "test.md correctly has two notification points (pass + fail)",
+    "All notifications include fallback note about envoy_publish failures"
   ],
-  "learningsInjected": [
-    "docs/solutions/envoy/async-health-startup-pattern.md",
-    "docs/solutions/daemon/opencode-serve-lifecycle.md"
-  ],
+  "learningsInjected": [],
   "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-08T13:10:32.786Z"
+  "completed": "2026-04-09T22:45:40.257Z"
 }

--- a/.opencode/skills/legion-worker/SKILL.md
+++ b/.opencode/skills/legion-worker/SKILL.md
@@ -35,7 +35,7 @@ Use the **backend** from your prompt to choose GitHub CLI or Linear MCP commands
 4. **Signal completion (MOST IMPORTANT)** — before you stop for ANY reason, you MUST: push your work, unsubscribe from explicit Envoy topics (see Exiting), add `worker-done` label, remove `worker-active` label. If you skip this, the issue silently stalls. Create a todo for this at session start (see Required Startup Todos below).
 4.5. **Write handoff data before signaling.** Each workflow has a handoff write step — you MUST attempt it before adding `worker-done`. The CLI will fail loudly if the write encounters an error. If the write fails, diagnose the issue and note it in your exit comment.
 5. **Clean up on exit** - remove `worker-active` label when exiting (done or blocked)
-6. **Notify the controller via Envoy** — after adding `worker-done`, send exactly one completion notification so the controller doesn't have to wait for its next polling cycle. Use `envoy_send(target_session="$CONTROLLER_SESSION_ID", message="Worker done: <issue> <mode> <outcome>")`. The controller session ID (`$CONTROLLER_SESSION_ID`) is provided in your dispatch prompt's ENVOY section. If `envoy_send` fails, that's fine — the label is the source of truth. **Do not also call `envoy_publish` — one notification only.**
+6. **Notify the controller via Envoy** — after adding `worker-done`, send exactly one completion notification so the controller doesn't have to wait for its next polling cycle. Use `envoy_publish(topic="notifications.legion.controller", message="Worker done: <issue> <mode> <outcome>")`. If `envoy_publish` fails, that's fine — the label is the source of truth.
 
 ## Skill Discipline
 
@@ -197,9 +197,9 @@ Then update labels:
 
 Then notify the controller via Envoy (best-effort, non-blocking):
 ```
-envoy_send(target_session="$CONTROLLER_SESSION_ID", message="Worker done: <issue-id> <mode> completed")
+envoy_publish(topic="notifications.legion.controller", message="Worker done: <issue-id> <mode> completed")
 ```
-If `envoy_send` fails, continue — the label is the source of truth.
+If `envoy_publish` fails, continue — the label is the source of truth.
 
 ## Mode Routing
 

--- a/.opencode/skills/legion-worker/workflows/architect.md
+++ b/.opencode/skills/legion-worker/workflows/architect.md
@@ -273,9 +273,9 @@ linear_linear(action="update",
 
 Then notify the controller via Envoy (best-effort, exactly one notification):
 ```
-envoy_send(target_session="$CONTROLLER_SESSION_ID", message="Worker done: $ISSUE_NUMBER architect completed. Sub-issues ready for planning.")
+envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER architect completed. Sub-issues ready for planning.")
 ```
-If `envoy_send` fails, continue — the label is the source of truth.
+If `envoy_publish` fails, continue — the label is the source of truth.
 
 ## Common Mistakes
 

--- a/.opencode/skills/legion-worker/workflows/implement.md
+++ b/.opencode/skills/legion-worker/workflows/implement.md
@@ -440,9 +440,9 @@ linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "
 
 Then notify the controller via Envoy (best-effort, exactly one notification):
 ```
-envoy_send(target_session="$CONTROLLER_SESSION_ID", message="Worker done: $ISSUE_NUMBER implement completed. PR ready for testing.")
+envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER implement completed. PR ready for testing.")
 ```
-If `envoy_send` fails, continue — the label is the source of truth.
+If `envoy_publish` fails, continue — the label is the source of truth.
 
 ---
 
@@ -614,6 +614,6 @@ linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "
 
 Then notify the controller via Envoy (best-effort, exactly one notification):
 ```
-envoy_send(target_session="$CONTROLLER_SESSION_ID", message="Worker done: $ISSUE_NUMBER implement completed after changes. PR ready for re-testing.")
+envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER implement completed after changes. PR ready for re-testing.")
 ```
-If `envoy_send` fails, continue — the label is the source of truth.
+If `envoy_publish` fails, continue — the label is the source of truth.

--- a/.opencode/skills/legion-worker/workflows/merge.md
+++ b/.opencode/skills/legion-worker/workflows/merge.md
@@ -96,4 +96,10 @@ Then remove `worker-active` if present:
 - **GitHub:** `gh issue edit $ISSUE_NUMBER --remove-label "worker-active" -R $OWNER/$REPO`
 - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current labels without "worker-active"])`
 
+Then notify the controller via Envoy (best-effort, exactly one notification):
+```
+envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER merge completed. Issue closed.")
+```
+If `envoy_publish` fails, continue — the label is the source of truth.
+
 > **Note:** GitHub auto-close may also fire when the PR merges, which is fine — closing an already-closed issue is a no-op. This explicit close is a safety net for cases where auto-close doesn't trigger (e.g., issue not linked to PR, Linear backend).

--- a/.opencode/skills/legion-worker/workflows/plan.md
+++ b/.opencode/skills/legion-worker/workflows/plan.md
@@ -420,9 +420,9 @@ Then remove `worker-active`:
 
 Then notify the controller via Envoy (best-effort, exactly one notification):
 ```
-envoy_send(target_session="$CONTROLLER_SESSION_ID", message="Worker done: $ISSUE_NUMBER plan completed. Ready for implementation.")
+envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER plan completed. Ready for implementation.")
 ```
-If `envoy_send` fails, continue — the label is the source of truth.
+If `envoy_publish` fails, continue — the label is the source of truth.
 
 **CRITICAL:** Only add `worker-done` after successfully posting the plan. Never add this label if:
 - Requirements were unclear and could not be resolved (use `user-input-needed` instead)

--- a/.opencode/skills/legion-worker/workflows/review.md
+++ b/.opencode/skills/legion-worker/workflows/review.md
@@ -299,9 +299,9 @@ linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "
 
 Then notify the controller via Envoy (best-effort, exactly one notification):
 ```
-envoy_send(target_session="$CONTROLLER_SESSION_ID", message="Worker done: $ISSUE_NUMBER review completed. See PR for review outcome.")
+envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER review completed. See PR for review outcome.")
 ```
-If `envoy_send` fails, continue — the label is the source of truth.
+If `envoy_publish` fails, continue — the label is the source of truth.
 
 ## Common Mistakes
 

--- a/.opencode/skills/legion-worker/workflows/test.md
+++ b/.opencode/skills/legion-worker/workflows/test.md
@@ -384,7 +384,7 @@ linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "
 
 Then notify the controller via Envoy (best-effort, exactly one notification):
 ```
-envoy_send(target_session="$CONTROLLER_SESSION_ID", message="Worker done: $ISSUE_NUMBER test passed.")
+envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER test passed.")
 ```
 
 **If any criterion fails:**
@@ -408,10 +408,10 @@ linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current_labels, "
 
 Then notify the controller via Envoy (best-effort, exactly one notification):
 ```
-envoy_send(target_session="$CONTROLLER_SESSION_ID", message="Worker done: $ISSUE_NUMBER test failed. See PR comments for details.")
+envoy_publish(topic="notifications.legion.controller", message="Worker done: $ISSUE_NUMBER test failed. See PR comments for details.")
 ```
 
-If `envoy_send` fails, continue — the label is the source of truth.
+If `envoy_publish` fails, continue — the label is the source of truth.
 
 ## Blocking on User Input
 


### PR DESCRIPTION
Closes #380

## Summary

Switch all worker completion notifications from `envoy_send(target_session=...)` to `envoy_publish(topic="notifications.legion.controller", message=...)`.

**Why:** `envoy_send` requires the controller's session ID, which silently fails if the session ID is unavailable or has changed (e.g., after daemon restart). `envoy_publish` broadcasts to the `notifications.legion.controller` topic, which the controller already subscribes to — always works regardless of session lifecycle.

**Changes (7 files):**
- `SKILL.md` — Rule 6 and Exiting section updated
- `workflows/architect.md` — completion notification
- `workflows/plan.md` — completion notification
- `workflows/implement.md` — both fresh and address-comments exit paths
- `workflows/test.md` — both pass and fail paths
- `workflows/review.md` — completion notification
- `workflows/merge.md` — **added** completion notification (was missing entirely)

Message content preserved. Only delivery mechanism changed.