### PR TITLE
sjawhar-legion-405: fix issue number extraction from compound issue IDs

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,31 +1,23 @@
 {
   "filesChanged": [
-    "packages/daemon/src/cli/poll-formatter.ts",
-    "packages/daemon/src/cli/__tests__/poll-formatter.test.ts",
-    "packages/daemon/src/cli/index.ts",
     "packages/daemon/src/daemon/server.ts",
-    "packages/daemon/src/state/types.ts"
+    "packages/daemon/src/daemon/__tests__/server.test.ts"
   ],
   "trickyParts": [
-    "Blocking conditions (user-input-needed, stale worker-active) must be checked BEFORE suggestedAction in the formatter — the state machine assigns non-skip actions like remove_worker_active_and_redispatch to stale workers, which would appear as ACTIONABLE without this precedence",
-    "IssueStateDict was not exported from types.ts — needed to export it for the formatter to type-check against, which is a minor cross-module coupling (acceptable given existing patterns)"
+    "Brace nesting required extra closing } for the new if (match) block — original code had 2 levels (startsWith + isInteger), new code has 3 levels (startsWith + match + isInteger)"
   ],
   "deviations": [
-    "Exported IssueStateDict from types.ts — plan referenced it in imports but it was not exported (prerequisite not in plan)",
-    "Refactored title extraction in server.ts to avoid double extraction — plan showed re-calling extractGitHubIssueTitles, implementation stores the Map and reuses it",
-    "CI checks never triggered on this PR despite workflow files existing — local verification (biome, tsc, bun test) passed; CI may need to be checked manually by tester/reviewer"
+    "Added 2 additional edge case tests (owner-repo-0, owner-repo-123abc) from cross-family review findings — plan only specified compound ID and no-digits tests",
+    "Updated comment in server.ts to reflect broader {owner}-{repo}-{number}[-{slug}] format"
   ],
-  "openQuestions": [
-    "CI did not trigger on PR #402 — may be a runner availability or repo configuration issue",
-    "1 pre-existing test failure in daemon/__tests__/index.test.ts (passes controller env vars to adapter.start on startup) — unrelated to poll changes"
-  ],
+  "openQuestions": [],
   "subPlanningNeeded": false,
   "learningsInjected": [
-    "docs/solutions/daemon/controller-observability.md",
+    "docs/solutions/daemon/server-side-dispatch-validation.md",
     "docs/solutions/testing/bun-fetch-mocking-patterns.md"
   ],
   "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-11T01:03:17.869Z"
+  "completed": "2026-04-11T02:54:54.282Z"
 }

--- a/.legion/plan.json
+++ b/.legion/plan.json
@@ -2,20 +2,20 @@
   "taskCount": 3,
   "independentTasks": 1,
   "routingHints": {
-    "complexity": "medium",
+    "complexity": "small",
     "estimatedImplementers": 1,
     "skipRetro": true,
     "skipArchitect": true
   },
   "concerns": [
-    "Titles require 3-line server.ts change — technically crosses daemon boundary but backward-compatible",
-    "cmdPoll tests mock global fetch — fragile if resolveLegionId or getDaemonPort have side effects in test env",
-    "IssueStateDict type import in poll-formatter.ts couples CLI to state module — acceptable given existing pattern"
+    "Regex change must not break simple {owner}-{repo}-{number} format — regression test exists at server.test.ts:1762",
+    "owner-repo-0 must remain invalid (preserve > 0 check)",
+    "owner-repo-123abc must NOT match (digits not followed by - or $)"
   ],
-  "learningsInjected": ["docs/solutions/daemon/controller-observability.md"],
-  "learningsHelpful": ["docs/solutions/daemon/controller-observability.md"],
-  "workflowRecommendation": "Simple feature — single implementer, skip architect. Tasks 1 is independent, Tasks 2-3 are sequential.",
+  "learningsInjected": [],
+  "learningsHelpful": [],
+  "workflowRecommendation": "Simple bug fix — single implementer, skip retro. Task 1 is independent, Tasks 2-3 are sequential.",
   "schemaVersion": 1,
   "phase": "plan",
-  "completed": "2026-04-11T00:45:30.626Z"
+  "completed": "2026-04-11T02:40:58.741Z"
 }

--- a/.legion/retro.json
+++ b/.legion/retro.json
@@ -1,9 +1,7 @@
 {
-  "skipped": false,
-  "docsCreated": [
-    "docs/solutions/daemon/state-machine-action-display-mismatch.md"
-  ],
+  "skipped": true,
+  "reason": "no significant learnings — mechanical regex fix",
   "schemaVersion": 1,
   "phase": "retro",
-  "completed": "2026-04-11T01:27:27.039Z"
+  "completed": "2026-04-11T03:21:28.289Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,32 +1,14 @@
 {
   "critical": 0,
   "important": 0,
-  "minor": 3,
+  "minor": 0,
   "verdict": "approved",
-  "keyFindings": [
-    {
-      "severity": "P3",
-      "file": "packages/daemon/src/cli/poll-formatter.ts",
-      "description": "Empty status strings render as ': 35' in SUMMARY — consider defaulting to '(no status)'"
-    },
-    {
-      "severity": "P3",
-      "file": "packages/daemon/src/cli/poll-formatter.ts",
-      "description": "No test exercises the isBlocked branch in categorizeIssues"
-    },
-    {
-      "severity": "P3",
-      "file": "packages/daemon/src/cli/poll-formatter.ts",
-      "description": "Low-severity terminal escape concern — issue titles printed verbatim from GitHub"
-    }
-  ],
+  "keyFindings": [],
   "learningsInjected": [
-    "docs/solutions/daemon/controller-observability.md",
-    "docs/solutions/testing/bun-fetch-mocking-patterns.md",
-    "docs/solutions/daemon/controller-lifecycle-separation.md"
+    "docs/solutions/daemon/server-side-dispatch-validation.md"
   ],
   "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-11T01:22:11.024Z"
+  "completed": "2026-04-11T03:18:23.876Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,20 +1,19 @@
 {
-  "passed": 6,
+  "passed": 5,
   "failed": 0,
   "failures": [],
-  "documentationFeedback": "PR description is clear and comprehensive with design decisions documented inline. No README/usage docs updated, appropriate for operator CLI. In-code comments explain blocking-before-actionable precedence.",
+  "documentationFeedback": "PR description is clear and comprehensive — documents root cause, fix approach, and all test scenarios. Updated comment in server.ts accurately reflects new format support. No user-facing docs needed for this internal daemon fix.",
   "observations": [
-    "Empty status strings from project board render as ': 35' in SUMMARY — minor UX issue, consider '(no status): 35'",
-    "Error handling with invalid team shows stack trace instead of clean error message (consistent with other commands but suboptimal UX)",
-    "CI did not trigger on PR #402 — statusCheckRollup empty. All checks run locally: biome clean, tsc clean, 729/730 tests pass (1 pre-existing failure)",
-    "Titles not visible in live test because daemon runs pre-PR code — unit tests verify title formatting works correctly"
+    "Bun --filter flag runs all 119 tests regardless of filter value — tests themselves verified correct by reading code and confirming assertions",
+    "All test runs consistent across 6 executions — no flakiness",
+    "New tests don't verify Envoy subscription for compound IDs — acceptable since Envoy depends on issueNumber being set (which IS verified) and separate pre-existing test covers Envoy-skip"
   ],
   "learningsInjected": [
-    "docs/solutions/daemon/controller-observability.md",
+    "docs/solutions/daemon/server-side-dispatch-validation.md",
     "docs/solutions/testing/bun-fetch-mocking-patterns.md"
   ],
   "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-11T01:10:59.680Z"
+  "completed": "2026-04-11T03:07:12.583Z"
 }

--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -1799,6 +1799,100 @@ describe("daemon server", () => {
       expect(planWorker?.issueNumber).toBe(44);
     });
 
+    it("auto-extracts issueNumber from compound issueId with trailing slug", async () => {
+      await startTestServer({ paths: repoPaths, repoManagerDeps });
+
+      const response = await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({
+          issueId: "acme-widgets-44-calendar-email-expense-review",
+          mode: "implement",
+          repo: "acme/widgets",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const workerRes = await requestJson("/workers");
+      const workers = (await workerRes.json()) as Array<{
+        id: string;
+        issueNumber?: number;
+      }>;
+      const worker = workers.find(
+        (w) => w.id === "acme-widgets-44-calendar-email-expense-review-implement"
+      );
+      expect(worker?.issueNumber).toBe(44);
+    });
+
+    it("does not extract issueNumber when no leading digits after prefix", async () => {
+      await startTestServer({ paths: repoPaths, repoManagerDeps });
+
+      const response = await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({
+          issueId: "acme-widgets-calendar",
+          mode: "implement",
+          repo: "acme/widgets",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const workerRes = await requestJson("/workers");
+      const workers = (await workerRes.json()) as Array<{
+        id: string;
+        issueNumber?: number;
+      }>;
+      const worker = workers.find((w) => w.id === "acme-widgets-calendar-implement");
+      expect(worker?.issueNumber).toBeUndefined();
+    });
+
+    it("does not extract issueNumber when issue number is zero", async () => {
+      await startTestServer({ paths: repoPaths, repoManagerDeps });
+
+      const response = await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({
+          issueId: "acme-widgets-0",
+          mode: "implement",
+          repo: "acme/widgets",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const workerRes = await requestJson("/workers");
+      const workers = (await workerRes.json()) as Array<{
+        id: string;
+        issueNumber?: number;
+      }>;
+      const worker = workers.find((w) => w.id === "acme-widgets-0-implement");
+      expect(worker?.issueNumber).toBeUndefined();
+    });
+
+    it("does not extract issueNumber when digits are followed by letters", async () => {
+      await startTestServer({ paths: repoPaths, repoManagerDeps });
+
+      const response = await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({
+          issueId: "acme-widgets-123abc",
+          mode: "implement",
+          repo: "acme/widgets",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const workerRes = await requestJson("/workers");
+      const workers = (await workerRes.json()) as Array<{
+        id: string;
+        issueNumber?: number;
+      }>;
+      const worker = workers.find((w) => w.id === "acme-widgets-123abc-implement");
+      expect(worker?.issueNumber).toBeUndefined();
+    });
+
     it("skips Envoy subscribe when issueNumber is absent", async () => {
       const envoySubscribeCalls: EnvoySubscribeCall[] = [];
       mockFetchForEnvoy(envoySubscribeCalls);

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -665,14 +665,17 @@ export function startServer(opts: ServerOptions): {
             let resolvedWorkspace: string | null = null;
             const repoRef = typeof repo === "string" ? parseIssueRepo(repo) : null;
             // Auto-extract issueNumber from issueId when not explicitly provided.
-            // GitHub issue IDs follow the format {owner}-{repo}-{number}.
+            // GitHub issue IDs follow the format {owner}-{repo}-{number}[-{slug}].
             if (issueNumber === undefined && repoRef) {
               const prefix = `${repoRef.owner}-${repoRef.repo}-`.toLowerCase();
               if (normalizedIssueId.startsWith(prefix)) {
-                const numStr = normalizedIssueId.slice(prefix.length);
-                const parsed = Number(numStr);
-                if (Number.isInteger(parsed) && parsed > 0) {
-                  issueNumber = parsed;
+                const remainder = normalizedIssueId.slice(prefix.length);
+                const match = remainder.match(/^(\d+)(?:-|$)/);
+                if (match) {
+                  const parsed = Number(match[1]);
+                  if (Number.isInteger(parsed) && parsed > 0) {
+                    issueNumber = parsed;
+                  }
                 }
               }
             }


### PR DESCRIPTION
Closes #405

## Summary

The auto-extraction logic in `POST /workers` used `Number()` on the entire remainder after slicing the `{owner}-{repo}-` prefix from the issue ID. For compound IDs with trailing slugs (e.g., `trajectory-labs-pbc-agent-c-9958-calendar-email-expense-review-banking-exfil-benign`), the remainder `9958-calendar-email-...` evaluates to `NaN` via `Number()`, leaving `issueNumber` undefined.

**Fix:** Switch to regex matching `/^(\d+)(?:-|$)/` which extracts only leading digits followed by a hyphen or end-of-string.

**Tests added:**
- Compound ID extraction (`acme-widgets-44-calendar-email-expense-review` → `issueNumber: 44`)
- No leading digits (`acme-widgets-calendar` → `issueNumber: undefined`)
- Zero issue number (`acme-widgets-0` → `issueNumber: undefined`, preserves `> 0` guard)
- Digits followed by letters (`acme-widgets-123abc` → `issueNumber: undefined`)

All 119 tests pass. Biome and tsc clean.