### PR TITLE
sjawhar-legion-397: replace broken item-list pipeline with fetch-and-collect endpoint

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,16 +1,12 @@
 {
-  "filesChanged": ["packages/daemon/src/daemon/repo-manager.ts"],
-  "trickyParts": [
-    "Used Promise.all to drain stdout/stderr concurrently with proc.exited to prevent pipe backpressure deadlock — identified during cross-family review"
+  "filesChanged": [
+    ".opencode/skills/legion-controller/SKILL.md"
   ],
+  "trickyParts": [],
   "deviations": [],
   "openQuestions": [],
   "subPlanningNeeded": false,
-  "learningsInjected": [
-    "docs/solutions/architecture-patterns/sync-to-async-modular-refactoring.md"
-  ],
-  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-10T00:39:23.353Z"
+  "completed": "2026-04-11T00:44:19.829Z"
 }

--- a/.legion/plan.json
+++ b/.legion/plan.json
@@ -1,28 +1,15 @@
 {
   "taskCount": 6,
-  "independentTasks": 4,
+  "independentTasks": 5,
   "routingHints": {
     "complexity": "small",
     "estimatedImplementers": 1,
-    "skipRetro": false,
+    "skipRetro": true,
     "skipArchitect": true
   },
-  "concerns": [
-    "MachineConfig.name must match MagicDNS hostname - assumption verified by existing sshHost usage but should be documented",
-    "Host networking exposes NATS ports directly - verify no port collisions during rollout",
-    "Live cluster verification (routez, JetStream persistence) requires Tailscale-connected host, not CI-testable"
-  ],
-  "learningsInjected": [
-    "envoy/docker-tailscale-networking.md",
-    "envoy/pulumi-remote-docker-patterns.md",
-    "infra/mixed-runtime-type-boundaries.md"
-  ],
-  "learningsHelpful": [
-    "envoy/docker-tailscale-networking.md",
-    "envoy/pulumi-remote-docker-patterns.md"
-  ],
-  "workflowRecommendation": "Standard pipeline — all phases needed. Tasks 1/2/4/5 are independent and can be parallelized by the implementer.",
+  "concerns": [],
+  "workflowRecommendation": "Simple skill file fix — single Markdown file edit, skip retro. 5 independent tasks (Tasks 1-5) can be parallelized, Task 6 is final verification + commit.",
   "schemaVersion": 1,
   "phase": "plan",
-  "completed": "2026-04-07T01:52:38.524Z"
+  "completed": "2026-04-11T00:38:04.474Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,28 +1,12 @@
 {
   "critical": 0,
-  "important": 2,
-  "minor": 1,
+  "important": 0,
+  "minor": 0,
   "verdict": "approved",
-  "keyFindings": [
-    {
-      "severity": "P2",
-      "file": "packages/daemon/src/daemon/__tests__/server.test.ts",
-      "description": "No test for multi-worker-per-issue cleanup. When both implement and test workers exist for a Done issue, workspace cleanup deduplicates via cleanedWorkspaceIssueIds but this path is untested."
-    },
-    {
-      "severity": "P2",
-      "file": "packages/daemon/src/daemon/server.ts",
-      "description": "detachWorkerFromEnvoy() and unsubscribeAllWorkerTopics() called during auto-cleanup (line 418-419) have no test coverage. Stale Envoy subscriptions could accumulate."
-    },
-    {
-      "severity": "P3",
-      "file": "packages/daemon/src/daemon/repo-manager.ts",
-      "description": "cleanupWorkspace() does not check jj workspace forget exit code (pre-existing). Benign for cleanup but worth documenting."
-    }
-  ],
+  "keyFindings": [],
   "learningsInjected": [],
   "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-10T00:47:13.801Z"
+  "completed": "2026-04-11T00:56:25.788Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,18 +1,12 @@
 {
-  "passed": 3,
+  "passed": 4,
   "failed": 0,
   "failures": [],
-  "documentationFeedback": "PR description clearly explains the 3-layer defense-in-depth approach. merge.md Step 7.5 includes 'Why here?' rationale. Controller SKILL.md Step 6 has clear 'MUST run' and 'Do NOT skip' guidance. Shell quoting in curl examples is now correct.",
-  "observations": [
-    "P2: No test for multiple workers per issue (e.g., both implement and test workers for same Done issue)",
-    "P2: No test verifying detachWorkerFromEnvoy() and unsubscribeAllWorkerTopics() are called during cleanup",
-    "P2: No test for concurrent /state/collect calls racing through cleanup",
-    "Two-pass cleanup approach (workspace first, state second) correctly preserves retry handle on failure",
-    "Map iteration with workers.delete() during second pass is safe in JS"
-  ],
+  "documentationFeedback": "PR description accurately enumerates all changes and what was NOT changed. In-file comments explain the 'why' (paginated GraphQL, 100 items/page). CRITICAL note scoping to 'Linear only' with separate GitHub explanation is clear.",
+  "observations": [],
   "learningsInjected": [],
   "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-10T00:37:07.003Z"
+  "completed": "2026-04-11T00:50:59.453Z"
 }

--- a/.opencode/skills/legion-controller/SKILL.md
+++ b/.opencode/skills/legion-controller/SKILL.md
@@ -138,7 +138,7 @@ digraph controller {
 The 9-step loop describes WHAT the controller does. Execution uses background polling via `task(run_in_background=true)`:
 
 1. **Main thread** — handles user messages, makes routing decisions, acts on poller reports. MUST never call `sleep` or block.
-2. **Background poller** — a persistent background task that fetches issues, posts to `/state/collect`, and reports state changes every ~60 seconds.
+2. **Background poller** — a persistent background task that calls `fetch-and-collect` (GitHub) or fetches issues and posts to `/state/collect` (Linear), and reports state changes every ~60 seconds.
 3. **Lifecycle:** Launch poller at session start. Check poller health each time the main thread processes a report — if the poller has stopped or timed out, re-launch immediately. The poller is disposable — cancel and re-launch freely.
 
 **Rules:**
@@ -180,16 +180,19 @@ These rules prevent the controller from burning its context window on redundant 
 ### 1. Fetch Issues
 
 ```bash
-# Derive OWNER and PROJECT_NUM from LEGION_ID for GitHub backend
+# Derive OWNER from LEGION_ID for GitHub backend (used for label/PR operations below)
 # LEGION_ID format for GitHub: "owner/project-number"
 if [ "$LEGION_ISSUE_BACKEND" = "github" ]; then
   OWNER="${LEGION_ID%%/*}"
-  PROJECT_NUM="${LEGION_ID##*/}"
 fi
 
-# Fetch issues based on backend
+# GitHub: the daemon fetches all project items internally (paginated GraphQL, 100 items/page)
+# and runs them through the state machine in one call.
+# Linear: fetch issues first, then pass to the state machine in step 3.
 if [ "$LEGION_ISSUE_BACKEND" = "github" ]; then
-  ISSUES_JSON=$(gh project item-list $PROJECT_NUM --owner $OWNER --format json)
+  COLLECTED=$(curl -s -X POST http://127.0.0.1:$LEGION_DAEMON_PORT/state/fetch-and-collect \
+    -H 'Content-Type: application/json' \
+    -d '{"backend": "github"}')
 else
   ISSUES_JSON=$(linear_linear(action="search", query={"team": "$LEGION_ID"}))
 fi
@@ -197,7 +200,9 @@ fi
 ACTIVE_WORKERS=$(curl -s http://127.0.0.1:$LEGION_DAEMON_PORT/workers | jq 'length')
 ```
 
-**CRITICAL:** Pass `ISSUES_JSON` directly to the state endpoint in step 3 without modification. Do NOT reconstruct, filter, or hand-craft the issue JSON. The state machine's parser handles both Linear and GitHub formats. Injecting your own assumptions about labels, status, or other fields produces stale data and wrong actions.
+**CRITICAL (Linear only):** Pass `ISSUES_JSON` directly to the state endpoint in step 3 without modification. Do NOT reconstruct, filter, or hand-craft the issue JSON. The state machine's parser handles the raw Linear format.
+
+For GitHub, the daemon's `fetch-and-collect` endpoint handles fetching and state collection internally — no raw issue JSON is involved.
 
 ### 2. Relay User Feedback
 
@@ -209,10 +214,14 @@ When both `user-input-needed` AND `user-feedback-given` labels present:
 
 Analyze via daemon:
 ```bash
-COLLECTED=$(echo "$ISSUES_JSON" | jq -Rs --arg backend "$LEGION_ISSUE_BACKEND" \
-  '{"backend": $backend, "issues": (. | fromjson)}' | \
-  curl -s -X POST http://127.0.0.1:$LEGION_DAEMON_PORT/state/collect \
-  -H 'Content-Type: application/json' --data @-)
+# For GitHub, COLLECTED was already set by fetch-and-collect in step 1.
+# For Linear, pipe issues to the state machine now.
+if [ "$LEGION_ISSUE_BACKEND" != "github" ]; then
+  COLLECTED=$(echo "$ISSUES_JSON" | jq -Rs --arg backend "$LEGION_ISSUE_BACKEND" \
+    '{"backend": $backend, "issues": (. | fromjson)}' | \
+    curl -s -X POST http://127.0.0.1:$LEGION_DAEMON_PORT/state/collect \
+    -H 'Content-Type: application/json' --data @-)
+fi
 ```
 
 The state endpoint returns JSON with both `suggestedAction` and raw signals:
@@ -825,17 +834,18 @@ issue is fully complete and no further prompts will be sent.
 
 ### 1. Trust the state machine
 
-The state machine checks worker liveness, PR status, labels, and draft state. POST issue
-data to `/state/collect` and route by `suggestedAction`. Don't independently check PRs,
-ports, or process status — that's the state machine's job.
+The state machine checks worker liveness, PR status, labels, and draft state. Use
+`fetch-and-collect` (GitHub) or POST issue data to `/state/collect` (Linear) and route
+by `suggestedAction`. Don't independently check PRs, ports, or process status — that's
+the state machine's job.
 
 For the full observability architecture and failure case studies, see `docs/solutions/daemon/controller-observability.md`.
 
 ### 2. Never reconstruct state machine input
 
-Pass issue tracker output directly to `/state/collect`. Do not hand-craft JSON, filter
-issues, or inject your own assumptions about labels or status. The state machine's
-parser handles the raw format.
+For GitHub, call `fetch-and-collect` — the daemon fetches project items internally via
+paginated GraphQL. For Linear, pass tracker output directly to `/state/collect`. Never
+hand-craft JSON, filter issues, or inject your own assumptions about labels or status.
 
 ### 3. Fresh data every loop iteration
 
@@ -908,7 +918,7 @@ If you catch yourself thinking any of these, STOP. You're about to make a mistak
 
 | Thought | What to do instead |
 |---------|--------------------|
-| "Let me construct the JSON for the state machine" | POST tracker output to `/state/collect` directly — no hand-crafting |
+| "Let me construct the JSON for the state machine" | Use `fetch-and-collect` (GitHub) or POST tracker output to `/state/collect` (Linear) — no hand-crafting |
 | "I know the label/status from last iteration" | Fetch fresh from the tracker. State goes stale between iterations. |
 | "The changes are lost" | Check open PRs (`gh pr list`), worker workspaces (daemon API), and issue comments before concluding anything is lost. Do NOT run `jj` — dispatch a worker to check version control. |
 | "I'll give the worker specific instructions" | State the mode, issue ID, and backend. Invoke the skill. Let the workflow guide the worker. |


### PR DESCRIPTION
Closes #397

## Summary

Replaces the controller skill's broken `gh project item-list | /state/collect` pipeline with the daemon's paginated `POST /state/fetch-and-collect` endpoint.

### Changes
- **Step 1 (Fetch Issues):** GitHub path now calls `POST /state/fetch-and-collect {"backend": "github"}` instead of `gh project item-list` (which only returned 30 items). `PROJECT_NUM` derivation removed; `OWNER` kept for downstream label/PR operations.
- **Step 3 (Process worker-done):** `POST /state/collect` now guarded for Linear only — GitHub's `COLLECTED` is already set in step 1.
- **CRITICAL note:** Scoped to "Linear only" with separate GitHub explanation.
- **Observability rules (§1, §2):** Updated to reference `fetch-and-collect` for GitHub, `/state/collect` for Linear.
- **Red flag anti-pattern:** Updated to distinguish GitHub vs Linear paths.

### Not changed
- Linear path (fully preserved)
- All other controller skill sections