### PR TITLE
sjawhar-legion-387: switch runJj from Bun.spawnSync to async Bun.spawn

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,20 +1,16 @@
 {
-  "filesChanged": [
-    "packages/daemon/src/daemon/server.ts",
-    "packages/daemon/src/daemon/__tests__/server.test.ts",
-    ".opencode/skills/legion-worker/workflows/merge.md",
-    ".opencode/skills/legion-controller/SKILL.md"
-  ],
+  "filesChanged": ["packages/daemon/src/daemon/repo-manager.ts"],
   "trickyParts": [
-    "Workspace cleanup failure must preserve worker state for retry — two-pass approach in cleanupDoneIssueWorkers separates workspace cleanup from state removal",
-    "Fire-and-forget cleanup runs after response is built but before return — idempotent by design since workers.delete() is synchronous"
+    "Used Promise.all to drain stdout/stderr concurrently with proc.exited to prevent pipe backpressure deadlock — identified during cross-family review"
   ],
   "deviations": [],
   "openQuestions": [],
   "subPlanningNeeded": false,
-  "learningsInjected": [],
+  "learningsInjected": [
+    "docs/solutions/architecture-patterns/sync-to-async-modular-refactoring.md"
+  ],
   "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-10T00:26:34.938Z"
+  "completed": "2026-04-10T00:39:23.353Z"
 }

--- a/packages/daemon/src/daemon/repo-manager.ts
+++ b/packages/daemon/src/daemon/repo-manager.ts
@@ -15,8 +15,6 @@ export interface JjResult {
 
 export interface RepoManagerDeps {
   runJj: (args: string[]) => Promise<JjResult>;
-  /** Truly async subprocess runner for non-blocking operations. Falls back to runJj if absent. */
-  spawnJjAsync?: (args: string[]) => Promise<JjResult>;
   exists: (path: string) => Promise<boolean>;
   rmDir: (path: string) => Promise<void>;
   symlink: (target: string, linkPath: string) => Promise<void>;
@@ -24,24 +22,20 @@ export interface RepoManagerDeps {
 
 const defaultDeps: RepoManagerDeps = {
   runJj: async (args) => {
-    const result = Bun.spawnSync(["jj", ...args], {
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: 120_000,
-    });
-    return {
-      exitCode: result.exitCode,
-      stdout: result.stdout.toString(),
-      stderr: result.stderr.toString(),
-    };
-  },
-  spawnJjAsync: async (args) => {
     const proc = Bun.spawn(["jj", ...args], {
       stdio: ["ignore", "pipe", "pipe"],
     });
-    const exitCode = await proc.exited;
-    const stdout = await new Response(proc.stdout).text();
-    const stderr = await new Response(proc.stderr).text();
-    return { exitCode, stdout, stderr };
+    const timeout = setTimeout(() => proc.kill(), 120_000);
+    try {
+      const [exitCode, stdout, stderr] = await Promise.all([
+        proc.exited,
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]);
+      return { exitCode, stdout, stderr };
+    } finally {
+      clearTimeout(timeout);
+    }
   },
   exists: async (p) => {
     const { existsSync } = await import("node:fs");
@@ -155,9 +149,7 @@ export async function ensureWorkspace(
 /**
  * Fire a non-blocking `jj git fetch` on an existing clone.
  *
- * Uses `spawnJjAsync` (truly non-blocking) when available, falling back to
- * `runJj` for tests. Rejects on non-zero exit codes so callers can log
- * failures via `.catch()`.
+ * Rejects on non-zero exit codes so callers can log failures via `.catch()`.
  */
 export async function startBackgroundFetch(
   paths: LegionPaths,
@@ -165,8 +157,7 @@ export async function startBackgroundFetch(
   deps: RepoManagerDeps = defaultDeps
 ): Promise<JjResult> {
   const clonePath = paths.repoClonePath(repo.host, repo.owner, repo.repo);
-  const runner = deps.spawnJjAsync ?? deps.runJj;
-  const result = await runner(["git", "fetch", "-R", clonePath]);
+  const result = await deps.runJj(["git", "fetch", "-R", clonePath]);
   if (result.exitCode !== 0) {
     throw new Error(`Background fetch failed for ${clonePath}: ${result.stderr}`);
   }


### PR DESCRIPTION
Closes #387

## Summary

Switch `runJj` in `repo-manager.ts` from `Bun.spawnSync` (which blocks the entire event loop during worker dispatch) to `Bun.spawn` + `await proc.exited`. This unblocks concurrent dispatches — 3 workers no longer serialize into 18-36s of frozen daemon.

### Changes
- **`defaultDeps.runJj`**: Replaced `Bun.spawnSync` with `Bun.spawn` + `Promise.all` for concurrent stream draining and exit waiting. 120s timeout preserved via `setTimeout` + `proc.kill()`.
- **`spawnJjAsync`**: Removed from both `RepoManagerDeps` interface and `defaultDeps` (now a duplicate of the unified `runJj`).
- **`startBackgroundFetch`**: Simplified to use `deps.runJj` directly instead of the `spawnJjAsync ?? runJj` fallback pattern.

### Verification
- 19/19 repo-manager unit tests pass
- Biome lint clean
- Single file changed: `packages/daemon/src/daemon/repo-manager.ts` (13 insertions, 22 deletions)