### PR TITLE
sjawhar-legion-389: fix phantom duplicate deliveries from slow prompt_async

### DIFF
--- a/packages/envoy/cmd/listener/main.go
+++ b/packages/envoy/cmd/listener/main.go
@@ -427,12 +427,22 @@ func main() {
 	log.Printf("session registry mode=%s", registryMode)
 
 	deliver := session.Deliverer{
-		MachineID:  cfg.MachineID,
-		HostBridge: os.Getenv("ENVOY_HOST_BRIDGE"),
-		Sessions:   sessions,
+		MachineID:    cfg.MachineID,
+		HostBridge:   os.Getenv("ENVOY_HOST_BRIDGE"),
+		RequestLimit: 30 * time.Second,
+		Sessions:     sessions,
 	}
 
 	dedupeCache := dedupe.New(10 * time.Minute)
+
+	// attemptCache tracks (dedupe_key, session_id) pairs BEFORE delivery to
+	// prevent phantom duplicates when slow serves accept prompt_async but
+	// the HTTP client times out before receiving 204. Keyed by DedupeKey
+	// (not EventID) because fan-out normalization can produce multiple
+	// envelopes with the same EventID but distinct DedupeKeys. The existing
+	// dedupeCache records only successful deliveries (post-delivery) and
+	// cannot catch this slow-204 case. See #389.
+	attemptCache := dedupe.New(5 * time.Minute)
 
 	consumer := "listener-" + strings.ReplaceAll(cfg.MachineID, " ", "-")
 	_ = client.JS().DeleteConsumer(bus.Stream, consumer)
@@ -456,11 +466,17 @@ func main() {
 				_ = msg.Ack()
 				return
 			}
+			if attemptCache.Seen(item.DedupeKey, sessionID) {
+				log.Printf("listener attempt-dedupe skip session=%s dedupe_key=%s", sessionID, item.DedupeKey)
+				_ = msg.Ack()
+				return
+			}
 			interest, err := registry.Get(sessionID)
 			var interestPtr *store.Interest
 			if err == nil {
 				interestPtr = &interest
 			}
+			attemptCache.Record(item.DedupeKey, sessionID)
 			result := session.HandleAgentMessage(item, sessionID, cfg.MachineID, interestPtr, &deliver)
 			if result.Err != nil {
 				log.Printf("listener agent delivery failed session=%s: %v", sessionID, result.Err)
@@ -490,10 +506,15 @@ func main() {
 				log.Printf("listener dedupe skip session=%s dedupe_key=%s", interest.SessionID, item.DedupeKey)
 				continue
 			}
+			if attemptCache.Seen(item.DedupeKey, interest.SessionID) {
+				log.Printf("listener attempt-dedupe skip session=%s dedupe_key=%s", interest.SessionID, item.DedupeKey)
+				continue
+			}
 			if item.SourceSession != "" && item.SourceSession == interest.SessionID {
 				log.Printf("listener skip echo session=%s topic=%s", interest.SessionID, item.Topic)
 				continue
 			}
+			attemptCache.Record(item.DedupeKey, interest.SessionID)
 			if err := deliver.Deliver(item, interest); err != nil {
 				log.Printf("listener delivery failed session=%s: %v", interest.SessionID, err)
 				failed = true

--- a/packages/envoy/internal/dedupe/dedupe_test.go
+++ b/packages/envoy/internal/dedupe/dedupe_test.go
@@ -196,3 +196,44 @@ func TestCache_Len(t *testing.T) {
 		t.Fatalf("expected 3, got %d", c.Len())
 	}
 }
+
+// TestCache_PreDeliveryAttemptDedupe validates the pattern used by the listener:
+// record BEFORE delivery so redeliveries of the same (dedupe_key, session_id)
+// are skipped even when the first attempt timed out (slow-204 case).
+func TestCache_PreDeliveryAttemptDedupe(t *testing.T) {
+	clock := newTestClock()
+	attempts := NewWithClock(5*time.Minute, clock.Now)
+	defer attempts.Stop()
+
+	dedupeKey := "publish.abc123"
+	sessionID := "ses-target"
+
+	// First delivery attempt: not yet seen
+	if attempts.Seen(dedupeKey, sessionID) {
+		t.Fatal("first attempt should not be seen")
+	}
+
+	// Record attempt BEFORE calling prompt_async
+	attempts.Record(dedupeKey, sessionID)
+
+	// Simulate JetStream redelivery (same dedupe_key) — should be skipped
+	if !attempts.Seen(dedupeKey, sessionID) {
+		t.Fatal("redelivery should be seen after attempt was recorded")
+	}
+
+	// Different dedupe_key to same session is still allowed
+	if attempts.Seen("publish.different", sessionID) {
+		t.Fatal("different dedupe_key should not be blocked")
+	}
+
+	// Same dedupe_key to different session is still allowed
+	if attempts.Seen(dedupeKey, "ses-other") {
+		t.Fatal("same dedupe_key to different session should not be blocked")
+	}
+
+	// After 5-min TTL, redelivery is allowed again
+	clock.Advance(5*time.Minute + 1)
+	if attempts.Seen(dedupeKey, sessionID) {
+		t.Fatal("attempt should expire after TTL")
+	}
+}

--- a/packages/envoy/internal/session/session.go
+++ b/packages/envoy/internal/session/session.go
@@ -112,5 +112,5 @@ func (d Deliverer) timeout() time.Duration {
 	if d.RequestLimit > 0 {
 		return d.RequestLimit
 	}
-	return 10 * time.Second
+	return 30 * time.Second
 }

--- a/packages/envoy/internal/session/session_test.go
+++ b/packages/envoy/internal/session/session_test.go
@@ -360,3 +360,17 @@ func TestDeliver_WrongMachineReturnsError(t *testing.T) {
 		t.Fatalf("expected 0 deliveries (wrong machine), got %d", count)
 	}
 }
+
+func TestDeliver_DefaultTimeout30s(t *testing.T) {
+	d := Deliverer{}
+	if got := d.timeout(); got != 30*time.Second {
+		t.Fatalf("expected default timeout 30s, got %v", got)
+	}
+}
+
+func TestDeliver_CustomTimeoutRespected(t *testing.T) {
+	d := Deliverer{RequestLimit: 5 * time.Second}
+	if got := d.timeout(); got != 5*time.Second {
+		t.Fatalf("expected custom timeout 5s, got %v", got)
+	}
+}


### PR DESCRIPTION
Closes #389

## Summary

Fix phantom duplicate deliveries caused by the listener's aggressive 10s HTTP timeout. Busy serves accept `prompt_async` but take >10s to return 204, causing NAK+redelivery of messages already being processed.

### Changes

1. **Increase `Deliverer.RequestLimit` from 10s to 30s** — the JetStream `AckWait` is 60s, so 30s timeout + processing time stays within the window.

2. **Pre-delivery attempt dedupe** — a second in-memory `(dedupe_key, session_id)` cache with 5-min TTL records delivery attempts *before* calling `prompt_async`. If JetStream redelivers the same message (because the first attempt "timed out"), the retry is skipped. Keyed by `DedupeKey` (not `EventID`) because fan-out normalization can produce multiple envelopes with the same `EventID` but distinct `DedupeKey`s.

### Files changed

- `packages/envoy/internal/session/session.go` — default timeout 10s → 30s
- `packages/envoy/cmd/listener/main.go` — explicit 30s `RequestLimit`, new `attemptCache` with checks in both agent and topic-match delivery paths
- `packages/envoy/internal/dedupe/dedupe_test.go` — test for pre-delivery attempt dedupe pattern
- `packages/envoy/internal/session/session_test.go` — tests for new default timeout