### PR TITLE
sjawhar-legion-382: fix plan worker envoy subscriptions missing after dispatch

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,20 +1,15 @@
 {
   "filesChanged": [
-    ".opencode/skills/legion-worker/SKILL.md",
-    ".opencode/skills/legion-worker/workflows/architect.md",
-    ".opencode/skills/legion-worker/workflows/plan.md",
-    ".opencode/skills/legion-worker/workflows/implement.md",
-    ".opencode/skills/legion-worker/workflows/test.md",
-    ".opencode/skills/legion-worker/workflows/review.md",
-    ".opencode/skills/legion-worker/workflows/merge.md"
+    "packages/daemon/src/daemon/server.ts",
+    "packages/daemon/src/daemon/__tests__/server.test.ts"
   ],
   "trickyParts": [
-    "merge.md had no notification at all — added new block after step 7's worker-active removal, before the Note"
+    "The issueNumber was never sent by the controller — the CLI flag exists but the controller skill never uses it. The fix auto-extracts from the issueId+repoRef prefix match instead of requiring it in the payload."
   ],
   "deviations": [],
   "openQuestions": [],
   "subPlanningNeeded": false,
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-09T22:42:47.106Z"
+  "completed": "2026-04-09T23:11:38.365Z"
 }

--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -1471,6 +1471,46 @@ describe("daemon server", () => {
       ]);
     });
 
+    it("auto-extracts issueNumber from issueId and subscribes plan worker to Envoy", async () => {
+      const envoySubscribeCalls: EnvoySubscribeCall[] = [];
+      mockFetchForEnvoy(envoySubscribeCalls);
+
+      await startTestServer({ paths: repoPaths, repoManagerDeps });
+
+      // Dispatch plan worker WITHOUT explicit issueNumber — matches real controller behavior
+      const response = await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({
+          issueId: "acme-widgets-44",
+          mode: "plan",
+          repo: "acme/widgets",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { sessionId: string };
+
+      await Bun.sleep(50);
+
+      // Should still subscribe — issueNumber auto-extracted from issueId
+      expect(envoySubscribeCalls).toHaveLength(1);
+      expect(envoySubscribeCalls[0].body.session_id).toBe(body.sessionId);
+      expect(envoySubscribeCalls[0].body.topics).toEqual([
+        "notifications.github.acme.widgets.issue.44.>",
+      ]);
+
+      // Verify envoyTopics stored on worker entry
+      const workerRes = await requestJson("/workers");
+      const workers = (await workerRes.json()) as Array<{
+        id: string;
+        envoyTopics?: string[];
+        issueNumber?: number;
+      }>;
+      const planWorker = workers.find((w) => w.id === "acme-widgets-44-plan");
+      expect(planWorker?.envoyTopics).toEqual(["notifications.github.acme.widgets.issue.44.>"]);
+      expect(planWorker?.issueNumber).toBe(44);
+    });
+
     it("skips Envoy subscribe when issueNumber is absent", async () => {
       const envoySubscribeCalls: EnvoySubscribeCall[] = [];
       mockFetchForEnvoy(envoySubscribeCalls);

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -523,7 +523,7 @@ export function startServer(opts: ServerOptions): {
             const workspace = payload.workspace;
             const version = typeof payload.version === "number" ? payload.version : 0;
             const envPayload = payload.env;
-            const issueNumber =
+            let issueNumber =
               typeof payload.issueNumber === "number" ? payload.issueNumber : undefined;
 
             const prompt = payload.prompt;
@@ -577,6 +577,18 @@ export function startServer(opts: ServerOptions): {
 
             let resolvedWorkspace: string | null = null;
             const repoRef = typeof repo === "string" ? parseIssueRepo(repo) : null;
+            // Auto-extract issueNumber from issueId when not explicitly provided.
+            // GitHub issue IDs follow the format {owner}-{repo}-{number}.
+            if (issueNumber === undefined && repoRef) {
+              const prefix = `${repoRef.owner}-${repoRef.repo}-`.toLowerCase();
+              if (normalizedIssueId.startsWith(prefix)) {
+                const numStr = normalizedIssueId.slice(prefix.length);
+                const parsed = Number(numStr);
+                if (Number.isInteger(parsed) && parsed > 0) {
+                  issueNumber = parsed;
+                }
+              }
+            }
             if (typeof repo === "string") {
               if (!opts.paths) {
                 return badRequest("repo_resolution_unavailable");


### PR DESCRIPTION
Closes #382

## Summary

Plan workers dispatched by the controller had no `envoyTopics` because `issueNumber` was never included in the `POST /workers` payload. The `--issue-number` CLI flag existed but the controller skill never passed it.

## Root Cause

The envoy subscription at dispatch time was gated on `issueNumber !== undefined` (server.ts:740), but the controller's `legion dispatch` command doesn't pass `--issue-number`. So the condition always failed silently for controller-dispatched plan workers.

## Fix

Auto-extract `issueNumber` from the `issueId` + `repoRef` when not explicitly provided in the payload. GitHub issue IDs follow the format `{owner}-{repo}-{number}`, so given `repoRef` (parsed from the `repo` field), we strip the `{owner}-{repo}-` prefix to get the number.

This makes the `issueNumber` payload field truly optional — it's auto-derived when a `repo` is provided, which covers all GitHub-backend dispatches.

## Test

Added test verifying plan worker dispatch WITHOUT `issueNumber` in payload still gets envoy subscriptions and stores `issueNumber` on the worker entry.