### PR TITLE
sjawhar-legion-385: auto-cleanup workspaces on issue close to prevent disk exhaustion

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,15 +1,20 @@
 {
   "filesChanged": [
     "packages/daemon/src/daemon/server.ts",
-    "packages/daemon/src/daemon/__tests__/server.test.ts"
+    "packages/daemon/src/daemon/__tests__/server.test.ts",
+    ".opencode/skills/legion-worker/workflows/merge.md",
+    ".opencode/skills/legion-controller/SKILL.md"
   ],
   "trickyParts": [
-    "The issueNumber was never sent by the controller — the CLI flag exists but the controller skill never uses it. The fix auto-extracts from the issueId+repoRef prefix match instead of requiring it in the payload."
+    "Workspace cleanup failure must preserve worker state for retry — two-pass approach in cleanupDoneIssueWorkers separates workspace cleanup from state removal",
+    "Fire-and-forget cleanup runs after response is built but before return — idempotent by design since workers.delete() is synchronous"
   ],
   "deviations": [],
   "openQuestions": [],
   "subPlanningNeeded": false,
+  "learningsInjected": [],
+  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-09T23:11:38.365Z"
+  "completed": "2026-04-10T00:26:34.938Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -6,28 +6,23 @@
   "keyFindings": [
     {
       "severity": "P2",
-      "file": "packages/envoy-plugin/src/__tests__/index.test.ts",
-      "description": "Init test sets OC_REGISTRY=undefined, skipping the registryDir code path where all non-blocking changes live (timer, syncPort, unref). Test proves init is fast when feature is disabled, not when active."
+      "file": "packages/daemon/src/daemon/__tests__/server.test.ts",
+      "description": "No test for multi-worker-per-issue cleanup. When both implement and test workers exist for a Done issue, workspace cleanup deduplicates via cleanedWorkspaceIssueIds but this path is untested."
     },
     {
       "severity": "P2",
-      "file": "packages/envoy-plugin/src/__tests__/index.test.ts",
-      "description": "Timeout test targets ECONNREFUSED (instant error), not actual timeout. Doesn't exercise AbortSignal.timeout path. Behavioral tester confirmed real timeout works (5003ms against black-hole server)."
+      "file": "packages/daemon/src/daemon/server.ts",
+      "description": "detachWorkerFromEnvoy() and unsubscribeAllWorkerTopics() called during auto-cleanup (line 418-419) have no test coverage. Stale Envoy subscriptions could accumulate."
     },
     {
       "severity": "P3",
-      "file": "packages/envoy-plugin/src/index.ts",
-      "description": "_activeFile variable assigned but never read — pre-existing dead code, good cleanup opportunity since surrounding code was modified."
+      "file": "packages/daemon/src/daemon/repo-manager.ts",
+      "description": "cleanupWorkspace() does not check jj workspace forget exit code (pre-existing). Benign for cleanup but worth documenting."
     }
   ],
-  "learningsInjected": [
-    "docs/solutions/envoy/async-health-startup-pattern.md",
-    "docs/solutions/daemon/envoy-auto-subscription-patterns.md"
-  ],
-  "learningsHelpful": [
-    "docs/solutions/envoy/async-health-startup-pattern.md"
-  ],
+  "learningsInjected": [],
+  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-08T15:19:09.415Z"
+  "completed": "2026-04-10T00:47:13.801Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,16 +1,18 @@
 {
-  "passed": 4,
+  "passed": 3,
   "failed": 0,
   "failures": [],
-  "documentationFeedback": "PR description and issue body clearly explain the problem and solution. All 7 changed files listed accurately.",
+  "documentationFeedback": "PR description clearly explains the 3-layer defense-in-depth approach. merge.md Step 7.5 includes 'Why here?' rationale. Controller SKILL.md Step 6 has clear 'MUST run' and 'Do NOT skip' guidance. Shell quoting in curl examples is now correct.",
   "observations": [
-    "implement.md correctly has two notification points (fresh + address-comments)",
-    "test.md correctly has two notification points (pass + fail)",
-    "All notifications include fallback note about envoy_publish failures"
+    "P2: No test for multiple workers per issue (e.g., both implement and test workers for same Done issue)",
+    "P2: No test verifying detachWorkerFromEnvoy() and unsubscribeAllWorkerTopics() are called during cleanup",
+    "P2: No test for concurrent /state/collect calls racing through cleanup",
+    "Two-pass cleanup approach (workspace first, state second) correctly preserves retry handle on failure",
+    "Map iteration with workers.delete() during second pass is safe in JS"
   ],
   "learningsInjected": [],
   "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-09T22:45:40.257Z"
+  "completed": "2026-04-10T00:37:07.003Z"
 }

--- a/.opencode/skills/legion-controller/SKILL.md
+++ b/.opencode/skills/legion-controller/SKILL.md
@@ -540,25 +540,37 @@ component. When in doubt, route to Backlog.
 3. Move the oldest clarified item to Backlog
 4. Dispatch architect
 
-### 6. Cleanup Done
+### 6. Cleanup Done (MUST run every iteration)
 
-For Done issues without live workers:
+**This step MUST execute on every loop iteration.** Iterate over ALL Done issues from the collected
+state that still have worker entries in the daemon. The daemon also auto-cleans Done issues during
+state collection (Layer 1), and the merge worker cleans up at merge time (Layer 2). This controller
+sweep is the **backup safety net** that catches stragglers — issues where the merge worker or daemon
+auto-cleanup didn't fire (e.g., issue was closed manually, daemon restarted between collect cycles).
+
+For each Done issue that has worker entries (check the `/workers` response):
 
 1. Remove workspace:
 ```bash
+# Use ANY worker ID for the issue — all modes share the same workspace
 curl -s -X DELETE "http://127.0.0.1:$LEGION_DAEMON_PORT/workers/$WORKER_ID/workspace" \
   -H 'Content-Type: application/json' \
-  -d '{"repo": "'"'$OWNER/$REPO'"'"}'
+  -d '{"repo": "'"$OWNER/$REPO"'"}'
 ```
 
 2. Prune all worker entries and crash history for the issue:
 ```bash
 curl -s -X POST "http://127.0.0.1:$LEGION_DAEMON_PORT/workers/prune" \
   -H 'Content-Type: application/json' \
-  -d '{"issueIds": ["'$ISSUE_ID'"]}'
+  -d '{"issueIds": ["'"$ISSUE_ID"'"]}'
 ```
 
-Both calls are idempotent. The prune call removes all worker modes for the issue, their crash history, and the dispatch validation cache.
+Both calls are idempotent. The prune call removes all worker modes for the issue, their crash
+history, and the dispatch validation cache. If the daemon auto-cleanup already handled this issue,
+both calls are no-ops.
+
+**Do NOT skip this step** even if the daemon auto-cleanup is active — the three layers are
+defense-in-depth against disk exhaustion.
 
 ### 7. Write Heartbeat
 

--- a/.opencode/skills/legion-worker/workflows/merge.md
+++ b/.opencode/skills/legion-worker/workflows/merge.md
@@ -1,6 +1,7 @@
 # Merge Workflow
 
-Merge the PR into main. The controller handles workspace cleanup after completion.
+Merge the PR into main, then clean up the workspace. Three-layer cleanup: merge worker (immediate),
+daemon auto-cleanup (on next state collect), controller backup sweep (Step 6).
 
 ## Workflow
 
@@ -95,6 +96,37 @@ linear_linear(action="update", id=$LEGION_ISSUE_ID, state="Done")
 Then remove `worker-active` if present:
 - **GitHub:** `gh issue edit $ISSUE_NUMBER --remove-label "worker-active" -R $OWNER/$REPO`
 - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current labels without "worker-active"])`
+
+### 7.5. Cleanup Workspace
+
+After the issue is closed and Done, clean up the workspace and worker entries to prevent disk exhaustion.
+Best-effort — do not fail the merge workflow if cleanup errors occur, but only prune worker state
+after workspace deletion succeeds (preserves retry handle for the daemon/controller backup layers).
+
+**1. Remove the filesystem workspace:**
+```bash
+CLEANUP_OK=false
+if curl -sf -X DELETE "http://127.0.0.1:$LEGION_DAEMON_PORT/workers/$LEGION_ISSUE_ID-merge/workspace" \
+  -H 'Content-Type: application/json' \
+  -d '{"repo": "'"$OWNER/$REPO"'"}'; then
+  CLEANUP_OK=true
+else
+  echo 'Workspace cleanup failed (non-fatal) — daemon/controller will retry'
+fi
+```
+
+**2. Prune worker entries only if workspace was removed:**
+```bash
+if [ "$CLEANUP_OK" = "true" ]; then
+  curl -sf -X POST "http://127.0.0.1:$LEGION_DAEMON_PORT/workers/prune" \
+    -H 'Content-Type: application/json' \
+    -d '{"issueIds": ["'"$LEGION_ISSUE_ID"'"]}' || echo 'Worker prune failed (non-fatal)'
+fi
+```
+
+**Why here?** The daemon also auto-cleans Done issues on its next state collection cycle (Layer 1 safety net),
+and the controller has a backup sweep (Step 6). This merge-time cleanup is the fastest path — it reclaims
+disk space immediately when the issue completes, without waiting for the next poll cycle.
 
 Then notify the controller via Envoy (best-effort, exactly one notification):
 ```

--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -22,6 +22,7 @@ describe("daemon server", () => {
   let sessionStatusHandler:
     | ((sessionId: string) => Promise<{ data?: unknown; error?: unknown }>)
     | null = null;
+  const originalSpawn = Bun.spawn;
   const originalFetch = globalThis.fetch;
   const legionId = "123e4567-e89b-12d3-a456-426614174000";
 
@@ -114,6 +115,7 @@ describe("daemon server", () => {
   }
 
   afterEach(async () => {
+    Bun.spawn = originalSpawn;
     globalThis.fetch = originalFetch;
     sessionStatusHandler = null;
     if (stopServer) {
@@ -881,6 +883,292 @@ describe("daemon server", () => {
       expect(response.status).toBe(200);
       const body = (await response.json()) as { issues: Record<string, unknown> };
       expect(body.issues).toEqual({});
+    });
+  });
+
+  describe("auto-cleanup on state collect", () => {
+    const paths: LegionPaths = {
+      dataDir: "/tmp/legion-data",
+      stateDir: "/tmp/legion-state",
+      reposDir: "/tmp/legion-data/repos",
+      workspacesDir: "/tmp/legion-data/workspaces",
+      legionsFile: "/tmp/legion-state/legions.json",
+      forLegion: (projectId: string) => ({
+        legionStateDir: `/tmp/legion-state/legions/${projectId}`,
+        workersFile: `/tmp/legion-state/legions/${projectId}/workers.json`,
+        feedbackFile: `/tmp/legion-state/legions/${projectId}/feedback.jsonl`,
+        logDir: `/tmp/legion-state/legions/${projectId}/logs`,
+        workspacesDir: `/tmp/legion-data/workspaces/${projectId}`,
+      }),
+      repoClonePath: (host: string, owner: string, repo: string) =>
+        `/tmp/legion-data/repos/${host}/${owner}/${repo}`,
+    };
+
+    function makeRepoManagerDeps(overrides?: Partial<RepoManagerDeps>): RepoManagerDeps {
+      return {
+        runJj: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+        exists: async () => true,
+        rmDir: async () => {},
+        symlink: async () => {},
+        ...overrides,
+      };
+    }
+
+    async function createRepoWorker(issueId: string) {
+      const response = await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({
+          issueId,
+          mode: "implement",
+          repo: "acme/widgets",
+        }),
+      });
+      expect(response.status).toBe(200);
+      return (await response.json()) as { id: string; sessionId: string };
+    }
+
+    it("auto-cleans workers for Done issues on state collect", async () => {
+      const rmDirCalls: string[] = [];
+      await startTestServer({
+        paths,
+        repoManagerDeps: makeRepoManagerDeps({
+          rmDir: async (workspacePath: string) => {
+            rmDirCalls.push(workspacePath);
+          },
+        }),
+      });
+
+      const created = await createRepoWorker("acme-widgets-42");
+
+      const response = await requestJson("/state/collect", {
+        method: "POST",
+        body: JSON.stringify({
+          backend: "github",
+          issues: [
+            {
+              id: "PVTI_abc",
+              content: {
+                number: 42,
+                repository: "acme/widgets",
+                url: "https://github.com/acme/widgets/issues/42",
+                type: "Issue",
+              },
+              status: "Done",
+              labels: [],
+            },
+          ],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const workersResponse = await requestJson("/workers");
+      expect((await workersResponse.json()) as WorkerEntry[]).toEqual([]);
+      expect(deleteSessionCalls).toEqual([created.sessionId]);
+      expect(rmDirCalls).toEqual([
+        "/tmp/legion-data/workspaces/123e4567-e89b-12d3-a456-426614174000/acme-widgets-42",
+      ]);
+    });
+
+    it("does not clean workers for non-Done issues", async () => {
+      await startTestServer({
+        paths,
+        repoManagerDeps: makeRepoManagerDeps(),
+      });
+
+      await createRepoWorker("acme-widgets-43");
+
+      const response = await requestJson("/state/collect", {
+        method: "POST",
+        body: JSON.stringify({
+          backend: "github",
+          issues: [
+            {
+              id: "PVTI_def",
+              content: {
+                number: 43,
+                repository: "acme/widgets",
+                url: "https://github.com/acme/widgets/issues/43",
+                type: "Issue",
+              },
+              status: "In Progress",
+              labels: [],
+            },
+          ],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const workersResponse = await requestJson("/workers");
+      const workers = (await workersResponse.json()) as WorkerEntry[];
+      expect(workers).toHaveLength(1);
+      expect(workers[0]?.id).toBe("acme-widgets-43-implement");
+      expect(deleteSessionCalls).toEqual([]);
+    });
+
+    it("auto-cleanup is idempotent", async () => {
+      const rmDirCalls: string[] = [];
+      await startTestServer({
+        paths,
+        repoManagerDeps: makeRepoManagerDeps({
+          rmDir: async (workspacePath: string) => {
+            rmDirCalls.push(workspacePath);
+          },
+        }),
+      });
+
+      const created = await createRepoWorker("acme-widgets-44");
+
+      const donePayload = JSON.stringify({
+        backend: "github",
+        issues: [
+          {
+            id: "PVTI_xyz",
+            content: {
+              number: 44,
+              repository: "acme/widgets",
+              url: "https://github.com/acme/widgets/issues/44",
+              type: "Issue",
+            },
+            status: "Done",
+            labels: [],
+          },
+        ],
+      });
+
+      const first = await requestJson("/state/collect", {
+        method: "POST",
+        body: donePayload,
+      });
+      expect(first.status).toBe(200);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const second = await requestJson("/state/collect", {
+        method: "POST",
+        body: donePayload,
+      });
+      expect(second.status).toBe(200);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const workersResponse = await requestJson("/workers");
+      expect((await workersResponse.json()) as WorkerEntry[]).toEqual([]);
+      expect(deleteSessionCalls).toEqual([created.sessionId]);
+      expect(rmDirCalls).toEqual([
+        "/tmp/legion-data/workspaces/123e4567-e89b-12d3-a456-426614174000/acme-widgets-44",
+      ]);
+    });
+
+    it("auto-cleans workers on fetch-and-collect", async () => {
+      const rmDirCalls: string[] = [];
+      await startTestServer({
+        paths,
+        repoManagerDeps: makeRepoManagerDeps({
+          rmDir: async (workspacePath: string) => {
+            rmDirCalls.push(workspacePath);
+          },
+        }),
+      });
+
+      const created = await createRepoWorker("acme-widgets-45");
+      Bun.spawn = ((cmd: string[]) => {
+        expect(cmd.slice(0, 3)).toEqual(["gh", "api", "graphql"]);
+        return {
+          stdout: new Blob([
+            JSON.stringify({
+              data: {
+                organization: {
+                  projectV2: {
+                    items: {
+                      pageInfo: { hasNextPage: false, endCursor: null },
+                      nodes: [
+                        {
+                          id: "PVTI_fetch",
+                          fieldValueByName: { name: "Done" },
+                          labels: { nodes: [] },
+                          content: {
+                            __typename: "Issue",
+                            number: 45,
+                            title: "Done issue",
+                            url: "https://github.com/acme/widgets/issues/45",
+                            repository: { nameWithOwner: "acme/widgets" },
+                            issueDependenciesSummary: { blockedBy: 0 },
+                            linkedPullRequests: { nodes: [] },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            }),
+          ]).stream(),
+          stderr: new Blob([""]).stream(),
+          exited: Promise.resolve(0),
+          kill: () => {},
+        } as unknown as ReturnType<typeof Bun.spawn>;
+      }) as typeof Bun.spawn;
+
+      const response = await requestJson("/state/fetch-and-collect", {
+        method: "POST",
+        body: JSON.stringify({ backend: "github", legionId: "acme/123" }),
+      });
+
+      expect(response.status).toBe(200);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const workersResponse = await requestJson("/workers");
+      expect((await workersResponse.json()) as WorkerEntry[]).toEqual([]);
+      expect(deleteSessionCalls).toEqual([created.sessionId]);
+      expect(rmDirCalls).toEqual([
+        "/tmp/legion-data/workspaces/123e4567-e89b-12d3-a456-426614174000/acme-widgets-45",
+      ]);
+    });
+
+    it("preserves worker state when workspace cleanup fails", async () => {
+      await startTestServer({
+        paths,
+        repoManagerDeps: makeRepoManagerDeps({
+          rmDir: async () => {
+            throw new Error("disk I/O error");
+          },
+        }),
+      });
+
+      await createRepoWorker("acme-widgets-46");
+
+      const response = await requestJson("/state/collect", {
+        method: "POST",
+        body: JSON.stringify({
+          backend: "github",
+          issues: [
+            {
+              id: "PVTI_fail",
+              content: {
+                number: 46,
+                repository: "acme/widgets",
+                url: "https://github.com/acme/widgets/issues/46",
+                type: "Issue",
+              },
+              status: "Done",
+              labels: [],
+            },
+          ],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Worker should still exist because workspace cleanup failed
+      const workersResponse = await requestJson("/workers");
+      const workers = (await workersResponse.json()) as WorkerEntry[];
+      expect(workers).toHaveLength(1);
+      expect(workers[0]?.id).toBe("acme-widgets-46-implement");
+      // Session should NOT have been deleted
+      expect(deleteSessionCalls).toEqual([]);
     });
   });
 

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -8,6 +8,7 @@ import {
   CollectedState,
   computeSessionId,
   type IssueState,
+  IssueStatus,
   WorkerMode,
   type WorkerModeLiteral,
 } from "../state/types";
@@ -347,6 +348,92 @@ export function startServer(opts: ServerOptions): {
   };
 
   const stateLoaded = loadState();
+
+  const cleanupDoneIssueWorkers = async (collectedState: CollectedState): Promise<void> => {
+    await stateLoaded;
+
+    const doneIssueIds = Object.entries(collectedState.issues)
+      .filter(([, issueState]) => issueState.status === IssueStatus.DONE)
+      .map(([issueId]) => issueId.toLowerCase());
+    if (doneIssueIds.length === 0) {
+      return;
+    }
+
+    const doneIssueIdSet = new Set(doneIssueIds);
+    const cleanedIssueIds = new Set<string>();
+    const failedWorkspaceIssueIds = new Set<string>();
+    const cleanedWorkspaceIssueIds = new Set<string>();
+    let cleanedWorkers = 0;
+
+    // First pass: attempt workspace cleanup (once per issue)
+    for (const [workerId, entry] of workers.entries()) {
+      const issueId = extractIssueIdFromWorkerId(workerId)?.toLowerCase();
+      if (!issueId || !doneIssueIdSet.has(issueId)) {
+        continue;
+      }
+      if (cleanedWorkspaceIssueIds.has(issueId) || failedWorkspaceIssueIds.has(issueId)) {
+        continue;
+      }
+      if (opts.paths && typeof entry.repo === "string") {
+        const repoRef = parseIssueRepo(entry.repo);
+        if (repoRef) {
+          try {
+            await cleanupWorkspace(
+              opts.paths,
+              opts.legionId,
+              issueId,
+              repoRef,
+              opts.repoManagerDeps
+            );
+            cleanedWorkspaceIssueIds.add(issueId);
+          } catch (error) {
+            console.warn(
+              `[auto-cleanup] workspace cleanup failed for ${issueId}: ${error instanceof Error ? error.message : String(error)}`
+            );
+            failedWorkspaceIssueIds.add(issueId);
+          }
+        }
+      }
+    }
+
+    // Second pass: remove worker state only for issues where workspace was cleaned (or no workspace)
+    for (const [workerId, entry] of workers.entries()) {
+      const issueId = extractIssueIdFromWorkerId(workerId)?.toLowerCase();
+      if (!issueId || !doneIssueIdSet.has(issueId)) {
+        continue;
+      }
+      // Skip issues where workspace cleanup failed — preserve state for retry
+      if (failedWorkspaceIssueIds.has(issueId)) {
+        continue;
+      }
+
+      try {
+        await opts.adapter.deleteSession(entry.sessionId);
+      } catch (error) {
+        console.warn(
+          `[auto-cleanup] session delete failed for ${entry.id}: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+
+      detachWorkerFromEnvoy(entry, "auto-cleanup-done");
+      unsubscribeAllWorkerTopics(entry.sessionId);
+      workers.delete(entry.id);
+      crashHistory.delete(entry.id);
+      cleanedIssueIds.add(issueId);
+      cleanedWorkers += 1;
+    }
+
+    for (const issueId of cleanedIssueIds) {
+      issueStateCache.delete(issueId);
+    }
+
+    if (cleanedWorkers > 0) {
+      await persistState();
+      console.log(
+        `[auto-cleanup] Cleaned ${cleanedWorkers} workers for ${cleanedIssueIds.size} Done issues`
+      );
+    }
+  };
 
   const server = Bun.serve({
     hostname,
@@ -1205,6 +1292,13 @@ export function startServer(opts: ServerOptions): {
               }
             }
 
+            cleanupDoneIssueWorkers(state).catch((err) =>
+              console.error(
+                "[auto-cleanup] failed:",
+                err instanceof Error ? err.message : String(err)
+              )
+            );
+
             return jsonResponse(CollectedState.toDict(state));
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
@@ -1261,6 +1355,13 @@ export function startServer(opts: ServerOptions): {
                 issueTitleCache.set(id, title);
               }
             }
+
+            cleanupDoneIssueWorkers(state).catch((err) =>
+              console.error(
+                "[auto-cleanup] failed:",
+                err instanceof Error ? err.message : String(err)
+              )
+            );
 
             return jsonResponse(CollectedState.toDict(state));
           } catch (error) {


### PR DESCRIPTION
Closes #385

## Summary

Three-layer defense-in-depth workspace cleanup to prevent disk exhaustion from accumulated workspaces:

### Layer 1: Daemon auto-cleanup (primary)
- Added `cleanupDoneIssueWorkers()` in `server.ts` that fires on `/state/collect` and `/state/fetch-and-collect`
- Idempotent, fire-and-forget — doesn't block the API response
- Preserves worker state if workspace cleanup fails, so subsequent cycles can retry
- 5 new tests covering: happy path, non-Done issues ignored, idempotency, fetch-and-collect, and failure-preserves-state

### Layer 2: Merge worker cleanup (immediate)
- Added Step 7.5 in `merge.md` — merge worker calls `DELETE /workers/{id}/workspace` + `POST /workers/prune` after issue close
- Conditional prune — only runs if workspace deletion succeeds (preserves retry handle)
- Uses `curl -sf` to detect HTTP errors

### Layer 3: Controller backup sweep (safety net)
- Strengthened Step 6 in controller SKILL.md — MUST run every iteration
- Documented relationship between all three layers
- Fixed shell quoting in existing curl examples