### PR TITLE
sjawhar-legion-398: add legion poll command for compact state machine summary

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,12 +1,31 @@
 {
   "filesChanged": [
-    ".opencode/skills/legion-controller/SKILL.md"
+    "packages/daemon/src/cli/poll-formatter.ts",
+    "packages/daemon/src/cli/__tests__/poll-formatter.test.ts",
+    "packages/daemon/src/cli/index.ts",
+    "packages/daemon/src/daemon/server.ts",
+    "packages/daemon/src/state/types.ts"
   ],
-  "trickyParts": [],
-  "deviations": [],
-  "openQuestions": [],
+  "trickyParts": [
+    "Blocking conditions (user-input-needed, stale worker-active) must be checked BEFORE suggestedAction in the formatter — the state machine assigns non-skip actions like remove_worker_active_and_redispatch to stale workers, which would appear as ACTIONABLE without this precedence",
+    "IssueStateDict was not exported from types.ts — needed to export it for the formatter to type-check against, which is a minor cross-module coupling (acceptable given existing patterns)"
+  ],
+  "deviations": [
+    "Exported IssueStateDict from types.ts — plan referenced it in imports but it was not exported (prerequisite not in plan)",
+    "Refactored title extraction in server.ts to avoid double extraction — plan showed re-calling extractGitHubIssueTitles, implementation stores the Map and reuses it",
+    "CI checks never triggered on this PR despite workflow files existing — local verification (biome, tsc, bun test) passed; CI may need to be checked manually by tester/reviewer"
+  ],
+  "openQuestions": [
+    "CI did not trigger on PR #402 — may be a runner availability or repo configuration issue",
+    "1 pre-existing test failure in daemon/__tests__/index.test.ts (passes controller env vars to adapter.start on startup) — unrelated to poll changes"
+  ],
   "subPlanningNeeded": false,
+  "learningsInjected": [
+    "docs/solutions/daemon/controller-observability.md",
+    "docs/solutions/testing/bun-fetch-mocking-patterns.md"
+  ],
+  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-11T00:44:19.829Z"
+  "completed": "2026-04-11T01:03:17.869Z"
 }

--- a/.legion/plan.json
+++ b/.legion/plan.json
@@ -1,6 +1,6 @@
 {
   "taskCount": 3,
-  "independentTasks": 3,
+  "independentTasks": 1,
   "routingHints": {
     "complexity": "medium",
     "estimatedImplementers": 1,
@@ -8,35 +8,14 @@
     "skipArchitect": true
   },
   "concerns": [
-    "SetRole uses ordered last-writer-wins, not true transactions — partial failure leaves role temporarily unheld",
-    "Registry.List() is cache-only — SetRole MUST use dedicated envoy_roles KV bucket for old-holder lookup",
-    "Controller migration must be ordered: await role claim before fire-and-forget mention subscriptions",
-    "16 occurrences of notifications.legion.controller across 12 files (3 code, 2 docs, 11 skills) — issue AC only listed 6 doc files, plan adds 5 workflow files",
-    "roleKV field added to Registry struct — existing tests that construct Registry directly may need updating"
+    "Titles require 3-line server.ts change — technically crosses daemon boundary but backward-compatible",
+    "cmdPoll tests mock global fetch — fragile if resolveLegionId or getDaemonPort have side effects in test env",
+    "IssueStateDict type import in poll-formatter.ts couples CLI to state module — acceptable given existing pattern"
   ],
-  "learningsInjected": [
-    "architecture-patterns/nats-kv-dual-bucket-lifecycle.md",
-    "envoy/listener-routing-by-topic-prefix.md",
-    "daemon/envoy-auto-subscription-patterns.md"
-  ],
-  "learningsHelpful": [
-    "architecture-patterns/nats-kv-dual-bucket-lifecycle.md",
-    "daemon/envoy-auto-subscription-patterns.md"
-  ],
-  "workflowRecommendation": "Standard pipeline — all phases needed. All 3 tasks are independent and can be parallelized by the implementer.",
-  "requiredSkills": {
-    "implement": [
-      "envoy",
-      "test-driven-development"
-    ],
-    "test": [
-      "envoy"
-    ],
-    "review": [
-      "envoy"
-    ]
-  },
+  "learningsInjected": ["docs/solutions/daemon/controller-observability.md"],
+  "learningsHelpful": ["docs/solutions/daemon/controller-observability.md"],
+  "workflowRecommendation": "Simple feature — single implementer, skip architect. Tasks 1 is independent, Tasks 2-3 are sequential.",
   "schemaVersion": 1,
   "phase": "plan",
-  "completed": "2026-04-11T00:20:49.123Z"
+  "completed": "2026-04-11T00:45:30.626Z"
 }

--- a/.legion/retro.json
+++ b/.legion/retro.json
@@ -1,0 +1,9 @@
+{
+  "skipped": false,
+  "docsCreated": [
+    "docs/solutions/daemon/state-machine-action-display-mismatch.md"
+  ],
+  "schemaVersion": 1,
+  "phase": "retro",
+  "completed": "2026-04-11T01:27:27.039Z"
+}

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,38 +1,32 @@
 {
   "critical": 0,
-  "important": 3,
-  "minor": 2,
+  "important": 0,
+  "minor": 3,
   "verdict": "approved",
   "keyFindings": [
     {
-      "severity": "P2",
-      "file": "packages/envoy/internal/mcpbridge/http_server_test.go",
-      "description": "CI envoy-go check fails: TestHTTPServer_StartAndStop WhatsApp MCP timeout. Unrelated to this PR (internal/mcpbridge package, not modified). Main passes consistently. Likely flaky — needs re-run or separate fix."
-    },
-    {
-      "severity": "P2",
-      "file": "packages/envoy/internal/integration/delivery_test.go",
-      "description": "Issue AC specifies 3 integration tests (transfer, no-prior-holder, idempotent). Only transfer test added as integration test. Other two covered by unit tests in kv_test.go which also use testcontainers NATS."
-    },
-    {
-      "severity": "P2",
-      "file": "packages/daemon/src/daemon/index.ts",
-      "description": "subscribeControllerToEnvoy() uses global fetch instead of injected deps.fetch. Daemon tests log 404 for /v1/roles/set. Pre-existing pattern but worsened by adding the role claim call."
+      "severity": "P3",
+      "file": "packages/daemon/src/cli/poll-formatter.ts",
+      "description": "Empty status strings render as ': 35' in SUMMARY — consider defaulting to '(no status)'"
     },
     {
       "severity": "P3",
-      "file": "packages/envoy/cmd/listener/main.go",
-      "description": "Redundant nil check in roleSetHandler (line 227) — readiness gate already ensures deps non-nil."
+      "file": "packages/daemon/src/cli/poll-formatter.ts",
+      "description": "No test exercises the isBlocked branch in categorizeIssues"
     },
     {
       "severity": "P3",
-      "file": ".sisyphus/plans/396-role-based-routing.md",
-      "description": "Historical plan document still references old topic. Not runtime code."
+      "file": "packages/daemon/src/cli/poll-formatter.ts",
+      "description": "Low-severity terminal escape concern — issue titles printed verbatim from GitHub"
     }
   ],
-  "learningsInjected": [],
+  "learningsInjected": [
+    "docs/solutions/daemon/controller-observability.md",
+    "docs/solutions/testing/bun-fetch-mocking-patterns.md",
+    "docs/solutions/daemon/controller-lifecycle-separation.md"
+  ],
   "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-11T01:17:31.160Z"
+  "completed": "2026-04-11T01:22:11.024Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,22 +1,20 @@
 {
-  "passed": 25,
+  "passed": 6,
   "failed": 0,
   "failures": [],
-  "documentationFeedback": "PR description clearly explains the 3-part implementation. Envoy SKILL.md has well-placed role-based routing section with examples. No setup instructions needed for backend feature.",
+  "documentationFeedback": "PR description is clear and comprehensive with design decisions documented inline. No README/usage docs updated, appropriate for operator CLI. In-code comments explain blocking-before-actionable precedence.",
   "observations": [
-    "P2: 2 missing integration tests (claim with no prior holder, idempotent) — covered by unit tests but spec requested integration tests",
-    "P2: subscribeControllerToEnvoy() uses global fetch instead of injected deps.fetch — testability concern, all daemon tests log 404 for role set",
-    "1 daemon test failure (passes controller env vars to adapter.start on startup) is pre-existing on main, not caused by this PR"
+    "Empty status strings from project board render as ': 35' in SUMMARY — minor UX issue, consider '(no status): 35'",
+    "Error handling with invalid team shows stack trace instead of clean error message (consistent with other commands but suboptimal UX)",
+    "CI did not trigger on PR #402 — statusCheckRollup empty. All checks run locally: biome clean, tsc clean, 729/730 tests pass (1 pre-existing failure)",
+    "Titles not visible in live test because daemon runs pre-PR code — unit tests verify title formatting works correctly"
   ],
   "learningsInjected": [
-    "testing/nats-kv-testing-patterns.md",
-    "architecture-patterns/nats-kv-dual-bucket-lifecycle.md",
-    "envoy/listener-routing-by-topic-prefix.md"
+    "docs/solutions/daemon/controller-observability.md",
+    "docs/solutions/testing/bun-fetch-mocking-patterns.md"
   ],
-  "learningsHelpful": [
-    "testing/nats-kv-testing-patterns.md"
-  ],
+  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-11T01:08:56.995Z"
+  "completed": "2026-04-11T01:10:59.680Z"
 }

--- a/docs/solutions/daemon/state-machine-action-display-mismatch.md
+++ b/docs/solutions/daemon/state-machine-action-display-mismatch.md
@@ -1,0 +1,87 @@
+---
+title: "State Machine Actions vs Display Categories: Check Blocking Before Actionable"
+category: daemon
+tags:
+  - state-machine
+  - display-logic
+  - formatter
+  - poll
+  - testing
+date: 2026-04-11
+status: active
+module: daemon
+related_issues:
+  - "#398"
+symptoms:
+  - "stale worker-active issues appear as ACTIONABLE instead of BLOCKED"
+  - "user-input-needed issues show up in wrong section"
+  - "test passes but blocked issues not categorized correctly in production"
+---
+
+# State Machine Actions vs Display Categories: Check Blocking Before Actionable
+
+## Context
+
+When building the `legion poll` command, the formatter initially used `suggestedAction !== "skip"` as the gate for the ACTIONABLE section. This seemed correct but produced wrong output for stale `worker-active` and `user-input-needed` issues.
+
+## The Problem
+
+The state machine in `decision.ts` assigns *operationally correct* actions that don't map directly to *display categories*:
+
+| Issue State | State Machine Action | Expected Display |
+|---|---|---|
+| `user-input-needed` label, has feedback | `relay_user_feedback` | **BLOCKED** |
+| `worker-active` label, no live worker | `remove_worker_active_and_redispatch` | **BLOCKED** |
+| Normal todo issue | `dispatch_planner` | **ACTIONABLE** |
+| Completed issue | `skip` | **SUMMARY** |
+
+The first two rows have non-`skip` actions but should display as BLOCKED. A naive `action !== "skip"` check puts them in ACTIONABLE.
+
+## The Rule
+
+**When formatting state machine output for display, check label-based blocking conditions BEFORE checking `suggestedAction`.** The correct precedence is:
+
+1. `labels.includes("user-input-needed")` → BLOCKED
+2. `labels.includes("worker-active") && !hasLiveWorker` → BLOCKED
+3. `isBlocked === true` → BLOCKED
+4. `suggestedAction !== "skip"` → ACTIONABLE
+5. Everything else → SUMMARY
+
+This ordering treats blocking conditions as semantic overrides — the issue may have an actionable machine action, but from the consumer's perspective it's stuck.
+
+## Test Fixture Rule
+
+**Test fixtures for state machine consumers must match real state machine output.** The initial test used:
+
+```typescript
+// WRONG: impossible state in production
+makeIssue({
+  suggestedAction: "skip",
+  labels: ["worker-active"],
+  hasLiveWorker: false,
+})
+```
+
+The state machine never produces `suggestedAction: "skip"` for a stale worker-active issue — it produces `remove_worker_active_and_redispatch`. The test passed but didn't catch the precedence bug because the fixture modeled an impossible state.
+
+The correct fixture:
+
+```typescript
+// RIGHT: matches real state machine output
+makeIssue({
+  suggestedAction: "remove_worker_active_and_redispatch",
+  labels: ["worker-active"],
+  hasLiveWorker: false,
+})
+```
+
+**Before writing test fixtures for state machine consumers, check `decision.ts` to verify what action each scenario actually produces.**
+
+## When This Applies
+
+Any code that:
+- Formats state machine output for human consumption (CLI, dashboard, notifications)
+- Categorizes issues into groups (actionable, blocked, waiting, done)
+- Builds compact summaries from `IssueStateDict` data
+
+This does NOT apply to code that executes state machine actions (the controller), which should use `suggestedAction` directly.

--- a/docs/solutions/index.json
+++ b/docs/solutions/index.json
@@ -13,6 +13,7 @@
       "daemon/controller-retro-20h-bug-pipeline-optimization.md",
       "controller/controller-session-anti-patterns.md",
       "daemon/server-side-dispatch-validation.md"
+      "daemon/state-machine-action-display-mismatch.md"
     ],
     "packages/daemon/src/daemon/serve-manager": [
       "daemon/opencode-serve-lifecycle.md",
@@ -50,6 +51,7 @@
       "daemon/server-side-dispatch-validation.md",
       "daemon/prompt-delivery-bootstrap-delay.md",
       "daemon/handoff-schema-migration-patterns.md"
+      "daemon/state-machine-action-display-mismatch.md"
     ],
     "packages/daemon": [
       "architecture-patterns/plugin-migration-assessment.md",
@@ -253,6 +255,7 @@
     "tag:state-machine": [
       "daemon/controller-observability.md",
       "integration-issues/github-graphql-pr-draft-status.md"
+      "daemon/state-machine-action-display-mismatch.md"
     ],
     "tag:state-management": ["daemon/controller-lifecycle-separation.md"],
     "tag:subagents": ["skill-patterns/parallel-subagent-background-execution.md"],
@@ -267,6 +270,7 @@
       "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md",
       "github-api/graphql-org-user-fallback.md",
       "testing/worker-smoke-testing-requirements.md"
+      "daemon/state-machine-action-display-mismatch.md"
     ],
     "tag:tmux": ["integration-patterns/tmux-askuserquestion-navigation.md"],
     "tag:validation": ["daemon/workspace-validation-retro.md"],
@@ -405,5 +409,8 @@
     "tag:health-check": ["envoy/nats-bus-client-self-healing.md"],
     "tag:subscription": ["envoy/nats-bus-client-self-healing.md"],
     "tag:goroutine-serialization": ["envoy/nats-bus-client-self-healing.md"]
+    "tag:display-logic": ["daemon/state-machine-action-display-mismatch.md"],
+    "tag:formatter": ["daemon/state-machine-action-display-mismatch.md"],
+    "tag:poll": ["daemon/state-machine-action-display-mismatch.md"]
   }
 }

--- a/docs/superpowers/plans/2026-04-11-legion-poll-command.md
+++ b/docs/superpowers/plans/2026-04-11-legion-poll-command.md
@@ -1,0 +1,525 @@
+# `legion poll` CLI Command Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `legion poll` CLI command that calls `POST /state/fetch-and-collect` and returns a compact, controller-friendly summary of actionable issues.
+
+**Architecture:** New CLI command (`pollCommand`) in the existing citty `defineCommand` pattern. A separate `poll-formatter.ts` module handles categorization (ACTIONABLE / BLOCKED / SUMMARY) and text formatting — kept separate because `index.ts` is already 1100 lines. The daemon's fetch-and-collect response is enhanced with a `titles` map (3-line change in server.ts) so the CLI can display human-readable issue titles.
+
+**Tech Stack:** TypeScript, Bun, citty CLI framework, existing daemon HTTP API
+
+**Constraints:**
+- `POST /state/fetch-and-collect` only supports `github` backend currently — hardcode it, no `--backend` flag.
+- Formatter exports only `formatPollOutput()` — internal categorization logic stays private.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `packages/daemon/src/cli/poll-formatter.ts` | **Create.** Pure formatting: categorize issues into ACTIONABLE/BLOCKED/SUMMARY, render text. Single public export: `formatPollOutput()`. No I/O. |
+| `packages/daemon/src/cli/__tests__/poll-formatter.test.ts` | **Create.** Output-focused tests for `formatPollOutput()`. |
+| `packages/daemon/src/cli/index.ts` | **Modify.** Add `cmdPoll()`, `pollCommand`, register in `mainCommand.subCommands`. |
+| `packages/daemon/src/daemon/server.ts` | **Modify.** Add `titles` map to fetch-and-collect response (3 lines). |
+
+---
+
+### Task 1: Create poll formatter module — Independent
+
+**Files:**
+- Create: `packages/daemon/src/cli/poll-formatter.ts`
+- Create: `packages/daemon/src/cli/__tests__/poll-formatter.test.ts`
+
+Pure module (no I/O) that categorizes issues and renders text output.
+
+- [ ] **Step 1: Write failing tests for formatPollOutput**
+
+Create `packages/daemon/src/cli/__tests__/poll-formatter.test.ts`:
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { formatPollOutput } from "../poll-formatter";
+import type { IssueStateDict } from "../../state/types";
+
+function makeIssue(overrides: Partial<IssueStateDict>): IssueStateDict {
+  return {
+    status: "In Progress",
+    labels: [],
+    hasPr: false,
+    prIsDraft: null,
+    ciStatus: null,
+    mergeableStatus: null,
+    hasLiveWorker: false,
+    workerMode: null,
+    workerStatus: null,
+    suggestedAction: "skip",
+    sessionId: "ses_test",
+    hasUserFeedback: false,
+    isBlocked: false,
+    source: null,
+    ...overrides,
+  };
+}
+
+describe("formatPollOutput", () => {
+  it("renders actionable issues grouped by action with titles", () => {
+    const issues: Record<string, IssueStateDict> = {
+      "acme-repo-42": makeIssue({
+        suggestedAction: "dispatch_implementer",
+        status: "In Progress",
+        source: { owner: "acme", repo: "repo", number: 42, url: "" },
+      }),
+      "acme-repo-43": makeIssue({
+        suggestedAction: "dispatch_implementer",
+        status: "In Progress",
+        source: { owner: "acme", repo: "repo", number: 43, url: "" },
+      }),
+      "acme-repo-44": makeIssue({
+        suggestedAction: "dispatch_planner",
+        status: "Todo",
+        source: { owner: "acme", repo: "repo", number: 44, url: "" },
+      }),
+    };
+    const titles: Record<string, string> = {
+      "acme-repo-42": "Fix widget alignment",
+      "acme-repo-43": "Add dark mode",
+      "acme-repo-44": "Redesign settings page",
+    };
+
+    const output = formatPollOutput(issues, titles);
+    expect(output).toContain("ACTIONABLE (3):");
+    expect(output).toContain("dispatch_implementer:");
+    expect(output).toContain('#42  In Progress  "Fix widget alignment"');
+    expect(output).toContain("dispatch_planner:");
+    expect(output).toContain('#44  Todo  "Redesign settings page"');
+  });
+
+  it("renders blocked issues (user-input-needed, stale worker-active, dependency-blocked)", () => {
+    const issues: Record<string, IssueStateDict> = {
+      "acme-repo-50": makeIssue({
+        suggestedAction: "skip",
+        status: "In Progress",
+        labels: ["user-input-needed"],
+        source: { owner: "acme", repo: "repo", number: 50, url: "" },
+      }),
+      "acme-repo-51": makeIssue({
+        suggestedAction: "skip",
+        status: "In Progress",
+        labels: ["worker-active"],
+        hasLiveWorker: false,
+        source: { owner: "acme", repo: "repo", number: 51, url: "" },
+      }),
+    };
+    const titles: Record<string, string> = {
+      "acme-repo-50": "Zendesk ticketing",
+      "acme-repo-51": "Profile pic storage",
+    };
+
+    const output = formatPollOutput(issues, titles);
+    expect(output).toContain("BLOCKED (2):");
+    expect(output).toContain('#50  user-input-needed  "Zendesk ticketing"');
+    expect(output).toContain('#51  worker-active (stale)  "Profile pic storage"');
+  });
+
+  it("renders summary counts for non-actionable skip issues", () => {
+    const issues: Record<string, IssueStateDict> = {
+      "acme-repo-100": makeIssue({ suggestedAction: "skip", status: "Done" }),
+      "acme-repo-101": makeIssue({ suggestedAction: "skip", status: "Done" }),
+      "acme-repo-102": makeIssue({ suggestedAction: "skip", status: "Icebox" }),
+    };
+    const output = formatPollOutput(issues, {});
+    expect(output).toContain("SUMMARY:");
+    expect(output).toContain("Done: 2");
+    expect(output).toContain("Icebox: 1");
+  });
+
+  it("omits empty sections", () => {
+    const issues: Record<string, IssueStateDict> = {
+      "acme-repo-42": makeIssue({
+        suggestedAction: "dispatch_planner",
+        status: "Todo",
+      }),
+    };
+    const output = formatPollOutput(issues, {});
+    expect(output).not.toContain("BLOCKED");
+    expect(output).not.toContain("SUMMARY");
+  });
+
+  it("falls back to issueId when source is null", () => {
+    const issues: Record<string, IssueStateDict> = {
+      "acme-repo-42": makeIssue({
+        suggestedAction: "dispatch_planner",
+        status: "Todo",
+        source: null,
+      }),
+    };
+    const output = formatPollOutput(issues, {});
+    expect(output).toContain("acme-repo-42  Todo");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test packages/daemon/src/cli/__tests__/poll-formatter.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement poll-formatter.ts**
+
+Create `packages/daemon/src/cli/poll-formatter.ts`:
+
+```typescript
+import type { ActionType, IssueStateDict, IssueSource } from "../state/types";
+
+interface ActionableIssue {
+  issueId: string;
+  action: ActionType;
+  status: string;
+  source: IssueSource | null;
+}
+
+interface BlockedIssue {
+  issueId: string;
+  reason: string;
+  source: IssueSource | null;
+}
+
+interface CategorizedIssues {
+  actionable: ActionableIssue[];
+  blocked: BlockedIssue[];
+  summary: Record<string, number>;
+}
+
+function categorizeIssues(
+  issues: Record<string, IssueStateDict>,
+): CategorizedIssues {
+  const actionable: ActionableIssue[] = [];
+  const blocked: BlockedIssue[] = [];
+  const summary: Record<string, number> = {};
+
+  for (const [issueId, issue] of Object.entries(issues)) {
+    if (issue.suggestedAction !== "skip") {
+      actionable.push({
+        issueId,
+        action: issue.suggestedAction,
+        status: issue.status,
+        source: issue.source,
+      });
+      continue;
+    }
+
+    // Skip items — check for blocking conditions
+    if (issue.labels.includes("user-input-needed")) {
+      blocked.push({ issueId, reason: "user-input-needed", source: issue.source });
+      continue;
+    }
+
+    if (issue.labels.includes("worker-active") && !issue.hasLiveWorker) {
+      blocked.push({ issueId, reason: "worker-active (stale)", source: issue.source });
+      continue;
+    }
+
+    if (issue.isBlocked) {
+      blocked.push({ issueId, reason: "blocked", source: issue.source });
+      continue;
+    }
+
+    // Non-actionable, non-blocked — count in summary
+    summary[issue.status] = (summary[issue.status] ?? 0) + 1;
+  }
+
+  return { actionable, blocked, summary };
+}
+
+function issueDisplayId(issueId: string, source: IssueSource | null): string {
+  if (source?.number) {
+    return `#${source.number}`;
+  }
+  return issueId;
+}
+
+/**
+ * Format the fetch-and-collect response into a compact, controller-friendly summary.
+ *
+ * Output sections (empty sections are omitted):
+ * - ACTIONABLE: issues grouped by suggestedAction
+ * - BLOCKED: skip issues with blocking labels
+ * - SUMMARY: counts of remaining skip issues by status
+ */
+export function formatPollOutput(
+  issues: Record<string, IssueStateDict>,
+  titles: Record<string, string>,
+): string {
+  const { actionable, blocked, summary } = categorizeIssues(issues);
+  const lines: string[] = [];
+
+  // ACTIONABLE section
+  if (actionable.length > 0) {
+    lines.push(`ACTIONABLE (${actionable.length}):`);
+
+    // Group by action
+    const byAction = new Map<string, ActionableIssue[]>();
+    for (const item of actionable) {
+      const group = byAction.get(item.action) ?? [];
+      group.push(item);
+      byAction.set(item.action, group);
+    }
+
+    for (const [action, items] of byAction) {
+      lines.push(`  ${action}:`);
+      for (const item of items) {
+        const id = issueDisplayId(item.issueId, item.source);
+        const title = titles[item.issueId];
+        const titlePart = title ? `  "${title}"` : "";
+        lines.push(`    ${id}  ${item.status}${titlePart}`);
+      }
+    }
+  }
+
+  // BLOCKED section
+  if (blocked.length > 0) {
+    if (lines.length > 0) lines.push("");
+    lines.push(`BLOCKED (${blocked.length}):`);
+    for (const item of blocked) {
+      const id = issueDisplayId(item.issueId, item.source);
+      const title = titles[item.issueId];
+      const titlePart = title ? `  "${title}"` : "";
+      lines.push(`  ${id}  ${item.reason}${titlePart}`);
+    }
+  }
+
+  // SUMMARY section
+  const summaryEntries = Object.entries(summary);
+  if (summaryEntries.length > 0) {
+    if (lines.length > 0) lines.push("");
+    const parts = summaryEntries.map(([status, count]) => `${status}: ${count}`);
+    lines.push("SUMMARY:");
+    lines.push(`  ${parts.join(" | ")}`);
+  }
+
+  return lines.join("\n");
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test packages/daemon/src/cli/__tests__/poll-formatter.test.ts`
+Expected: PASS (all 5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(cli): add poll formatter module"
+jj new
+```
+
+---
+
+### Task 2: Add cmdPoll, pollCommand, and titles response — Depends on: Task 1
+
+**Files:**
+- Modify: `packages/daemon/src/cli/index.ts`
+- Modify: `packages/daemon/src/daemon/server.ts:1366`
+
+- [ ] **Step 1: Add titles to fetch-and-collect response**
+
+In `packages/daemon/src/daemon/server.ts`, modify the fetch-and-collect handler's return (around line 1366):
+
+```typescript
+// BEFORE:
+return jsonResponse(CollectedState.toDict(state));
+
+// AFTER:
+const titles: Record<string, string> = {};
+for (const [id, title] of extractGitHubIssueTitles(rawIssues)) {
+  titles[id] = title;
+}
+return jsonResponse({ ...CollectedState.toDict(state), titles });
+```
+
+- [ ] **Step 2: Add the import to index.ts**
+
+At the top of `packages/daemon/src/cli/index.ts`, add:
+```typescript
+import { formatPollOutput } from "./poll-formatter";
+```
+
+- [ ] **Step 3: Add cmdPoll function**
+
+Add after other `cmd*` functions, before the command definitions:
+
+```typescript
+export async function cmdPoll(team: string, opts: { json: boolean }): Promise<void> {
+  const legionId = await resolveLegionId(team, {});
+  const daemonPort = await getDaemonPort(legionId);
+  const baseUrl = `http://127.0.0.1:${daemonPort}`;
+
+  let response: Response;
+  try {
+    response = await fetch(`${baseUrl}/state/fetch-and-collect`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ backend: "github" }),
+    });
+  } catch (_error) {
+    throw new CliError(
+      `Could not connect to daemon. Is it running?\nTried: ${baseUrl}/state/fetch-and-collect`,
+    );
+  }
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new CliError(`Daemon returned ${response.status}: ${body}`);
+  }
+
+  const data = (await response.json()) as {
+    issues: Record<string, import("../state/types").IssueStateDict>;
+    titles?: Record<string, string>;
+  };
+
+  if (opts.json) {
+    process.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
+    return;
+  }
+
+  const output = formatPollOutput(data.issues, data.titles ?? {});
+  if (output) {
+    console.log(output);
+  } else {
+    console.log("No issues found.");
+  }
+}
+```
+
+- [ ] **Step 4: Add pollCommand definition**
+
+Add alongside other command definitions:
+
+```typescript
+export const pollCommand = defineCommand({
+  meta: { name: "poll", description: "Poll state machine for compact actionable summary" },
+  args: {
+    team: { type: "positional", description: "Legion key or UUID", required: true },
+    json: {
+      type: "boolean",
+      description: "Output raw JSON from fetch-and-collect",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    try {
+      await cmdPoll(args.team, { json: args.json });
+    } catch (e) {
+      if (e instanceof CliError) {
+        console.error(e.message);
+        process.exit(e.code);
+      }
+      throw e;
+    }
+  },
+});
+```
+
+- [ ] **Step 5: Register pollCommand in mainCommand.subCommands**
+
+In the `mainCommand` definition, add `poll: pollCommand` to `subCommands`:
+
+```typescript
+subCommands: {
+    start: startCommand,
+    stop: stopCommand,
+    status: statusCommand,
+    attach: attachCommand,
+    dispatch: dispatchCommand,
+    prompt: promptCommand,
+    "reset-crashes": resetCrashesCommand,
+    teams: legionsCommand,
+    "collect-state": collectStateCommand,
+    poll: pollCommand,
+    handoff: handoffCommand,
+},
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "feat(cli): add legion poll command with formatted and JSON output"
+jj new
+```
+
+---
+
+### Task 3: Verify — lint, typecheck, full test suite — Depends on: Task 2
+
+- [ ] **Step 1: Run Biome lint**
+
+Run: `bunx biome check src/` (cwd: `packages/daemon`)
+Expected: Clean. If formatting issues: `bunx biome check --write src/`
+
+- [ ] **Step 2: Run TypeScript type check**
+
+Run: `bunx tsc --noEmit` (cwd: `packages/daemon`)
+Expected: No type errors.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `bun test` (cwd: `packages/daemon`)
+Expected: All tests pass including the new formatter tests.
+
+- [ ] **Step 4: Commit if fixes were needed**
+
+Only if steps 1-3 required changes:
+```bash
+jj describe -m "chore: lint and type fixes for poll command"
+jj new
+```
+
+---
+
+## Testing Plan
+
+### Setup
+- `bun install` (from repo root)
+- Ensure a daemon is running: `legion start <team> -w .`
+
+### Health Check
+- `curl -s http://127.0.0.1:13370/health` returns `{"status":"ok",...}`
+- Retry for 10s before declaring failure
+
+### Verification Steps
+
+1. **Formatted output (default)**
+   - Action: `legion poll <team>`
+   - Expected: Multi-section output with ACTIONABLE, BLOCKED (if any), SUMMARY sections. Issue titles in quotes.
+   - Tool: CLI
+
+2. **JSON output**
+   - Action: `legion poll <team> --json`
+   - Expected: Raw JSON with `issues` and `titles` fields, parseable by `jq`
+   - Tool: CLI + `jq`
+
+3. **Error handling — no daemon**
+   - Action: `legion poll nonexistent-team` (with daemon stopped)
+   - Expected: Error message about daemon not reachable, non-zero exit code
+   - Tool: CLI
+
+### Tools Needed
+- CLI (`legion poll`)
+- `curl` for health check
+- `jq` for JSON validation
+
+### Skills to Invoke
+- No project-specific testing skills needed — standard CLI testing with `bun test`
+
+---
+
+## Dependency Graph
+
+```
+Task 1 (poll formatter)  ──► Task 2 (cmdPoll + titles + command) ──► Task 3 (verify)
+```
+
+- **Task 1**: Independent — pure formatter module with tests
+- **Task 2**: Depends on Task 1 — wires formatter to CLI, adds titles to daemon response
+- **Task 3**: Depends on Task 2 — final lint/typecheck/test verification

--- a/packages/daemon/src/cli/__tests__/poll-formatter.test.ts
+++ b/packages/daemon/src/cli/__tests__/poll-formatter.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "bun:test";
+import { formatPollOutput } from "../poll-formatter";
+import type { IssueStateDict } from "../../state/types";
+
+function makeIssue(overrides: Partial<IssueStateDict>): IssueStateDict {
+  return {
+    status: "In Progress",
+    labels: [],
+    hasPr: false,
+    prIsDraft: null,
+    ciStatus: null,
+    mergeableStatus: null,
+    hasLiveWorker: false,
+    workerMode: null,
+    workerStatus: null,
+    suggestedAction: "skip",
+    sessionId: "ses_test",
+    hasUserFeedback: false,
+    isBlocked: false,
+    source: null,
+    ...overrides,
+  };
+}
+
+describe("formatPollOutput", () => {
+  it("renders actionable issues grouped by action with titles", () => {
+    const issues: Record<string, IssueStateDict> = {
+      "acme-repo-42": makeIssue({
+        suggestedAction: "dispatch_implementer",
+        status: "In Progress",
+        source: { owner: "acme", repo: "repo", number: 42, url: "" },
+      }),
+      "acme-repo-43": makeIssue({
+        suggestedAction: "dispatch_implementer",
+        status: "In Progress",
+        source: { owner: "acme", repo: "repo", number: 43, url: "" },
+      }),
+      "acme-repo-44": makeIssue({
+        suggestedAction: "dispatch_planner",
+        status: "Todo",
+        source: { owner: "acme", repo: "repo", number: 44, url: "" },
+      }),
+    };
+    const titles: Record<string, string> = {
+      "acme-repo-42": "Fix widget alignment",
+      "acme-repo-43": "Add dark mode",
+      "acme-repo-44": "Redesign settings page",
+    };
+
+    const output = formatPollOutput(issues, titles);
+    expect(output).toContain("ACTIONABLE (3):");
+    expect(output).toContain("dispatch_implementer:");
+    expect(output).toContain('#42  In Progress  "Fix widget alignment"');
+    expect(output).toContain("dispatch_planner:");
+    expect(output).toContain('#44  Todo  "Redesign settings page"');
+  });
+
+  it("renders blocked issues (user-input-needed, stale worker-active, dependency-blocked)", () => {
+    const issues: Record<string, IssueStateDict> = {
+      "acme-repo-50": makeIssue({
+        suggestedAction: "skip",
+        status: "In Progress",
+        labels: ["user-input-needed"],
+        source: { owner: "acme", repo: "repo", number: 50, url: "" },
+      }),
+      "acme-repo-51": makeIssue({
+        suggestedAction: "skip",
+        status: "In Progress",
+        labels: ["worker-active"],
+        hasLiveWorker: false,
+        source: { owner: "acme", repo: "repo", number: 51, url: "" },
+      }),
+    };
+    const titles: Record<string, string> = {
+      "acme-repo-50": "Zendesk ticketing",
+      "acme-repo-51": "Profile pic storage",
+    };
+
+    const output = formatPollOutput(issues, titles);
+    expect(output).toContain("BLOCKED (2):");
+    expect(output).toContain('#50  user-input-needed  "Zendesk ticketing"');
+    expect(output).toContain('#51  worker-active (stale)  "Profile pic storage"');
+  });
+
+  it("renders summary counts for non-actionable skip issues", () => {
+    const issues: Record<string, IssueStateDict> = {
+      "acme-repo-100": makeIssue({ suggestedAction: "skip", status: "Done" }),
+      "acme-repo-101": makeIssue({ suggestedAction: "skip", status: "Done" }),
+      "acme-repo-102": makeIssue({ suggestedAction: "skip", status: "Icebox" }),
+    };
+    const output = formatPollOutput(issues, {});
+    expect(output).toContain("SUMMARY:");
+    expect(output).toContain("Done: 2");
+    expect(output).toContain("Icebox: 1");
+  });
+
+  it("omits empty sections", () => {
+    const issues: Record<string, IssueStateDict> = {
+      "acme-repo-42": makeIssue({
+        suggestedAction: "dispatch_planner",
+        status: "Todo",
+      }),
+    };
+    const output = formatPollOutput(issues, {});
+    expect(output).not.toContain("BLOCKED");
+    expect(output).not.toContain("SUMMARY");
+  });
+
+  it("falls back to issueId when source is null", () => {
+    const issues: Record<string, IssueStateDict> = {
+      "acme-repo-42": makeIssue({
+        suggestedAction: "dispatch_planner",
+        status: "Todo",
+        source: null,
+      }),
+    };
+    const output = formatPollOutput(issues, {});
+    expect(output).toContain("acme-repo-42  Todo");
+  });
+});

--- a/packages/daemon/src/cli/__tests__/poll-formatter.test.ts
+++ b/packages/daemon/src/cli/__tests__/poll-formatter.test.ts
@@ -55,16 +55,18 @@ describe("formatPollOutput", () => {
     expect(output).toContain('#44  Todo  "Redesign settings page"');
   });
 
-  it("renders blocked issues (user-input-needed, stale worker-active, dependency-blocked)", () => {
+  it("renders blocked issues (user-input-needed, stale worker-active)", () => {
     const issues: Record<string, IssueStateDict> = {
       "acme-repo-50": makeIssue({
-        suggestedAction: "skip",
+        // Real state machine: user-input-needed issues may have relay_user_feedback action
+        suggestedAction: "relay_user_feedback",
         status: "In Progress",
         labels: ["user-input-needed"],
         source: { owner: "acme", repo: "repo", number: 50, url: "" },
       }),
       "acme-repo-51": makeIssue({
-        suggestedAction: "skip",
+        // Real state machine: stale worker-active gets remove_worker_active_and_redispatch
+        suggestedAction: "remove_worker_active_and_redispatch",
         status: "In Progress",
         labels: ["worker-active"],
         hasLiveWorker: false,
@@ -80,6 +82,8 @@ describe("formatPollOutput", () => {
     expect(output).toContain("BLOCKED (2):");
     expect(output).toContain('#50  user-input-needed  "Zendesk ticketing"');
     expect(output).toContain('#51  worker-active (stale)  "Profile pic storage"');
+    // These should NOT appear in ACTIONABLE
+    expect(output).not.toContain("ACTIONABLE");
   });
 
   it("renders summary counts for non-actionable skip issues", () => {

--- a/packages/daemon/src/cli/__tests__/poll-formatter.test.ts
+++ b/packages/daemon/src/cli/__tests__/poll-formatter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { formatPollOutput } from "../poll-formatter";
 import type { IssueStateDict } from "../../state/types";
+import { formatPollOutput } from "../poll-formatter";
 
 function makeIssue(overrides: Partial<IssueStateDict>): IssueStateDict {
   return {

--- a/packages/daemon/src/cli/index.ts
+++ b/packages/daemon/src/cli/index.ts
@@ -977,7 +977,7 @@ export async function cmdPoll(team: string, opts: { json: boolean }): Promise<vo
     });
   } catch (_error) {
     throw new CliError(
-      `Could not connect to daemon. Is it running?\nTried: ${baseUrl}/state/fetch-and-collect`,
+      `Could not connect to daemon. Is it running?\nTried: ${baseUrl}/state/fetch-and-collect`
     );
   }
 

--- a/packages/daemon/src/cli/index.ts
+++ b/packages/daemon/src/cli/index.ts
@@ -18,6 +18,7 @@ import {
 import { HANDOFF_PHASES, isHandoffPhase } from "../handoff/schema";
 import type { HandoffPhase } from "../handoff/types";
 import { resolveLegionId } from "./legion-resolver";
+import { formatPollOutput } from "./poll-formatter";
 
 export class CliError extends Error {
   constructor(
@@ -962,6 +963,70 @@ export const collectStateCommand = defineCommand({
   },
 });
 
+export async function cmdPoll(team: string, opts: { json: boolean }): Promise<void> {
+  const legionId = await resolveLegionId(team, {});
+  const daemonPort = await getDaemonPort(legionId);
+  const baseUrl = `http://127.0.0.1:${daemonPort}`;
+
+  let response: Response;
+  try {
+    response = await fetch(`${baseUrl}/state/fetch-and-collect`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ backend: "github" }),
+    });
+  } catch (_error) {
+    throw new CliError(
+      `Could not connect to daemon. Is it running?\nTried: ${baseUrl}/state/fetch-and-collect`,
+    );
+  }
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new CliError(`Daemon returned ${response.status}: ${body}`);
+  }
+
+  const data = (await response.json()) as {
+    issues: Record<string, import("../state/types").IssueStateDict>;
+    titles?: Record<string, string>;
+  };
+
+  if (opts.json) {
+    process.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
+    return;
+  }
+
+  const output = formatPollOutput(data.issues, data.titles ?? {});
+  if (output) {
+    console.log(output);
+  } else {
+    console.log("No issues found.");
+  }
+}
+
+export const pollCommand = defineCommand({
+  meta: { name: "poll", description: "Poll state machine for compact actionable summary" },
+  args: {
+    team: { type: "positional", description: "Legion key or UUID", required: true },
+    json: {
+      type: "boolean",
+      description: "Output raw JSON from fetch-and-collect",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    try {
+      await cmdPoll(args.team, { json: args.json });
+    } catch (e) {
+      if (e instanceof CliError) {
+        console.error(e.message);
+        process.exit(e.code);
+      }
+      throw e;
+    }
+  },
+});
+
 export const handoffCommand = defineCommand({
   meta: { name: "handoff", description: "Read and write local handoff files" },
   subCommands: {
@@ -1091,6 +1156,7 @@ export const mainCommand = defineCommand({
     "reset-crashes": resetCrashesCommand,
     teams: legionsCommand,
     "collect-state": collectStateCommand,
+    poll: pollCommand,
     handoff: handoffCommand,
   },
 });

--- a/packages/daemon/src/cli/poll-formatter.ts
+++ b/packages/daemon/src/cli/poll-formatter.ts
@@ -25,17 +25,9 @@ function categorizeIssues(issues: Record<string, IssueStateDict>): CategorizedIs
   const summary: Record<string, number> = {};
 
   for (const [issueId, issue] of Object.entries(issues)) {
-    if (issue.suggestedAction !== "skip") {
-      actionable.push({
-        issueId,
-        action: issue.suggestedAction,
-        status: issue.status,
-        source: issue.source,
-      });
-      continue;
-    }
-
-    // Skip items — check for blocking conditions
+    // Check blocking conditions FIRST — these take precedence over suggestedAction
+    // because the state machine may assign actionable actions (e.g., remove_worker_active_and_redispatch)
+    // to issues that should appear as blocked in the poll summary.
     if (issue.labels.includes("user-input-needed")) {
       blocked.push({ issueId, reason: "user-input-needed", source: issue.source });
       continue;
@@ -48,6 +40,17 @@ function categorizeIssues(issues: Record<string, IssueStateDict>): CategorizedIs
 
     if (issue.isBlocked) {
       blocked.push({ issueId, reason: "blocked", source: issue.source });
+      continue;
+    }
+
+    // Non-blocked items: actionable if not skip, otherwise summary
+    if (issue.suggestedAction !== "skip") {
+      actionable.push({
+        issueId,
+        action: issue.suggestedAction,
+        status: issue.status,
+        source: issue.source,
+      });
       continue;
     }
 
@@ -84,7 +87,7 @@ export function formatPollOutput(
   if (actionable.length > 0) {
     lines.push(`ACTIONABLE (${actionable.length}):`);
 
-    // Group by action
+    // Group by action and sort for stable output
     const byAction = new Map<string, ActionableIssue[]>();
     for (const item of actionable) {
       const group = byAction.get(item.action) ?? [];
@@ -92,7 +95,9 @@ export function formatPollOutput(
       byAction.set(item.action, group);
     }
 
-    for (const [action, items] of byAction) {
+    for (const [action, items] of [...byAction.entries()].sort((a, b) =>
+      a[0].localeCompare(b[0])
+    )) {
       lines.push(`  ${action}:`);
       for (const item of items) {
         const id = issueDisplayId(item.issueId, item.source);
@@ -116,7 +121,7 @@ export function formatPollOutput(
   }
 
   // SUMMARY section
-  const summaryEntries = Object.entries(summary);
+  const summaryEntries = Object.entries(summary).sort((a, b) => a[0].localeCompare(b[0]));
   if (summaryEntries.length > 0) {
     if (lines.length > 0) lines.push("");
     const parts = summaryEntries.map(([status, count]) => `${status}: ${count}`);

--- a/packages/daemon/src/cli/poll-formatter.ts
+++ b/packages/daemon/src/cli/poll-formatter.ts
@@ -1,0 +1,128 @@
+import type { ActionType, IssueSource, IssueStateDict } from "../state/types";
+
+interface ActionableIssue {
+  issueId: string;
+  action: ActionType;
+  status: string;
+  source: IssueSource | null;
+}
+
+interface BlockedIssue {
+  issueId: string;
+  reason: string;
+  source: IssueSource | null;
+}
+
+interface CategorizedIssues {
+  actionable: ActionableIssue[];
+  blocked: BlockedIssue[];
+  summary: Record<string, number>;
+}
+
+function categorizeIssues(issues: Record<string, IssueStateDict>): CategorizedIssues {
+  const actionable: ActionableIssue[] = [];
+  const blocked: BlockedIssue[] = [];
+  const summary: Record<string, number> = {};
+
+  for (const [issueId, issue] of Object.entries(issues)) {
+    if (issue.suggestedAction !== "skip") {
+      actionable.push({
+        issueId,
+        action: issue.suggestedAction,
+        status: issue.status,
+        source: issue.source,
+      });
+      continue;
+    }
+
+    // Skip items — check for blocking conditions
+    if (issue.labels.includes("user-input-needed")) {
+      blocked.push({ issueId, reason: "user-input-needed", source: issue.source });
+      continue;
+    }
+
+    if (issue.labels.includes("worker-active") && !issue.hasLiveWorker) {
+      blocked.push({ issueId, reason: "worker-active (stale)", source: issue.source });
+      continue;
+    }
+
+    if (issue.isBlocked) {
+      blocked.push({ issueId, reason: "blocked", source: issue.source });
+      continue;
+    }
+
+    // Non-actionable, non-blocked — count in summary
+    summary[issue.status] = (summary[issue.status] ?? 0) + 1;
+  }
+
+  return { actionable, blocked, summary };
+}
+
+function issueDisplayId(issueId: string, source: IssueSource | null): string {
+  if (source?.number) {
+    return `#${source.number}`;
+  }
+  return issueId;
+}
+
+/**
+ * Format the fetch-and-collect response into a compact, controller-friendly summary.
+ *
+ * Output sections (empty sections are omitted):
+ * - ACTIONABLE: issues grouped by suggestedAction
+ * - BLOCKED: skip issues with blocking labels
+ * - SUMMARY: counts of remaining skip issues by status
+ */
+export function formatPollOutput(
+  issues: Record<string, IssueStateDict>,
+  titles: Record<string, string>
+): string {
+  const { actionable, blocked, summary } = categorizeIssues(issues);
+  const lines: string[] = [];
+
+  // ACTIONABLE section
+  if (actionable.length > 0) {
+    lines.push(`ACTIONABLE (${actionable.length}):`);
+
+    // Group by action
+    const byAction = new Map<string, ActionableIssue[]>();
+    for (const item of actionable) {
+      const group = byAction.get(item.action) ?? [];
+      group.push(item);
+      byAction.set(item.action, group);
+    }
+
+    for (const [action, items] of byAction) {
+      lines.push(`  ${action}:`);
+      for (const item of items) {
+        const id = issueDisplayId(item.issueId, item.source);
+        const title = titles[item.issueId];
+        const titlePart = title ? `  "${title}"` : "";
+        lines.push(`    ${id}  ${item.status}${titlePart}`);
+      }
+    }
+  }
+
+  // BLOCKED section
+  if (blocked.length > 0) {
+    if (lines.length > 0) lines.push("");
+    lines.push(`BLOCKED (${blocked.length}):`);
+    for (const item of blocked) {
+      const id = issueDisplayId(item.issueId, item.source);
+      const title = titles[item.issueId];
+      const titlePart = title ? `  "${title}"` : "";
+      lines.push(`  ${id}  ${item.reason}${titlePart}`);
+    }
+  }
+
+  // SUMMARY section
+  const summaryEntries = Object.entries(summary);
+  if (summaryEntries.length > 0) {
+    if (lines.length > 0) lines.push("");
+    const parts = summaryEntries.map(([status, count]) => `${status}: ${count}`);
+    lines.push("SUMMARY:");
+    lines.push(`  ${parts.join(" | ")}`);
+  }
+
+  return lines.join("\n");
+}

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -1349,11 +1349,15 @@ export function startServer(opts: ServerOptions): {
               issueStateCache.set(issueId.toLowerCase(), issueState);
             }
 
-            // Populate issue title cache from raw GitHub project items
-            if (backend === "github" && rawIssues) {
-              for (const [id, title] of extractGitHubIssueTitles(rawIssues)) {
-                issueTitleCache.set(id, title);
-              }
+            // Extract titles from raw GitHub project items
+            const extractedTitles =
+              backend === "github" && rawIssues
+                ? extractGitHubIssueTitles(rawIssues)
+                : new Map<string, string>();
+
+            // Populate issue title cache
+            for (const [id, title] of extractedTitles) {
+              issueTitleCache.set(id, title);
             }
 
             cleanupDoneIssueWorkers(state).catch((err) =>
@@ -1363,7 +1367,10 @@ export function startServer(opts: ServerOptions): {
               )
             );
 
-            return jsonResponse(CollectedState.toDict(state));
+            return jsonResponse({
+              ...CollectedState.toDict(state),
+              titles: Object.fromEntries(extractedTitles),
+            });
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             console.error(`[fetch-and-collect] backend=${backend} error=${message}`);

--- a/packages/daemon/src/state/types.ts
+++ b/packages/daemon/src/state/types.ts
@@ -411,7 +411,7 @@ export interface FetchedIssueData {
 /**
  * Serialized form of IssueState.
  */
-interface IssueStateDict {
+export interface IssueStateDict {
   status: IssueStatusLiteral | string;
   labels: string[];
   hasPr: boolean;


### PR DESCRIPTION
Closes #398

## Summary

Add a `legion poll` CLI command that calls `POST /state/fetch-and-collect` internally and returns a compact, controller-friendly summary of actionable issues — reducing context window usage from raw JSON to a few lines.

### Output format
```
ACTIONABLE (7):
  dispatch_implementer:
    #42  In Progress  "Fix widget alignment"
  dispatch_planner:
    #44  Todo  "Redesign settings page"

BLOCKED (2):
  #50  user-input-needed  "Zendesk ticketing"
  #51  worker-active (stale)  "Profile pic storage"

SUMMARY:
  Done: 45 | Icebox: 8
```

### Changes
- **New:** `packages/daemon/src/cli/poll-formatter.ts` — pure formatter module (no I/O), categorizes issues into ACTIONABLE/BLOCKED/SUMMARY
- **New:** `packages/daemon/src/cli/__tests__/poll-formatter.test.ts` — 5 tests with realistic state machine fixtures
- **Modified:** `packages/daemon/src/cli/index.ts` — `cmdPoll()`, `pollCommand`, registered in `mainCommand.subCommands`
- **Modified:** `packages/daemon/src/daemon/server.ts` — added `titles` map to fetch-and-collect response (backward-compatible additive field)
- **Modified:** `packages/daemon/src/state/types.ts` — exported `IssueStateDict` for formatter type safety

### Design decisions
- Blocking conditions (user-input-needed, stale worker-active) are checked BEFORE suggestedAction to correctly classify issues the state machine gives actionable actions to (e.g., `remove_worker_active_and_redispatch`)
- Output is deterministically sorted (action groups alphabetically, summary alphabetically) for stable controller consumption
- Backend hardcoded to `github` since `fetch-and-collect` only supports that currently
- `--json` flag passes through raw fetch-and-collect response for programmatic use