### PR TITLE
sjawhar-legion-114: add blockedByIds to state pipeline with full blocker references

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,23 +1,38 @@
 {
   "filesChanged": [
-    "packages/daemon/src/daemon/server.ts",
-    "packages/daemon/src/daemon/__tests__/server.test.ts"
+    "packages/daemon/src/state/types.ts",
+    "packages/daemon/src/state/github-fetch.ts",
+    "packages/daemon/src/state/backends/github.ts",
+    "packages/daemon/src/state/fetch.ts",
+    "packages/daemon/src/state/decision.ts",
+    "packages/daemon/src/cli/poll-formatter.ts",
+    "packages/daemon/src/state/__tests__/github-fetch.test.ts",
+    "packages/daemon/src/state/backends/__tests__/github.test.ts",
+    "packages/daemon/src/state/__tests__/decision.test.ts",
+    "packages/daemon/src/state/__tests__/decision-regressions.test.ts",
+    "packages/daemon/src/cli/__tests__/poll-formatter.test.ts",
+    "packages/daemon/src/__tests__/integration.test.ts"
   ],
   "trickyParts": [
-    "Brace nesting required extra closing } for the new if (match) block — original code had 2 levels (startsWith + isInteger), new code has 3 levels (startsWith + match + isInteger)"
+    "createParsedIssue() parameter changed from isBlocked:boolean to blockedByIds:string[] — all callers and test fixtures needed updating",
+    "FetchedIssueData.isBlocked changed from optional to required — test fixtures across 4 files needed blockedByIds:[] and isBlocked:false added",
+    "blockerRefs extracted in nodeToProjectItem() must filter to OPEN-only before passing to backend parser"
   ],
   "deviations": [
-    "Added 2 additional edge case tests (owner-repo-0, owner-repo-123abc) from cross-family review findings — plan only specified compound ID and no-digits tests",
-    "Updated comment in server.ts to reflect broader {owner}-{repo}-{number}[-{slug}] format"
+    "issueDependenciesSummary kept alongside blockedBy connection per plan — not removed in this PR"
   ],
   "openQuestions": [],
   "subPlanningNeeded": false,
   "learningsInjected": [
-    "docs/solutions/daemon/server-side-dispatch-validation.md",
-    "docs/solutions/testing/bun-fetch-mocking-patterns.md"
+    "docs/solutions/integration-issues/github-graphql-pr-draft-status.md",
+    "docs/solutions/github-api/graphql-org-user-fallback.md",
+    "docs/solutions/daemon/controller-observability.md"
   ],
-  "learningsHelpful": [],
+  "learningsHelpful": [
+    "docs/solutions/integration-issues/github-graphql-pr-draft-status.md",
+    "docs/solutions/github-api/graphql-org-user-fallback.md"
+  ],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-11T02:54:54.282Z"
+  "completed": "2026-04-11T03:25:22.808Z"
 }

--- a/.legion/retro.json
+++ b/.legion/retro.json
@@ -1,7 +1,7 @@
 {
   "skipped": true,
-  "reason": "no significant learnings — mechanical regex fix",
+  "reason": "no significant learnings — clean pipeline extension following established patterns",
   "schemaVersion": 1,
   "phase": "retro",
-  "completed": "2026-04-11T03:21:28.289Z"
+  "completed": "2026-04-11T03:52:17.269Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,14 +1,35 @@
 {
   "critical": 0,
   "important": 0,
-  "minor": 0,
+  "minor": 3,
   "verdict": "approved",
-  "keyFindings": [],
-  "learningsInjected": [
-    "docs/solutions/daemon/server-side-dispatch-validation.md"
+  "keyFindings": [
+    {
+      "severity": "P3",
+      "file": "packages/daemon/src/state/decision.ts",
+      "description": "Redundant null coalescing on blockedByIds and isBlocked — both are required fields on FetchedIssueData"
+    },
+    {
+      "severity": "P3",
+      "file": "packages/daemon/src/cli/poll-formatter.ts",
+      "description": "Redundant optional chaining on blockedByIds — required string[] on IssueStateDict"
+    },
+    {
+      "severity": "P3",
+      "file": "packages/daemon/src/cli/__tests__/poll-formatter.test.ts",
+      "description": "Test fixture with impossible state (isBlocked: false + non-empty blockedByIds) — needs clarifying comment"
+    }
   ],
-  "learningsHelpful": [],
+  "learningsInjected": [
+    "docs/solutions/integration-issues/github-graphql-pr-draft-status.md",
+    "docs/solutions/github-api/graphql-org-user-fallback.md",
+    "docs/solutions/daemon/controller-observability.md"
+  ],
+  "learningsHelpful": [
+    "docs/solutions/integration-issues/github-graphql-pr-draft-status.md",
+    "docs/solutions/github-api/graphql-org-user-fallback.md"
+  ],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-11T03:18:23.876Z"
+  "completed": "2026-04-11T03:46:49.900Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,19 +1,23 @@
 {
-  "passed": 5,
+  "passed": 10,
   "failed": 0,
   "failures": [],
-  "documentationFeedback": "PR description is clear and comprehensive — documents root cause, fix approach, and all test scenarios. Updated comment in server.ts accurately reflects new format support. No user-facing docs needed for this internal daemon fix.",
+  "documentationFeedback": "PR description is clear and comprehensive. Code comments explain extraction and filtering logic. No README/usage docs needed for internal pipeline extension.",
   "observations": [
-    "Bun --filter flag runs all 119 tests regardless of filter value — tests themselves verified correct by reading code and confirming assertions",
-    "All test runs consistent across 6 executions — no flakiness",
-    "New tests don't verify Envoy subscription for compound IDs — acceptable since Envoy depends on issueNumber being set (which IS verified) and separate pre-existing test covers Envoy-skip"
+    "P2: No single end-to-end pipeline test for blocked issues (AC9 verified piecemeal across 4 test files)",
+    "P3: poll-formatter test uses impossible fixture state (blockedByIds non-empty but isBlocked: false)",
+    "P3: FetchedIssueData test fixtures set isBlocked independently from blockedByIds",
+    "issueDependenciesSummary retained alongside blockedBy connection (intentional per plan, follow-on cleanup)",
+    "Defensive null-coalescing in decision.ts redundant but harmless"
   ],
   "learningsInjected": [
-    "docs/solutions/daemon/server-side-dispatch-validation.md",
-    "docs/solutions/testing/bun-fetch-mocking-patterns.md"
+    "docs/solutions/daemon/state-machine-action-display-mismatch.md",
+    "docs/solutions/integration-issues/github-graphql-pr-draft-status.md"
   ],
-  "learningsHelpful": [],
+  "learningsHelpful": [
+    "docs/solutions/daemon/state-machine-action-display-mismatch.md"
+  ],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-11T03:07:12.583Z"
+  "completed": "2026-04-11T03:37:21.835Z"
 }

--- a/packages/daemon/src/__tests__/integration.test.ts
+++ b/packages/daemon/src/__tests__/integration.test.ts
@@ -154,6 +154,8 @@ describe("Integration: state pipeline", () => {
         hasHumanApproved: false,
         hasTestPassed: false,
         hasTestFailed: false,
+        blockedByIds: [],
+        isBlocked: false,
         source: null,
       },
       {
@@ -173,6 +175,8 @@ describe("Integration: state pipeline", () => {
         hasHumanApproved: false,
         hasTestPassed: false,
         hasTestFailed: false,
+        blockedByIds: [],
+        isBlocked: false,
         source: null,
       },
     ];

--- a/packages/daemon/src/cli/__tests__/poll-formatter.test.ts
+++ b/packages/daemon/src/cli/__tests__/poll-formatter.test.ts
@@ -17,6 +17,7 @@ function makeIssue(overrides: Partial<IssueStateDict>): IssueStateDict {
     sessionId: "ses_test",
     hasUserFeedback: false,
     isBlocked: false,
+    blockedByIds: [],
     source: null,
     ...overrides,
   };
@@ -120,5 +121,51 @@ describe("formatPollOutput", () => {
     };
     const output = formatPollOutput(issues, {});
     expect(output).toContain("acme-repo-42  Todo");
+  });
+
+  it("renders blocker IDs for blocked issues", () => {
+    const issues: Record<string, IssueStateDict> = {
+      "sjawhar-legion-114": makeIssue({
+        isBlocked: true,
+        blockedByIds: ["sjawhar-legion-110", "sjawhar-legion-112"],
+        source: { owner: "sjawhar", repo: "legion", number: 114, url: "" },
+      }),
+    };
+
+    const output = formatPollOutput(issues, { "sjawhar-legion-114": "Track blockers" });
+
+    expect(output).toContain("blocked by sjawhar-legion-110, sjawhar-legion-112");
+  });
+
+  it("falls back to generic blocked text when blocker IDs are unavailable", () => {
+    const issues: Record<string, IssueStateDict> = {
+      "sjawhar-legion-115": makeIssue({
+        isBlocked: true,
+        blockedByIds: [],
+        source: { owner: "sjawhar", repo: "legion", number: 115, url: "" },
+      }),
+    };
+
+    const output = formatPollOutput(issues, {});
+
+    expect(output).toContain("#115  blocked");
+    expect(output).not.toContain("blocked by");
+  });
+
+  it("does not render blocker text for non-blocked issues", () => {
+    const issues: Record<string, IssueStateDict> = {
+      "sjawhar-legion-116": makeIssue({
+        suggestedAction: "dispatch_implementer",
+        isBlocked: false,
+        blockedByIds: ["sjawhar-legion-110"],
+        source: { owner: "sjawhar", repo: "legion", number: 116, url: "" },
+      }),
+    };
+
+    const output = formatPollOutput(issues, { "sjawhar-legion-116": "Implement feature" });
+
+    expect(output).not.toContain("blocked by");
+    expect(output).not.toContain("#116  blocked");
+    expect(output).toContain('#116  In Progress  "Implement feature"');
   });
 });

--- a/packages/daemon/src/cli/poll-formatter.ts
+++ b/packages/daemon/src/cli/poll-formatter.ts
@@ -39,7 +39,9 @@ function categorizeIssues(issues: Record<string, IssueStateDict>): CategorizedIs
     }
 
     if (issue.isBlocked) {
-      blocked.push({ issueId, reason: "blocked", source: issue.source });
+      const blockerList = issue.blockedByIds?.join(", ") ?? "";
+      const reason = blockerList ? `blocked by ${blockerList}` : "blocked";
+      blocked.push({ issueId, reason, source: issue.source });
       continue;
     }
 

--- a/packages/daemon/src/state/__tests__/decision-regressions.test.ts
+++ b/packages/daemon/src/state/__tests__/decision-regressions.test.ts
@@ -21,6 +21,8 @@ describe("decision regressions (known pipeline stalls)", () => {
       hasHumanApproved: false,
       hasTestPassed: false,
       hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
       source: null,
     };
 
@@ -46,6 +48,8 @@ describe("decision regressions (known pipeline stalls)", () => {
       hasHumanApproved: false,
       hasTestPassed: false,
       hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
       source: null,
     };
 

--- a/packages/daemon/src/state/__tests__/decision.test.ts
+++ b/packages/daemon/src/state/__tests__/decision.test.ts
@@ -448,6 +448,8 @@ describe("buildIssueState", () => {
       hasHumanApproved: false,
       hasTestPassed: false,
       hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
       source: null,
     };
 
@@ -473,6 +475,8 @@ describe("buildIssueState", () => {
       hasHumanApproved: false,
       hasTestPassed: false,
       hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
       source: null,
     };
     const state = buildIssueState(data, "00000000-0000-0000-0000-000000000000");
@@ -497,6 +501,8 @@ describe("buildIssueState", () => {
       hasHumanApproved: false,
       hasTestPassed: false,
       hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
       source: null,
     };
 
@@ -522,6 +528,8 @@ describe("buildIssueState", () => {
       hasHumanApproved: false,
       hasTestPassed: false,
       hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
       source: null,
     };
 
@@ -547,6 +555,8 @@ describe("buildIssueState", () => {
       hasHumanApproved: false,
       hasTestPassed: false,
       hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
       source: null,
     };
 
@@ -573,6 +583,8 @@ describe("buildIssueState", () => {
       hasHumanApproved: false,
       hasTestPassed: false,
       hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
       source: null,
     };
 
@@ -602,6 +614,8 @@ describe("buildIssueState", () => {
       hasHumanApproved: false,
       hasTestPassed: false,
       hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
       source: null,
     };
 
@@ -632,6 +646,8 @@ describe("buildIssueState", () => {
       hasHumanApproved: false,
       hasTestPassed: false,
       hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
       source: null,
     };
     const stateTodo = buildIssueState(dataTodo, legionId);
@@ -654,6 +670,8 @@ describe("buildIssueState", () => {
       hasHumanApproved: false,
       hasTestPassed: false,
       hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
       source: null,
     };
     const stateReview = buildIssueState(dataReview, legionId);
@@ -678,11 +696,102 @@ describe("buildIssueState", () => {
       hasHumanApproved: false,
       hasTestPassed: false,
       hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
       source: null,
     };
 
     const state = buildIssueState(data, "00000000-0000-0000-0000-000000000000");
     expect(state.suggestedAction).toBe("relay_user_feedback");
+  });
+
+  it("overrides dispatch actions to skip when blockedByIds are present", () => {
+    const data: FetchedIssueData = {
+      issueId: "ENG-99",
+      status: "Todo",
+      labels: [],
+      hasPr: false,
+      prIsDraft: null,
+      ciStatus: null,
+      mergeableStatus: null,
+      hasLiveWorker: false,
+      workerMode: null,
+      workerStatus: null,
+      hasUserFeedback: false,
+      hasUserInputNeeded: false,
+      hasNeedsApproval: false,
+      hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
+      blockedByIds: ["sjawhar-legion-110"],
+      isBlocked: true,
+      source: null,
+    };
+
+    const state = buildIssueState(data, "00000000-0000-0000-0000-000000000000");
+
+    expect(state.suggestedAction).toBe("skip");
+    expect(state.blockedByIds).toEqual(["sjawhar-legion-110"]);
+    expect(state.isBlocked).toBe(true);
+  });
+
+  it("does not override normal actions when blockedByIds is empty", () => {
+    const data: FetchedIssueData = {
+      issueId: "ENG-100",
+      status: "Todo",
+      labels: [],
+      hasPr: false,
+      prIsDraft: null,
+      ciStatus: null,
+      mergeableStatus: null,
+      hasLiveWorker: false,
+      workerMode: null,
+      workerStatus: null,
+      hasUserFeedback: false,
+      hasUserInputNeeded: false,
+      hasNeedsApproval: false,
+      hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
+      source: null,
+    };
+
+    const state = buildIssueState(data, "00000000-0000-0000-0000-000000000000");
+
+    expect(state.suggestedAction).toBe("dispatch_planner");
+    expect(state.blockedByIds).toEqual([]);
+  });
+
+  it("threads blockedByIds through to issue state output", () => {
+    const data: FetchedIssueData = {
+      issueId: "ENG-101",
+      status: "In Progress",
+      labels: ["worker-done"],
+      hasPr: true,
+      prIsDraft: false,
+      ciStatus: "passing",
+      mergeableStatus: null,
+      hasLiveWorker: false,
+      workerMode: null,
+      workerStatus: null,
+      hasUserFeedback: false,
+      hasUserInputNeeded: false,
+      hasNeedsApproval: false,
+      hasHumanApproved: false,
+      hasTestPassed: false,
+      hasTestFailed: false,
+      blockedByIds: ["sjawhar-legion-110", "sjawhar-legion-112"],
+      isBlocked: true,
+      source: null,
+    };
+
+    const state = buildIssueState(data, "00000000-0000-0000-0000-000000000000");
+
+    expect(state.suggestedAction).toBe("transition_to_testing");
+    expect(state.blockedByIds).toEqual(["sjawhar-legion-110", "sjawhar-legion-112"]);
+    expect(state.isBlocked).toBe(true);
   });
 });
 
@@ -705,6 +814,8 @@ describe("approval gate", () => {
       hasHumanApproved: false,
       hasTestPassed: false,
       hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
       source: null,
     };
 
@@ -730,6 +841,8 @@ describe("approval gate", () => {
       hasHumanApproved: true,
       hasTestPassed: false,
       hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
       source: null,
     };
 
@@ -755,6 +868,8 @@ describe("approval gate", () => {
       hasHumanApproved: false,
       hasTestPassed: false,
       hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
       source: null,
     };
 
@@ -782,6 +897,8 @@ describe("orphan detection", () => {
       hasHumanApproved: false,
       hasTestPassed: false,
       hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
       source: null,
     };
 
@@ -807,6 +924,8 @@ describe("orphan detection", () => {
       hasHumanApproved: false,
       hasTestPassed: false,
       hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
       source: null,
     };
 
@@ -832,6 +951,8 @@ describe("orphan detection", () => {
       hasHumanApproved: false,
       hasTestPassed: false,
       hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
       source: null,
     };
 
@@ -860,6 +981,8 @@ describe("orphan detection", () => {
         hasHumanApproved: false,
         hasTestPassed: false,
         hasTestFailed: false,
+        blockedByIds: [],
+        isBlocked: false,
         source: null,
       };
 
@@ -886,6 +1009,8 @@ describe("orphan detection", () => {
       hasHumanApproved: false,
       hasTestPassed: false,
       hasTestFailed: false,
+      blockedByIds: [],
+      isBlocked: false,
       source: null,
     };
 
@@ -918,6 +1043,8 @@ describe("buildCollectedState", () => {
         hasHumanApproved: false,
         hasTestPassed: false,
         hasTestFailed: false,
+        blockedByIds: [],
+        isBlocked: false,
         source: null,
       },
       {
@@ -937,6 +1064,8 @@ describe("buildCollectedState", () => {
         hasHumanApproved: false,
         hasTestPassed: false,
         hasTestFailed: false,
+        blockedByIds: [],
+        isBlocked: false,
         source: null,
       },
     ];
@@ -968,6 +1097,8 @@ describe("buildCollectedState", () => {
         hasHumanApproved: false,
         hasTestPassed: false,
         hasTestFailed: false,
+        blockedByIds: [],
+        isBlocked: false,
         source: null,
       },
     ];
@@ -1000,6 +1131,8 @@ describe("buildCollectedState", () => {
         hasHumanApproved: false,
         hasTestPassed: false,
         hasTestFailed: false,
+        blockedByIds: [],
+        isBlocked: false,
         source: null,
       },
       {
@@ -1019,6 +1152,8 @@ describe("buildCollectedState", () => {
         hasHumanApproved: false,
         hasTestPassed: false,
         hasTestFailed: false,
+        blockedByIds: [],
+        isBlocked: false,
         source: null,
       },
       {
@@ -1038,6 +1173,8 @@ describe("buildCollectedState", () => {
         hasHumanApproved: false,
         hasTestPassed: false,
         hasTestFailed: false,
+        blockedByIds: [],
+        isBlocked: false,
         source: null,
       },
     ];
@@ -1066,6 +1203,7 @@ describe("canDispatchMode", () => {
       suggestedAction: "dispatch_merger",
       sessionId: "ses_test123",
       hasUserFeedback: false,
+      blockedByIds: [],
       isBlocked: false,
       source: null,
       ...overrides,

--- a/packages/daemon/src/state/__tests__/github-fetch.test.ts
+++ b/packages/daemon/src/state/__tests__/github-fetch.test.ts
@@ -452,4 +452,140 @@ describe("fetchGitHubProjectItems", () => {
       expect((error as Error).message).toContain("GraphQL errors: Rate limit exceeded");
     }
   });
+
+  it("includes only open blocker refs for issue content", async () => {
+    const mockRunner: CommandRunner = async () => ({
+      stdout: JSON.stringify({
+        data: {
+          organization: {
+            projectV2: {
+              items: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [
+                  {
+                    id: "item-blocked",
+                    fieldValueByName: { name: "In Progress" },
+                    labels: { labels: { nodes: [] } },
+                    content: {
+                      __typename: "Issue",
+                      number: 42,
+                      title: "Blocked Issue",
+                      url: "https://github.com/sjawhar/legion/issues/42",
+                      repository: { nameWithOwner: "sjawhar/legion" },
+                      issueDependenciesSummary: { blockedBy: 2 },
+                      blockedBy: {
+                        nodes: [
+                          {
+                            number: 110,
+                            state: "OPEN",
+                            repository: { nameWithOwner: "sjawhar/legion" },
+                          },
+                          {
+                            number: 112,
+                            state: "CLOSED",
+                            repository: { nameWithOwner: "sjawhar/legion" },
+                          },
+                        ],
+                      },
+                      linkedPullRequests: { nodes: [] },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const result = await fetchGitHubProjectItems("sjawhar", 1, mockRunner);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      blockerRefs: [{ number: 110, repository: "sjawhar/legion" }],
+    });
+    expect(result.items[0].blockerRefs as unknown[]).toHaveLength(1);
+  });
+
+  it("returns an empty blockerRefs array when blockedBy is null", async () => {
+    const mockRunner: CommandRunner = async () => ({
+      stdout: JSON.stringify({
+        data: {
+          organization: {
+            projectV2: {
+              items: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [
+                  {
+                    id: "item-unblocked",
+                    fieldValueByName: { name: "Todo" },
+                    labels: { labels: { nodes: [] } },
+                    content: {
+                      __typename: "Issue",
+                      number: 43,
+                      title: "Unblocked Issue",
+                      url: "https://github.com/sjawhar/legion/issues/43",
+                      repository: { nameWithOwner: "sjawhar/legion" },
+                      issueDependenciesSummary: { blockedBy: 0 },
+                      blockedBy: null,
+                      linkedPullRequests: { nodes: [] },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const result = await fetchGitHubProjectItems("sjawhar", 1, mockRunner);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({ blockerRefs: [] });
+  });
+
+  it("returns an empty blockerRefs array for pull request items", async () => {
+    const mockRunner: CommandRunner = async () => ({
+      stdout: JSON.stringify({
+        data: {
+          organization: {
+            projectV2: {
+              items: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [
+                  {
+                    id: "item-pr",
+                    fieldValueByName: { name: "Done" },
+                    labels: { labels: { nodes: [] } },
+                    content: {
+                      __typename: "PullRequest",
+                      number: 44,
+                      title: "Blocked PR",
+                      url: "https://github.com/sjawhar/legion/pull/44",
+                      repository: { nameWithOwner: "sjawhar/legion" },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const result = await fetchGitHubProjectItems("sjawhar", 1, mockRunner);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      blockerRefs: [],
+      content: { type: "PullRequest", number: 44 },
+    });
+  });
 });

--- a/packages/daemon/src/state/backends/__tests__/github.test.ts
+++ b/packages/daemon/src/state/backends/__tests__/github.test.ts
@@ -223,4 +223,63 @@ describe("GitHubTracker.parseIssues", () => {
     expect(tracker.parseIssues({ items: [] })).toEqual([]);
     expect(tracker.parseIssues([])).toEqual([]);
   });
+
+  it("maps blocker refs to blockedByIds and marks issues blocked", () => {
+    const result = tracker.parseIssues({
+      items: [
+        makeItem({
+          blockerRefs: [
+            { number: 110, repository: "sjawhar/legion" },
+            { number: 112, repository: "sjawhar/legion" },
+          ],
+        }),
+      ],
+    });
+
+    expect(result[0].blockedByIds).toEqual(["sjawhar-legion-110", "sjawhar-legion-112"]);
+    expect(result[0].isBlocked).toBe(true);
+  });
+
+  it("keeps blockedByIds empty when blockerRefs is an empty array", () => {
+    const result = tracker.parseIssues({ items: [makeItem({ blockerRefs: [] })] });
+
+    expect(result[0].blockedByIds).toEqual([]);
+    expect(result[0].isBlocked).toBe(false);
+  });
+
+  it("keeps blockedByIds empty when blockerRefs is absent", () => {
+    const result = tracker.parseIssues({ items: [makeItem()] });
+
+    expect(result[0].blockedByIds).toEqual([]);
+    expect(result[0].isBlocked).toBe(false);
+  });
+
+  it("deduplicates and sorts blockedByIds lexicographically", () => {
+    const result = tracker.parseIssues({
+      items: [
+        makeItem({
+          blockerRefs: [
+            { number: 112, repository: "sjawhar/legion" },
+            { number: 110, repository: "sjawhar/legion" },
+            { number: 112, repository: "sjawhar/legion" },
+          ],
+        }),
+      ],
+    });
+
+    expect(result[0].blockedByIds).toEqual(["sjawhar-legion-110", "sjawhar-legion-112"]);
+  });
+
+  it("builds blockedByIds for blockers from other repositories", () => {
+    const result = tracker.parseIssues({
+      items: [
+        makeItem({
+          blockerRefs: [{ number: 5, repository: "acme/other-repo" }],
+        }),
+      ],
+    });
+
+    expect(result[0].blockedByIds).toEqual(["acme-other-repo-5"]);
+    expect(result[0].isBlocked).toBe(true);
+  });
 });

--- a/packages/daemon/src/state/backends/github.ts
+++ b/packages/daemon/src/state/backends/github.ts
@@ -20,6 +20,7 @@ interface GitHubProjectItem {
   labels?: string[] | null;
   "linked pull requests"?: string[] | null;
   isBlocked?: boolean;
+  blockerRefs?: Array<{ number: number; repository: string }>;
   [key: string]: unknown;
 }
 
@@ -116,9 +117,24 @@ export class GitHubTracker implements IssueTracker {
         number,
         url: typeof content.url === "string" ? content.url : "",
       };
-      const isBlocked = typedItem.isBlocked === true;
+      // Build blockedByIds from raw blocker references
+      const blockedByIds: string[] = [];
+      if (Array.isArray(typedItem.blockerRefs)) {
+        for (const ref of typedItem.blockerRefs) {
+          if (typeof ref.number === "number" && typeof ref.repository === "string") {
+            const blockerOwnerRepo = parseOwnerRepo(ref.repository);
+            if (blockerOwnerRepo) {
+              blockedByIds.push(
+                buildIssueId(blockerOwnerRepo.owner, blockerOwnerRepo.repo, ref.number)
+              );
+            }
+          }
+        }
+      }
+      // Dedup and sort for stable output
+      const uniqueBlockedByIds = [...new Set(blockedByIds)].sort();
 
-      parsed.push(createParsedIssue(issueId, status, labels, prRef, source, isBlocked));
+      parsed.push(createParsedIssue(issueId, status, labels, prRef, source, uniqueBlockedByIds));
     }
 
     return parsed;

--- a/packages/daemon/src/state/decision.ts
+++ b/packages/daemon/src/state/decision.ts
@@ -319,6 +319,7 @@ export function buildIssueState(data: FetchedIssueData, legionId: string): Issue
     suggestedAction: action,
     sessionId,
     hasUserFeedback: data.hasUserFeedback,
+    blockedByIds: data.blockedByIds ?? [],
     isBlocked: data.isBlocked ?? false,
     source: data.source,
   };

--- a/packages/daemon/src/state/fetch.ts
+++ b/packages/daemon/src/state/fetch.ts
@@ -586,6 +586,7 @@ export async function enrichParsedIssues(
       hasHumanApproved: issue.hasHumanApproved,
       hasTestPassed: issue.hasTestPassed,
       hasTestFailed: issue.hasTestFailed,
+      blockedByIds: issue.blockedByIds,
       isBlocked: issue.isBlocked,
       source: issue.source,
     };

--- a/packages/daemon/src/state/github-fetch.ts
+++ b/packages/daemon/src/state/github-fetch.ts
@@ -31,6 +31,13 @@ interface GitHubProjectItemNode {
         issueDependenciesSummary?: {
           blockedBy: number;
         } | null;
+        blockedBy?: {
+          nodes: Array<{
+            number: number;
+            state: string;
+            repository: { nameWithOwner: string };
+          }>;
+        } | null;
         linkedPullRequests?: {
           nodes: Array<{ url: string }>;
         } | null;
@@ -99,6 +106,13 @@ query($owner: String!, $number: Int!, $first: Int!, $after: String) {
               url
               repository { nameWithOwner }
               issueDependenciesSummary { blockedBy }
+              blockedBy(first: 50) {
+                nodes {
+                  number
+                  state
+                  repository { nameWithOwner }
+                }
+              }
               linkedPullRequests: closedByPullRequestsReferences(first: 10, includeClosedPrs: true) {
                 nodes { url }
               }
@@ -150,6 +164,13 @@ query($owner: String!, $number: Int!, $first: Int!, $after: String) {
               url
               repository { nameWithOwner }
               issueDependenciesSummary { blockedBy }
+              blockedBy(first: 50) {
+                nodes {
+                  number
+                  state
+                  repository { nameWithOwner }
+                }
+              }
               linkedPullRequests: closedByPullRequestsReferences(first: 10, includeClosedPrs: true) {
                 nodes { url }
               }
@@ -223,6 +244,15 @@ function nodeToProjectItem(node: GitHubProjectItemNode): Record<string, unknown>
     labels,
     isBlocked:
       typename === "Issue" ? (content.issueDependenciesSummary?.blockedBy ?? 0) > 0 : false,
+    blockerRefs:
+      typename === "Issue" && content.blockedBy?.nodes
+        ? content.blockedBy.nodes
+            .filter((n) => n.state === "OPEN")
+            .map((n) => ({
+              number: n.number,
+              repository: n.repository.nameWithOwner,
+            }))
+        : [],
     ...(linkedPRs.length > 0 ? { "linked pull requests": linkedPRs } : {}),
   };
 }

--- a/packages/daemon/src/state/types.ts
+++ b/packages/daemon/src/state/types.ts
@@ -294,6 +294,7 @@ export interface ParsedIssue {
   labels: string[];
   prRef: GitHubPRRef | null;
   source: IssueSource | null; // Structured metadata for GitHub issues, null for Linear
+  blockedByIds: string[];
   isBlocked: boolean;
 
   // Computed properties (implemented as getters)
@@ -319,7 +320,7 @@ export function createParsedIssue(
   labels: string[],
   prRef: GitHubPRRef | null,
   source: IssueSource | null = null,
-  isBlocked: boolean = false
+  blockedByIds: string[] = []
 ): ParsedIssue {
   return {
     issueId,
@@ -327,8 +328,8 @@ export function createParsedIssue(
     labels,
     prRef,
     source,
-    isBlocked,
-
+    blockedByIds,
+    isBlocked: blockedByIds.length > 0,
     get hasWorkerDone() {
       return this.labels.includes("worker-done");
     },
@@ -404,7 +405,8 @@ export interface FetchedIssueData {
   hasHumanApproved: boolean;
   hasTestPassed: boolean;
   hasTestFailed: boolean;
-  isBlocked?: boolean;
+  blockedByIds: string[];
+  isBlocked: boolean;
   source: IssueSource | null; // Canonical identity for GitHub issues, null for Linear
 }
 
@@ -424,6 +426,7 @@ export interface IssueStateDict {
   suggestedAction: ActionType;
   sessionId: string;
   hasUserFeedback: boolean;
+  blockedByIds: string[];
   isBlocked: boolean;
   source: IssueSource | null;
 }
@@ -451,6 +454,7 @@ export interface IssueState {
   suggestedAction: ActionType;
   sessionId: string;
   hasUserFeedback: boolean;
+  blockedByIds: string[];
   isBlocked: boolean;
   source: IssueSource | null; // Canonical identity for GitHub issues, null for Linear
 }
@@ -473,6 +477,7 @@ export const IssueState = {
       suggestedAction: state.suggestedAction,
       sessionId: state.sessionId,
       hasUserFeedback: state.hasUserFeedback,
+      blockedByIds: state.blockedByIds,
       isBlocked: state.isBlocked,
       source: state.source,
     };


### PR DESCRIPTION
Closes #114

## Summary

Extends the count-based `isBlocked: boolean` (from PR #402) to surface the actual blocking issue IDs throughout the state pipeline.

### Changes
- **GraphQL queries** (`github-fetch.ts`): Added `blockedBy(first: 50)` connection to Issue fragments in both ORG_QUERY and USER_QUERY, filtered to OPEN-only blockers
- **Type pipeline** (`types.ts`, `fetch.ts`, `decision.ts`): Added `blockedByIds: string[]` to `ParsedIssue`, `FetchedIssueData`, `IssueState`, and `IssueStateDict`; `isBlocked` now computed from `blockedByIds.length > 0`
- **GitHub backend** (`backends/github.ts`): Builds `blockedByIds` from `blockerRefs` using `buildIssueId()`, with dedup + sort for stable output
- **Poll formatter** (`poll-formatter.ts`): Displays canonical blocker IDs verbatim — e.g., `blocked by sjawhar-legion-110, sjawhar-legion-112`
- **Tests**: 14 new tests across 4 test files covering GraphQL extraction, backend parsing, decision threading, and formatter display

### Design Decisions
- `issueDependenciesSummary` kept for backward compatibility — removal is follow-on cleanup
- `blockerRefs` extracted in `nodeToProjectItem()`, IDs built in `parseIssues()` — follows existing separation
- Canonical Legion IDs displayed in poll (not `#N`) because `buildIssueId()` is one-way
- `first: 50` on `blockedBy` — GitHub caps dependencies at 50 per issue