### PR TITLE
sjawhar-legion-411: add failure notifications to all worker workflows and merge retry logic

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,16 +1,27 @@
 {
-  "filesChanged": [],
+  "filesChanged": [
+    ".opencode/skills/legion-worker/workflows/merge.md",
+    ".opencode/skills/legion-worker/SKILL.md",
+    ".opencode/skills/legion-worker/workflows/architect.md",
+    ".opencode/skills/legion-worker/workflows/plan.md"
+  ],
   "trickyParts": [
-    "No implementation needed — all implementable sub-issues (#238, #239) were already completed and merged before this dispatch"
+    "Step 1 of merge.md required expanding two single-line bullets into multi-line structured blocks with both GitHub and Linear commands",
+    "Step 6 replacement was the largest change — the retry-aware merge section handles race conditions, PR state inspection, retry loops, and three distinct failure classification paths"
   ],
-  "deviations": [
-    "No-op implementation phase: architect and planner both confirmed no remaining work. #240 (index evolution) is intentionally deferred until 20+ issues accumulate feedback data."
-  ],
-  "openQuestions": [
-    "#240 remains open and blocked on data accumulation — should #218 be closed since Changes 1 and 2 are complete?"
-  ],
+  "deviations": [],
+  "openQuestions": [],
   "subPlanningNeeded": false,
+  "learningsInjected": [
+    "docs/solutions/skill-patterns/cross-cutting-workflow-concerns.md",
+    "docs/solutions/skill-patterns/worker-skill-failure-modes.md",
+    "docs/solutions/daemon/envoy-auto-subscription-patterns.md"
+  ],
+  "learningsHelpful": [
+    "docs/solutions/skill-patterns/worker-skill-failure-modes.md",
+    "docs/solutions/daemon/envoy-auto-subscription-patterns.md"
+  ],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-11T13:07:41.264Z"
+  "completed": "2026-04-11T13:30:53.415Z"
 }

--- a/.legion/plan.json
+++ b/.legion/plan.json
@@ -1,24 +1,37 @@
 {
-  "taskCount": 0,
-  "independentTasks": 0,
+  "learningsInjected": [
+    "docs/solutions/skill-patterns/cross-cutting-workflow-concerns.md",
+    "docs/solutions/skill-patterns/worker-skill-failure-modes.md",
+    "docs/solutions/daemon/envoy-auto-subscription-patterns.md"
+  ],
+  "learningsHelpful": [
+    "docs/solutions/skill-patterns/cross-cutting-workflow-concerns.md",
+    "docs/solutions/skill-patterns/worker-skill-failure-modes.md"
+  ],
+  "scope": "small",
+  "components": [
+    ".opencode/skills/legion-worker/workflows/merge.md",
+    ".opencode/skills/legion-worker/SKILL.md",
+    ".opencode/skills/legion-worker/workflows/architect.md",
+    ".opencode/skills/legion-worker/workflows/plan.md"
+  ],
+  "planFile": "docs/superpowers/plans/2026-04-11-worker-failure-notifications-merge-retry.md",
+  "taskCount": 3,
+  "requiredSkills": [],
+  "subIssues": [],
   "routingHints": {
-    "complexity": "none",
-    "estimatedImplementers": 0,
-    "skipRetro": true,
-    "skipArchitect": true
+    "skipRetro": false,
+    "complexity": "small",
+    "estimatedImplementers": 1
   },
   "concerns": [
-    "All implementable sub-issues (#238, #239) are already CLOSED with worker-done and test-passed labels.",
-    "Sub-issue #240 (index evolution) is intentionally blocked until 20+ issues accumulate feedback data — do NOT attempt to implement.",
-    "No plan produced — nothing remains to implement for #218."
+    "Merge retry substeps must NOT contain envoy_publish — only terminal exits notify",
+    "Permission errors and unknown errors are merged into one catch-all path using agent judgment on error output",
+    "implement.md and review.md have no inline escalation exits — they rely on SKILL.md shared protocol",
+    "test.md already has pass/fail notifications — only its escalation path via SKILL.md needs the new notification",
+    "Linear backend variants must be included alongside GitHub commands in all exit paths"
   ],
-  "learningsInjected": [
-    "skill-patterns/cross-cutting-workflow-concerns.md",
-    "daemon/handoff-schema-migration-patterns.md"
-  ],
-  "learningsHelpful": [],
-  "workflowRecommendation": "No implementation needed — close #218 as completed. #240 remains open as separate tracking ticket.",
   "schemaVersion": 1,
   "phase": "plan",
-  "completed": "2026-04-11T13:02:16.603Z"
+  "completed": "2026-04-11T13:18:43.284Z"
 }

--- a/.legion/retro.json
+++ b/.legion/retro.json
@@ -1,7 +1,10 @@
 {
-  "skipped": true,
-  "reason": "no significant learnings — implement phase was a no-op (sub-issues #238/#239 already complete)",
+  "skipped": false,
+  "docsCreated": [
+    "docs/solutions/skill-patterns/worker-notification-conventions.md",
+    "docs/solutions/skill-patterns/merge-retry-race-condition-pattern.md"
+  ],
   "schemaVersion": 1,
   "phase": "retro",
-  "completed": "2026-04-11T13:31:56.968Z"
+  "completed": "2026-04-11T16:32:11.200Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,24 +1,25 @@
 {
   "critical": 0,
-  "important": 1,
-  "minor": 0,
+  "important": 0,
+  "minor": 1,
   "verdict": "approved",
   "keyFindings": [
     {
-      "severity": "P2",
-      "file": ".opencode/skills/legion-worker/references/knowledge-injection.md",
-      "description": "Line 91 references deprecated `learningsUsed` field instead of canonical `learningsInjected`. Stale cross-reference missed during #239 field rename. The learning doc daemon/handoff-schema-migration-patterns.md (line 81) explicitly warned about this class of bug."
+      "severity": "P3",
+      "file": ".legion/implement.json",
+      "description": "Missing trailing newline — non-functional, already flagged by tester"
     }
   ],
   "learningsInjected": [
-    "skill-patterns/cross-cutting-workflow-concerns.md",
-    "daemon/handoff-schema-migration-patterns.md",
-    "skill-patterns/worker-skill-failure-modes.md"
+    "docs/solutions/skill-patterns/worker-skill-failure-modes.md",
+    "docs/solutions/skill-patterns/cross-cutting-workflow-concerns.md",
+    "docs/solutions/daemon/envoy-auto-subscription-patterns.md"
   ],
   "learningsHelpful": [
-    "daemon/handoff-schema-migration-patterns.md"
+    "docs/solutions/skill-patterns/worker-skill-failure-modes.md",
+    "docs/solutions/daemon/envoy-auto-subscription-patterns.md"
   ],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-11T13:29:34.440Z"
+  "completed": "2026-04-11T13:48:53.161Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -2,22 +2,22 @@
   "passed": 12,
   "failed": 0,
   "failures": [],
-  "documentationFeedback": "knowledge-injection.md is clear and comprehensive (91 lines). P2: line 91 refers to deprecated `learningsUsed` instead of canonical `learningsInjected` — inconsistency introduced when #239 renamed the field but didn't update the reference file.",
+  "documentationFeedback": "PR description is clear and well-structured with changes listed by file and message format convention. Issue body describes both problems with evidence (PR #393 silent failure).",
   "observations": [
-    "P2: references/knowledge-injection.md line 91 says `learningsUsed` but canonical field is `learningsInjected` (renamed in #239)",
-    "Production evidence: #218's own architect handoff includes learningsInjected/learningsHelpful with real values, proving end-to-end functionality",
-    "Pre-existing test failures (3/1154): 2 from @pulumi/docker infra tests, 1 from daemon env var test — unrelated to #218"
+    "P3: .legion/implement.json missing trailing newline — non-functional",
+    "state: MERGED detection in step 6 is a good addition for handling concurrent merge processes",
+    "All envoy_publish calls follow fire-and-forget pattern consistent with envoy-auto-subscription-patterns.md"
   ],
   "learningsInjected": [
-    "skill-patterns/cross-cutting-workflow-concerns.md",
-    "daemon/handoff-schema-migration-patterns.md",
-    "skill-patterns/worker-skill-failure-modes.md"
+    "docs/solutions/skill-patterns/worker-skill-failure-modes.md",
+    "docs/solutions/skill-patterns/cross-cutting-workflow-concerns.md",
+    "docs/solutions/daemon/envoy-auto-subscription-patterns.md"
   ],
   "learningsHelpful": [
-    "skill-patterns/cross-cutting-workflow-concerns.md",
-    "daemon/handoff-schema-migration-patterns.md"
+    "docs/solutions/skill-patterns/worker-skill-failure-modes.md",
+    "docs/solutions/daemon/envoy-auto-subscription-patterns.md"
   ],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-11T13:18:59.785Z"
+  "completed": "2026-04-11T13:42:29.763Z"
 }

--- a/.opencode/skills/legion-worker/SKILL.md
+++ b/.opencode/skills/legion-worker/SKILL.md
@@ -166,7 +166,12 @@ linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="## Escalation
 ```
 
 3. Update labels: add `user-input-needed`, remove `worker-active`
-4. Exit immediately
+4. Notify the controller via Envoy (best-effort):
+   ```
+   envoy_publish(topic="notifications.role.legion-controller", message="Worker blocked: $ISSUE_NUMBER [current mode] needs user input")
+   ```
+   If `envoy_publish` fails, continue — the label is the source of truth.
+5. Exit immediately
 
 The controller will resume your session when the user responds.
 

--- a/.opencode/skills/legion-worker/workflows/architect.md
+++ b/.opencode/skills/legion-worker/workflows/architect.md
@@ -58,7 +58,19 @@ If still unclear, escalate.
 
 ### 3. Act
 
-**If unclear:** Add `user-input-needed` label, remove `worker-active` label, post comment with specific questions, exit.
+**If unclear:**
+- Add `user-input-needed` label:
+  - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "user-input-needed" --remove-label "worker-active" -R $OWNER/$REPO`
+  - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current without "worker-active" plus "user-input-needed"])`
+- Post comment with specific questions:
+  - **GitHub:** `gh issue comment $ISSUE_NUMBER --body "..." -R $OWNER/$REPO`
+  - **Linear:** `linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="...")`
+- Notify controller (best-effort):
+  ```
+  envoy_publish(topic="notifications.role.legion-controller", message="Worker blocked: $ISSUE_NUMBER architect needs user input")
+  ```
+  If `envoy_publish` fails, continue — the label is the source of truth.
+- Exit
 
 **If too big:** Break down into sub-issues. Each sub-issue must be spec-ready:
 - Clear problem statement (what needs to change and why)

--- a/.opencode/skills/legion-worker/workflows/merge.md
+++ b/.opencode/skills/legion-worker/workflows/merge.md
@@ -13,8 +13,29 @@ Before doing anything, verify the PR is open and mergeable:
 gh pr view "$LEGION_ISSUE_ID" --json state,merged,mergeable
 ```
 
-- If **already merged**: verify changes are on main (`jj log --revisions main`), then exit cleanly.
-- If **closed without merge**: escalate with `user-input-needed` — something unexpected happened.
+- If **already merged**: verify changes are on main (`jj log --revisions main`), then notify the controller and exit cleanly:
+  - Remove `worker-active`:
+    - **GitHub:** `gh issue edit $ISSUE_NUMBER --remove-label "worker-active" -R $OWNER/$REPO`
+    - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current without "worker-active"])`
+  - Notify controller (best-effort):
+    ```
+    envoy_publish(topic="notifications.role.legion-controller", message="Worker done: $ISSUE_NUMBER merge skipped — PR already merged")
+    ```
+    If `envoy_publish` fails, continue — the label is the source of truth.
+  - Exit
+- If **closed without merge**: something unexpected happened.
+  - Post comment:
+    - **GitHub:** `gh issue comment $ISSUE_NUMBER --body "PR was closed without merging. Unexpected state — needs investigation." -R $OWNER/$REPO`
+    - **Linear:** `linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="PR was closed without merging. Unexpected state.")`
+  - Add `user-input-needed`:
+    - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "user-input-needed" --remove-label "worker-active" -R $OWNER/$REPO`
+    - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current without "worker-active" plus "user-input-needed"])`
+  - Notify controller (best-effort):
+    ```
+    envoy_publish(topic="notifications.role.legion-controller", message="Worker failed: $ISSUE_NUMBER merge failed — PR closed without merge")
+    ```
+    If `envoy_publish` fails, continue — the label is the source of truth.
+  - Exit
 - If **open**: proceed to step 2.
 
 ### 2. Rebase onto Main
@@ -39,6 +60,11 @@ If rebase produces conflicts:
 - Post comment describing the conflict
   - **GitHub:** `gh issue comment $ISSUE_NUMBER --body "..." -R $OWNER/$REPO`
   - **Linear:** `linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="...")`
+- Notify controller (best-effort):
+  ```
+  envoy_publish(topic="notifications.role.legion-controller", message="Worker failed: $ISSUE_NUMBER merge failed — unresolvable rebase conflict")
+  ```
+  If `envoy_publish` fails, continue — the label is the source of truth.
 - Exit
 
 **Protected files:** The `.legion/` directory contains handoff data between pipeline phases. These files are intentional and must be preserved during merge — do not remove them or add `.legion/` to `.gitignore`.
@@ -64,20 +90,80 @@ gh pr checks "$LEGION_ISSUE_ID" --watch
 
 Only escalate with `user-input-needed` if something has gone fundamentally wrong (e.g., infrastructure issues, impossible conflicts, external service failures). Normal code issues like type errors should be fixed, not escalated.
 
-### 6. Merge
+**If CI fails with a fundamental issue** (infrastructure failures, impossible conflicts, external service errors — NOT normal code issues):
+- Post comment explaining the fundamental failure:
+  - **GitHub:** `gh issue comment $ISSUE_NUMBER --body "Merge blocked: CI has a fundamental failure that cannot be fixed by the merge worker. [describe the issue]" -R $OWNER/$REPO`
+  - **Linear:** `linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="Merge blocked: fundamental CI failure.")`
+- Add `user-input-needed` label:
+  - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "user-input-needed" --remove-label "worker-active" -R $OWNER/$REPO`
+  - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current without "worker-active" plus "user-input-needed"])`
+- Notify controller (best-effort):
+  ```
+  envoy_publish(topic="notifications.role.legion-controller", message="Worker failed: $ISSUE_NUMBER merge blocked — fundamental CI failure")
+  ```
+  If `envoy_publish` fails, continue — the label is the source of truth.
+- Exit
+
+### 6. Merge (with conflict retry)
+
+Attempt to merge. If the merge fails due to a race condition (main moved since rebase), retry.
 
 ```bash
 gh pr merge "$LEGION_ISSUE_ID" --squash --delete-branch
 ```
 
-**If merge fails with a permission error** (e.g., external repo you don't own):
-- Post a comment explaining the permission issue
-  - **GitHub:** `gh issue comment $ISSUE_NUMBER --body "..." -R $OWNER/$REPO`
-  - **Linear:** `linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="...")`
-- Add `user-input-needed` label
+**If merge succeeds:** Proceed to step 7.
+
+**If merge fails — classify the failure** by checking PR state:
+
+```bash
+gh pr view "$LEGION_ISSUE_ID" --json state,mergeable,mergeStateStatus -R $OWNER/$REPO
+```
+
+**If `state` is `MERGED`:** The PR was merged by another process (manual merge, auto-merge). Proceed to step 7 — this is a success, not a failure.
+
+**If `mergeStateStatus` is `BEHIND` or `DIRTY` (race condition — main moved):**
+
+Retry up to **2 times** (track your retry count):
+
+1. Rebase onto latest main:
+   ```bash
+   jj git fetch
+   jj rebase -d main
+   ```
+2. Verify clean rebase — `jj status` must show no conflicts. If conflicts exist, resolve them (same as step 3). If conflicts are unresolvable, exit via the unresolvable-conflict path in step 3.
+3. Push: `jj git push`
+4. Wait for CI: `gh pr checks "$LEGION_ISSUE_ID" --watch` — fix any CI failures (same as step 5)
+5. Retry merge: `gh pr merge "$LEGION_ISSUE_ID" --squash --delete-branch`
+6. If merge succeeds, proceed to step 7. If it fails again, go back to substep 1 (unless retries exhausted).
+
+**If merge still fails after 2 retries:**
+- Post comment:
+  - **GitHub:** `gh issue comment $ISSUE_NUMBER --body "Merge failed after 2 conflict retries. The PR keeps falling behind main despite rebasing. Manual intervention needed." -R $OWNER/$REPO`
+  - **Linear:** `linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="Merge failed after 2 conflict retries. Manual intervention needed.")`
+- Add `user-input-needed` label:
   - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "user-input-needed" --remove-label "worker-active" -R $OWNER/$REPO`
   - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current without "worker-active" plus "user-input-needed"])`
-- Exit — the user needs to merge manually or grant access
+- Notify controller (best-effort):
+  ```
+  envoy_publish(topic="notifications.role.legion-controller", message="Worker failed: $ISSUE_NUMBER merge failed after 2 conflict retries")
+  ```
+  If `envoy_publish` fails, continue — the label is the source of truth.
+- Exit
+
+**If merge fails for any other reason** (permission error, unknown error — inspect the error output to determine the cause):
+- Post a comment describing the failure and what you observed:
+  - **GitHub:** `gh issue comment $ISSUE_NUMBER --body "Merge failed: [describe the error — permission denied, unexpected API error, etc.]. Manual intervention needed." -R $OWNER/$REPO`
+  - **Linear:** `linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="Merge failed: [describe error].")`
+- Add `user-input-needed` label:
+  - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "user-input-needed" --remove-label "worker-active" -R $OWNER/$REPO`
+  - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current without "worker-active" plus "user-input-needed"])`
+- Notify controller (best-effort):
+  ```
+  envoy_publish(topic="notifications.role.legion-controller", message="Worker failed: $ISSUE_NUMBER merge failed — [brief error description]")
+  ```
+  If `envoy_publish` fails, continue — the label is the source of truth.
+- Exit
 
 ### 7. Close Issue
 

--- a/.opencode/skills/legion-worker/workflows/plan.md
+++ b/.opencode/skills/legion-worker/workflows/plan.md
@@ -202,7 +202,12 @@ The skill handles:
 2. Post a comment explaining what needs clarification:
    - **GitHub:** `gh issue comment $ISSUE_NUMBER --body "..." -R $OWNER/$REPO`
    - **Linear:** `linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="...")`
-3. Exit immediately - do NOT add `worker-done`
+3. Notify controller (best-effort):
+   ```
+   envoy_publish(topic="notifications.role.legion-controller", message="Worker blocked: $ISSUE_NUMBER plan needs user input — requirements unclear")
+   ```
+   If `envoy_publish` fails, continue — the label is the source of truth.
+4. Exit immediately - do NOT add `worker-done`
 
 ### 3. Invoke /superpowers/writing-plans
 
@@ -314,7 +319,12 @@ This spawns parallel cross-family reviewers:
 2. Post a comment explaining unresolved review issues:
    - **GitHub:** `gh issue comment $ISSUE_NUMBER --body "..." -R $OWNER/$REPO`
    - **Linear:** `linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="...")`
-3. Exit without `worker-done`
+3. Notify controller (best-effort):
+   ```
+   envoy_publish(topic="notifications.role.legion-controller", message="Worker blocked: $ISSUE_NUMBER plan review failed after 3 iterations")
+   ```
+   If `envoy_publish` fails, continue — the label is the source of truth.
+4. Exit without `worker-done`
 
 **If a reviewer fails/times out:** Proceed with partial results. Note the missing review in the issue comment.
 

--- a/docs/solutions/index.json
+++ b/docs/solutions/index.json
@@ -12,7 +12,7 @@
       "github-api/graphql-org-user-fallback.md",
       "daemon/controller-retro-20h-bug-pipeline-optimization.md",
       "controller/controller-session-anti-patterns.md",
-      "daemon/server-side-dispatch-validation.md"
+      "daemon/server-side-dispatch-validation.md",
       "daemon/state-machine-action-display-mismatch.md"
     ],
     "packages/daemon/src/daemon/serve-manager": [
@@ -53,7 +53,7 @@
       "daemon/envoy-auto-subscription-patterns.md",
       "daemon/server-side-dispatch-validation.md",
       "daemon/prompt-delivery-bootstrap-delay.md",
-      "daemon/handoff-schema-migration-patterns.md"
+      "daemon/handoff-schema-migration-patterns.md",
       "daemon/state-machine-action-display-mismatch.md"
     ],
     "packages/daemon": [
@@ -73,7 +73,9 @@
       "testing/worker-smoke-testing-requirements.md",
       "daemon/envoy-auto-subscription-patterns.md",
       "skill-patterns/cross-cutting-workflow-concerns.md",
-      "daemon/handoff-schema-migration-patterns.md"
+      "daemon/handoff-schema-migration-patterns.md",
+      "skill-patterns/worker-notification-conventions.md",
+      "skill-patterns/merge-retry-race-condition-pattern.md"
     ],
     ".opencode/skills/legion-controller": [
       "integration-patterns/controller-worker-protocol.md",
@@ -89,7 +91,9 @@
       "skill-patterns/parallel-subagent-background-execution.md",
       "delegation/delegation-hardening-retro.md",
       "delegation/hardening-patterns.md",
-      "skill-patterns/cross-cutting-workflow-concerns.md"
+      "skill-patterns/cross-cutting-workflow-concerns.md",
+      "skill-patterns/worker-notification-conventions.md",
+      "skill-patterns/merge-retry-race-condition-pattern.md"
     ],
     "tests": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
     "tag:SIGTERM": ["daemon/opencode-serve-lifecycle.md"],
@@ -191,7 +195,10 @@
       "integration-issues/linear-mcp-label-resolution.md"
     ],
     "tag:mcp": ["integration-issues/linear-mcp-label-resolution.md"],
-    "tag:merge": ["skill-patterns/worker-skill-failure-modes.md"],
+    "tag:merge": [
+      "skill-patterns/worker-skill-failure-modes.md",
+      "skill-patterns/merge-retry-race-condition-pattern.md"
+    ],
     "tag:migration": ["architecture-patterns/plugin-migration-assessment.md"],
     "tag:mocking": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
     "tag:modular-architecture": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
@@ -228,7 +235,10 @@
     ],
     "tag:pytest-mock": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
     "tag:python": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
-    "tag:race-condition": ["architecture-patterns/shared-state-file-ownership.md"],
+    "tag:race-condition": [
+      "architecture-patterns/shared-state-file-ownership.md",
+      "skill-patterns/merge-retry-race-condition-pattern.md"
+    ],
     "tag:dead-code": ["best-practices/typescript-dead-code-audit.md"],
     "tag:noUnusedLocals": ["best-practices/typescript-dead-code-audit.md"],
     "tag:barrel-exports": ["best-practices/typescript-dead-code-audit.md"],
@@ -251,13 +261,14 @@
     "tag:skill-authoring": ["skill-patterns/parallel-subagent-background-execution.md"],
     "tag:skills": [
       "skill-patterns/worker-skill-failure-modes.md",
-      "skill-patterns/cross-cutting-workflow-concerns.md"
+      "skill-patterns/cross-cutting-workflow-concerns.md",
+      "skill-patterns/worker-notification-conventions.md"
     ],
     "tag:stale-detection": ["delegation/delegation-hardening-retro.md"],
     "tag:state-file": ["architecture-patterns/shared-state-file-ownership.md"],
     "tag:state-machine": [
       "daemon/controller-observability.md",
-      "integration-issues/github-graphql-pr-draft-status.md"
+      "integration-issues/github-graphql-pr-draft-status.md",
       "daemon/state-machine-action-display-mismatch.md"
     ],
     "tag:state-management": ["daemon/controller-lifecycle-separation.md"],
@@ -272,7 +283,7 @@
     "tag:testing": [
       "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md",
       "github-api/graphql-org-user-fallback.md",
-      "testing/worker-smoke-testing-requirements.md"
+      "testing/worker-smoke-testing-requirements.md",
       "daemon/state-machine-action-display-mismatch.md"
     ],
     "tag:tmux": ["integration-patterns/tmux-askuserquestion-navigation.md"],
@@ -281,10 +292,14 @@
     "tag:worker-isolation": ["daemon/worker-directory-resolution.md"],
     "tag:worker-lifecycle": [
       "integration-issues/external-repo-pr-auto-transition-gap.md",
-      "testing/worker-smoke-testing-requirements.md"
+      "testing/worker-smoke-testing-requirements.md",
+      "skill-patterns/worker-notification-conventions.md"
     ],
     "tag:worker-spawning": ["daemon/worker-directory-fix.md"],
-    "tag:workers": ["skill-patterns/worker-skill-failure-modes.md"],
+    "tag:workers": [
+      "skill-patterns/worker-skill-failure-modes.md",
+      "skill-patterns/worker-notification-conventions.md"
+    ],
     "tag:workflow-design": [
       "skill-patterns/parallel-subagent-background-execution.md",
       "skill-patterns/cross-cutting-workflow-concerns.md"
@@ -415,6 +430,26 @@
     "tag:display-logic": ["daemon/state-machine-action-display-mismatch.md"],
     "tag:formatter": ["daemon/state-machine-action-display-mismatch.md"],
     "tag:poll": ["daemon/state-machine-action-display-mismatch.md"],
-    "packages/envoy/internal/mcpbridge": ["testing/sse-mock-initialization-order.md"]
+    "packages/envoy/internal/mcpbridge": ["testing/sse-mock-initialization-order.md"],
+    "tag:notifications": [
+      "skill-patterns/worker-notification-conventions.md",
+      "daemon/envoy-auto-subscription-patterns.md"
+    ],
+    "tag:escalation": [
+      "skill-patterns/worker-notification-conventions.md"
+    ],
+    "tag:conventions": [
+      "skill-patterns/worker-notification-conventions.md"
+    ],
+    "tag:retry": [
+      "skill-patterns/merge-retry-race-condition-pattern.md"
+    ],
+    "tag:conflict-resolution": [
+      "skill-patterns/merge-retry-race-condition-pattern.md"
+    ],
+    "tag:github-api": [
+      "skill-patterns/merge-retry-race-condition-pattern.md",
+      "github-api/graphql-org-user-fallback.md"
+    ]
   }
 }

--- a/docs/solutions/skill-patterns/merge-retry-race-condition-pattern.md
+++ b/docs/solutions/skill-patterns/merge-retry-race-condition-pattern.md
@@ -1,0 +1,66 @@
+---
+title: "Merge retry pattern for race-condition conflicts"
+category: skill-patterns
+tags:
+  - merge
+  - retry
+  - race-condition
+  - github-api
+  - conflict-resolution
+date: 2026-04-11
+status: active
+module: legion-worker
+related_issues:
+  - "411"
+---
+
+# Merge Retry Pattern for Race-Condition Conflicts
+
+## Problem
+
+When a merge worker runs `gh pr merge --squash`, the merge can fail because `main` moved since the last rebase. This is a race condition — another PR was merged between the worker's rebase and merge attempt. The `gh pr merge` command doesn't distinguish "you lost a race" from "you don't have permission" in its error output.
+
+## Solution: PR State Inspection + Bounded Retry
+
+After a merge failure, inspect the PR state to classify the failure before deciding what to do:
+
+```bash
+gh pr view "$LEGION_ISSUE_ID" --json state,mergeable,mergeStateStatus -R $OWNER/$REPO
+```
+
+### Classification
+
+| `state` | `mergeStateStatus` | Meaning | Action |
+|---------|-------------------|---------|--------|
+| `MERGED` | (any) | Another process merged it | Success — proceed to post-merge steps |
+| `OPEN` | `BEHIND` or `DIRTY` | Race condition — main moved | Retry (bounded) |
+| `OPEN` | anything else | Permission error, unknown error | Escalate with `user-input-needed` |
+| `CLOSED` | (any) | PR closed without merge | Escalate — unexpected state |
+
+### Retry Loop
+
+Each retry iteration:
+1. Rebase onto latest main (`jj git fetch && jj rebase -d main`)
+2. Verify clean rebase — `jj status` must show no conflicts
+3. Push
+4. Wait for CI to pass (fix any CI failures)
+5. Retry merge
+
+**Bound:** Max 2 retries. After exhaustion, escalate with `user-input-needed` and `Worker failed:` notification.
+
+### Why bounded
+
+Unbounded retries risk infinite loops on high-traffic repos where `main` moves faster than CI can run. 2 retries is enough for normal race conditions (where 1-2 other PRs merged). If it fails 3 times, something systemic is happening (e.g., a merge train, branch protection rules) that needs human attention.
+
+### Why retry substeps don't notify
+
+Only terminal exits (retry-exhausted, other-error, success) send `envoy_publish` notifications. Intermediate retry iterations are internal to the workflow — the controller doesn't need to know about retries in progress, only final outcomes.
+
+## When to apply this pattern
+
+Any workflow step that:
+1. Can fail due to a race condition (resource moved between check and act)
+2. Has an API to inspect the current state after failure
+3. Can be retried with a fresh state (rebase, re-fetch, re-check)
+
+The `mergeStateStatus` field is GitHub-specific. For Linear or other backends, find the equivalent state inspection mechanism.

--- a/docs/solutions/skill-patterns/worker-notification-conventions.md
+++ b/docs/solutions/skill-patterns/worker-notification-conventions.md
@@ -1,0 +1,82 @@
+---
+title: "Worker notification conventions and two-tier escalation architecture"
+category: skill-patterns
+tags:
+  - envoy
+  - notifications
+  - worker-lifecycle
+  - escalation
+  - conventions
+date: 2026-04-11
+status: active
+module: legion-worker
+related_issues:
+  - "411"
+---
+
+# Worker Notification Conventions and Two-Tier Escalation Architecture
+
+## Three-Tier Message Format
+
+Every `envoy_publish` notification from a worker to the controller uses exactly one of three prefixes:
+
+| Prefix | Meaning | When to use |
+|--------|---------|-------------|
+| `Worker done:` | Success exit | Work completed, PR ready for next phase |
+| `Worker failed:` | Terminal failure | Unrecoverable error, needs investigation |
+| `Worker blocked:` | Needs user input | `user-input-needed` label added, waiting for human |
+
+**Message body format:** `"Worker [done|failed|blocked]: $ISSUE_NUMBER [workflow] [brief reason]"`
+
+Examples:
+- `Worker done: 411 merge completed. Issue closed.`
+- `Worker failed: 411 merge failed — unresolvable rebase conflict`
+- `Worker blocked: 411 plan needs user input — requirements unclear`
+
+**Why the prefix matters:** The controller subscribes to `notifications.role.legion-controller` and can pattern-match on the prefix without parsing the full message. This enables future routing logic without changing the message format.
+
+**Edge case — `already-merged`:** Uses `Worker done:` not `Worker failed:` because the PR was merged (by another process). The merge worker's job is to get the code merged, and that happened — it's a success.
+
+## Two-Tier Escalation Architecture
+
+Worker workflows use two tiers of escalation, and knowing which tier a workflow uses determines where to add notifications:
+
+### Tier 1: Inline Escalation (workflow-specific exit paths)
+
+**Workflows:** architect.md, plan.md, merge.md
+
+These have specific, workflow-unique exit conditions with custom messages. Each exit path includes its own label updates, issue comments, and `envoy_publish` calls inline.
+
+Example: merge.md has 6 distinct failure paths (already-merged, closed-without-merge, unresolvable-conflict, fundamental-CI, retry-exhausted, other-error), each with a unique notification message.
+
+### Tier 2: Delegated Escalation (shared SKILL.md protocol)
+
+**Workflows:** implement.md, review.md, test.md
+
+These delegate all `user-input-needed` escalation to SKILL.md's "Blocking on User Input" section. They don't have inline escalation blocks — instead, their text says "follow the escalation pattern from SKILL.md."
+
+**Consequence:** Adding a notification to SKILL.md's shared protocol automatically covers implement, review, and test escalation paths without touching those workflow files.
+
+### Before adding notifications to a workflow:
+
+1. Check whether the workflow has inline escalation blocks or delegates to SKILL.md
+2. If it delegates, the SKILL.md change covers it — no per-workflow change needed
+3. If it has inline exits, patch each exit point individually (per the cross-cutting-workflow-concerns pattern)
+
+## Notification Pattern
+
+Every notification block follows this structure:
+
+```markdown
+- Notify controller (best-effort):
+  ```
+  envoy_publish(topic="notifications.role.legion-controller", message="Worker [prefix]: $ISSUE_NUMBER [details]")
+  ```
+  If `envoy_publish` fails, continue — the label is the source of truth.
+```
+
+**Key constraint:** Labels are always set BEFORE the notification. The notification is an optimization (faster signal), not the authoritative state. See `daemon/envoy-auto-subscription-patterns.md` for details.
+
+## When NOT to notify
+
+Retry substeps within a workflow (e.g., the merge retry loop) should NOT contain `envoy_publish` calls. Only terminal exits notify. This prevents notification spam during normal retry behavior.

--- a/docs/superpowers/plans/2026-04-11-worker-failure-notifications-merge-retry.md
+++ b/docs/superpowers/plans/2026-04-11-worker-failure-notifications-merge-retry.md
@@ -1,0 +1,386 @@
+# Worker Failure Notifications & Merge Retry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Execute tasks sequentially — do not parallelize.
+
+**Goal:** Add failure notifications to all worker workflow exit paths and bounded retry logic to the merge workflow for race-condition conflicts.
+
+**Architecture:** Two fixes applied to markdown workflow instruction files:
+1. Add `envoy_publish` failure notifications at every non-success exit point across worker workflows and the shared escalation protocol in SKILL.md
+2. Add bounded retry logic (max 2 retries) to merge.md step 6 for handling conflicts when `main` moves between rebase and merge
+
+Notification pattern: best-effort, fire-and-forget, labels remain source of truth. Follow the existing success-notification pattern already in each workflow.
+
+**Tech Stack:** Markdown workflow files (skill instructions for LLM agents), `gh` CLI, `jj`, Envoy `envoy_publish`
+
+**Assumptions:**
+- Only terminal exit notifications — no "retrying" progress signals during the retry loop
+- After a merge failure, use `gh pr view --json state,mergeable,mergeStateStatus` to detect race conditions (BEHIND/DIRTY). For other failures (permission, unknown), the agent reads the error output and uses judgment — the API cannot distinguish these.
+- Post-rebase `jj status` check required before every retry push
+- `test.md` already has pass/fail notifications; its escalation exit delegates to SKILL.md
+- `implement.md` and `review.md` don't have explicit inline escalation exits — they delegate to SKILL.md's shared "Blocking on User Input" protocol
+
+**Relevant learnings:**
+1. `skill-patterns/cross-cutting-workflow-concerns.md`: Pattern for adding cross-cutting steps — patch inline at each exit point rather than creating shared abstractions
+2. `skill-patterns/worker-skill-failure-modes.md`: Real merge failure modes (already-merged, permission errors) that need coverage
+3. `daemon/envoy-auto-subscription-patterns.md`: `envoy_publish` is fire-and-forget; labels are source of truth
+
+---
+
+### Task 1: Merge retry logic + failure notifications in merge.md
+
+**Files:**
+- Modify: `.opencode/skills/legion-worker/workflows/merge.md`
+
+This task modifies merge.md to: (a) add bounded conflict-retry logic to step 6, and (b) add failure notifications to every non-success exit path (steps 1, 3, 5, and 6).
+
+- [ ] **Step 1: Add notification to step 1 — already merged exit**
+
+In step 1 (Check PR State), find the bullet starting with `- If **already merged**` (currently line 16). Replace the single-line bullet with:
+
+```markdown
+- If **already merged**: verify changes are on main (`jj log --revisions main`), then notify the controller and exit cleanly:
+  - Remove `worker-active`:
+    - **GitHub:** `gh issue edit $ISSUE_NUMBER --remove-label "worker-active" -R $OWNER/$REPO`
+    - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current without "worker-active"])`
+  - Notify controller (best-effort):
+    ```
+    envoy_publish(topic="notifications.role.legion-controller", message="Worker done: $ISSUE_NUMBER merge skipped — PR already merged")
+    ```
+    If `envoy_publish` fails, continue — the label is the source of truth.
+  - Exit
+```
+
+- [ ] **Step 2: Add notification to step 1 — closed without merge exit**
+
+In step 1, find the bullet starting with `- If **closed without merge**` (currently line 17). Replace the single-line bullet with:
+
+```markdown
+- If **closed without merge**: something unexpected happened.
+  - Post comment:
+    - **GitHub:** `gh issue comment $ISSUE_NUMBER --body "PR was closed without merging. Unexpected state — needs investigation." -R $OWNER/$REPO`
+    - **Linear:** `linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="PR was closed without merging. Unexpected state.")`
+  - Add `user-input-needed`:
+    - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "user-input-needed" --remove-label "worker-active" -R $OWNER/$REPO`
+    - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current without "worker-active" plus "user-input-needed"])`
+  - Notify controller (best-effort):
+    ```
+    envoy_publish(topic="notifications.role.legion-controller", message="Worker failed: $ISSUE_NUMBER merge failed — PR closed without merge")
+    ```
+    If `envoy_publish` fails, continue — the label is the source of truth.
+  - Exit
+```
+
+- [ ] **Step 3: Add notification to step 3 — unresolvable conflict exit**
+
+In step 3 (Resolve Conflicts), find the `**If conflicts are unresolvable:**` block (currently starting around line 35). Before the final `- Exit` line in that block, insert:
+
+```markdown
+- Notify controller (best-effort):
+  ```
+  envoy_publish(topic="notifications.role.legion-controller", message="Worker failed: $ISSUE_NUMBER merge failed — unresolvable rebase conflict")
+  ```
+  If `envoy_publish` fails, continue — the label is the source of truth.
+```
+
+- [ ] **Step 4: Add explicit escalation with notification to step 5 — fundamental CI failure**
+
+In step 5 (Wait for CI), after the paragraph ending with "Normal code issues like type errors should be fixed, not escalated." (currently line 65), append:
+
+```markdown
+
+**If CI fails with a fundamental issue** (infrastructure failures, impossible conflicts, external service errors — NOT normal code issues):
+- Post comment explaining the fundamental failure:
+  - **GitHub:** `gh issue comment $ISSUE_NUMBER --body "Merge blocked: CI has a fundamental failure that cannot be fixed by the merge worker. [describe the issue]" -R $OWNER/$REPO`
+  - **Linear:** `linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="Merge blocked: fundamental CI failure.")`
+- Add `user-input-needed` label:
+  - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "user-input-needed" --remove-label "worker-active" -R $OWNER/$REPO`
+  - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current without "worker-active" plus "user-input-needed"])`
+- Notify controller (best-effort):
+  ```
+  envoy_publish(topic="notifications.role.legion-controller", message="Worker failed: $ISSUE_NUMBER merge blocked — fundamental CI failure")
+  ```
+  If `envoy_publish` fails, continue — the label is the source of truth.
+- Exit
+```
+
+- [ ] **Step 5: Replace step 6 with retry-aware version**
+
+Replace the entire step 6 content — from `### 6. Merge` (currently line 67) through the permission-error exit block ending with `- Exit — the user needs to merge manually or grant access` (currently line 80) — with:
+
+```markdown
+### 6. Merge (with conflict retry)
+
+Attempt to merge. If the merge fails due to a race condition (main moved since rebase), retry.
+
+```bash
+gh pr merge "$LEGION_ISSUE_ID" --squash --delete-branch
+```
+
+**If merge succeeds:** Proceed to step 7.
+
+**If merge fails — classify the failure** by checking PR state:
+
+```bash
+gh pr view "$LEGION_ISSUE_ID" --json state,mergeable,mergeStateStatus -R $OWNER/$REPO
+```
+
+**If `state` is `MERGED`:** The PR was merged by another process (manual merge, auto-merge). Proceed to step 7 — this is a success, not a failure.
+
+**If `mergeStateStatus` is `BEHIND` or `DIRTY` (race condition — main moved):**
+
+Retry up to **2 times** (track your retry count):
+
+1. Rebase onto latest main:
+   ```bash
+   jj git fetch
+   jj rebase -d main
+   ```
+2. Verify clean rebase — `jj status` must show no conflicts. If conflicts exist, resolve them (same as step 3). If conflicts are unresolvable, exit via the unresolvable-conflict path in step 3.
+3. Push: `jj git push`
+4. Wait for CI: `gh pr checks "$LEGION_ISSUE_ID" --watch` — fix any CI failures (same as step 5)
+5. Retry merge: `gh pr merge "$LEGION_ISSUE_ID" --squash --delete-branch`
+6. If merge succeeds, proceed to step 7. If it fails again, go back to substep 1 (unless retries exhausted).
+
+**If merge still fails after 2 retries:**
+- Post comment:
+  - **GitHub:** `gh issue comment $ISSUE_NUMBER --body "Merge failed after 2 conflict retries. The PR keeps falling behind main despite rebasing. Manual intervention needed." -R $OWNER/$REPO`
+  - **Linear:** `linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="Merge failed after 2 conflict retries. Manual intervention needed.")`
+- Add `user-input-needed` label:
+  - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "user-input-needed" --remove-label "worker-active" -R $OWNER/$REPO`
+  - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current without "worker-active" plus "user-input-needed"])`
+- Notify controller (best-effort):
+  ```
+  envoy_publish(topic="notifications.role.legion-controller", message="Worker failed: $ISSUE_NUMBER merge failed after 2 conflict retries")
+  ```
+  If `envoy_publish` fails, continue — the label is the source of truth.
+- Exit
+
+**If merge fails for any other reason** (permission error, unknown error — inspect the error output to determine the cause):
+- Post a comment describing the failure and what you observed:
+  - **GitHub:** `gh issue comment $ISSUE_NUMBER --body "Merge failed: [describe the error — permission denied, unexpected API error, etc.]. Manual intervention needed." -R $OWNER/$REPO`
+  - **Linear:** `linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="Merge failed: [describe error].")`
+- Add `user-input-needed` label:
+  - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "user-input-needed" --remove-label "worker-active" -R $OWNER/$REPO`
+  - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current without "worker-active" plus "user-input-needed"])`
+- Notify controller (best-effort):
+  ```
+  envoy_publish(topic="notifications.role.legion-controller", message="Worker failed: $ISSUE_NUMBER merge failed — [brief error description]")
+  ```
+  If `envoy_publish` fails, continue — the label is the source of truth.
+- Exit
+```
+
+- [ ] **Step 6: Verify merge.md changes**
+
+Run: `grep -c "envoy_publish" .opencode/skills/legion-worker/workflows/merge.md`
+Expected: at least `7` (1 success in step 7.5 + 6 failure: already-merged, closed-without-merge, unresolvable-conflict, fundamental-CI, retry-exhausted, other-error)
+
+Run: `grep "mergeStateStatus" .opencode/skills/legion-worker/workflows/merge.md`
+Expected: at least 2 lines (the `gh pr view` command and the BEHIND/DIRTY condition)
+
+Run: `grep "2 retries\|2 times" .opencode/skills/legion-worker/workflows/merge.md`
+Expected: at least 2 matches
+
+---
+
+### Task 2: Failure notifications for SKILL.md, architect.md, and plan.md
+
+**Files:**
+- Modify: `.opencode/skills/legion-worker/SKILL.md` (Blocking on User Input section)
+- Modify: `.opencode/skills/legion-worker/workflows/architect.md` (step 3 "If unclear" exit)
+- Modify: `.opencode/skills/legion-worker/workflows/plan.md` (steps 2 and 4 escalation exits)
+
+This task adds failure notifications to: (a) the shared "Blocking on User Input" protocol in SKILL.md (covers implement, review, and test escalation exits), (b) architect.md's inline "unclear" exit, and (c) plan.md's two inline escalation exits.
+
+- [ ] **Step 1: Add notification to SKILL.md shared escalation protocol**
+
+In SKILL.md, find the "Blocking on User Input" section. The current numbered steps are:
+
+```
+1. Push your work: `jj git push`
+2. Post a structured escalation comment to the issue: [...]
+3. Update labels: add `user-input-needed`, remove `worker-active`
+4. Exit immediately
+```
+
+Insert a new step 4 between "Update labels" (current step 3) and "Exit immediately" (current step 4), and renumber:
+
+```markdown
+3. Update labels: add `user-input-needed`, remove `worker-active`
+4. Notify the controller via Envoy (best-effort):
+   ```
+   envoy_publish(topic="notifications.role.legion-controller", message="Worker blocked: $ISSUE_NUMBER [current mode] needs user input")
+   ```
+   If `envoy_publish` fails, continue — the label is the source of truth.
+5. Exit immediately
+```
+
+Note: `[current mode]` is a placeholder the worker fills in with their actual mode (architect, plan, implement, test, review, merge). This matches how `$ISSUE_NUMBER` is already used as a placeholder throughout the workflows.
+
+- [ ] **Step 2: Add notification to architect.md — unclear exit**
+
+In architect.md step 3 (Act), find the line `**If unclear:** Add \`user-input-needed\` label, remove \`worker-active\` label, post comment with specific questions, exit.` (currently line 61). Replace it with:
+
+```markdown
+**If unclear:**
+- Add `user-input-needed` label:
+  - **GitHub:** `gh issue edit $ISSUE_NUMBER --add-label "user-input-needed" --remove-label "worker-active" -R $OWNER/$REPO`
+  - **Linear:** `linear_linear(action="update", id=$LEGION_ISSUE_ID, labels=[...current without "worker-active" plus "user-input-needed"])`
+- Post comment with specific questions:
+  - **GitHub:** `gh issue comment $ISSUE_NUMBER --body "..." -R $OWNER/$REPO`
+  - **Linear:** `linear_linear(action="comment", id=$LEGION_ISSUE_ID, body="...")`
+- Notify controller (best-effort):
+  ```
+  envoy_publish(topic="notifications.role.legion-controller", message="Worker blocked: $ISSUE_NUMBER architect needs user input")
+  ```
+  If `envoy_publish` fails, continue — the label is the source of truth.
+- Exit
+```
+
+- [ ] **Step 3: Add notification to plan.md step 2 — unclear requirements exit**
+
+In plan.md step 2 (inside the `**If the skill determines requirements are fundamentally unclear**` block), the current escalation substeps end with:
+
+```
+3. Exit immediately - do NOT add `worker-done`
+```
+
+Insert a new substep 3 before Exit and renumber:
+
+```markdown
+3. Notify controller (best-effort):
+   ```
+   envoy_publish(topic="notifications.role.legion-controller", message="Worker blocked: $ISSUE_NUMBER plan needs user input — requirements unclear")
+   ```
+   If `envoy_publish` fails, continue — the label is the source of truth.
+4. Exit immediately - do NOT add `worker-done`
+```
+
+- [ ] **Step 4: Add notification to plan.md step 4 — review max iterations exit**
+
+In plan.md step 4 (inside the `**Max 3 iterations.** If still failing:` block), the current escalation substeps end with:
+
+```
+3. Exit without `worker-done`
+```
+
+Insert a new substep 3 before Exit and renumber:
+
+```markdown
+3. Notify controller (best-effort):
+   ```
+   envoy_publish(topic="notifications.role.legion-controller", message="Worker blocked: $ISSUE_NUMBER plan review failed after 3 iterations")
+   ```
+   If `envoy_publish` fails, continue — the label is the source of truth.
+4. Exit without `worker-done`
+```
+
+- [ ] **Step 5: Verify all non-merge changes**
+
+Run: `grep -c "envoy_publish" .opencode/skills/legion-worker/SKILL.md`
+Expected: at least `1`
+
+Run: `grep -c "envoy_publish" .opencode/skills/legion-worker/workflows/architect.md`
+Expected: at least `2` (1 existing success + 1 new failure)
+
+Run: `grep -c "envoy_publish" .opencode/skills/legion-worker/workflows/plan.md`
+Expected: at least `3` (1 existing success + 2 new failure)
+
+---
+
+### Task 3: Final verification and commit
+
+**Files:** All modified files (read-only verification), then commit
+
+- [ ] **Step 1: Read each modified file's exit paths and confirm notification coverage**
+
+Read the changed sections of each file and verify:
+
+1. **merge.md**: Every exit path (steps 1, 3, 5, 6, 7.5) has exactly one `envoy_publish` call. The retry substeps (1-6 inside step 6) do NOT contain any `envoy_publish` — only the terminal exits after retry exhaustion or other failure.
+
+2. **SKILL.md**: The "Blocking on User Input" section includes an `envoy_publish` step between label update and exit.
+
+3. **architect.md**: The "If unclear" exit in step 3 includes an `envoy_publish` call.
+
+4. **plan.md**: Both escalation exits (step 2 unclear requirements, step 4 review max iterations) include `envoy_publish` calls. Step 1.5's escalation delegates to SKILL.md (covered by SKILL.md change).
+
+5. **implement.md, review.md, test.md**: No changes needed. Verify these files do NOT have inline `user-input-needed` escalation exits with explicit label/comment instructions — their only escalation path is through SKILL.md's general "Blocking on User Input" protocol (now updated with a notification). Run: `grep -c "user-input-needed" .opencode/skills/legion-worker/workflows/implement.md .opencode/skills/legion-worker/workflows/review.md .opencode/skills/legion-worker/workflows/test.md` — any matches should be in descriptive text or test-specific pass/fail handling, not in inline escalation blocks that duplicate the SKILL.md protocol.
+
+- [ ] **Step 2: Verify notification message format consistency**
+
+Run: `grep -r "envoy_publish.*message=" .opencode/skills/legion-worker/workflows/ .opencode/skills/legion-worker/SKILL.md`
+
+All notification messages should follow one of these patterns:
+- `Worker done:` — success exits
+- `Worker failed:` — terminal failure exits
+- `Worker blocked:` — user-input-needed exits
+
+- [ ] **Step 3: Commit all changes**
+
+```bash
+jj describe -m "fix(worker): add failure notifications to all worker workflows and merge retry logic
+
+Adds envoy_publish failure notifications at every non-success exit path across
+worker workflows (merge, architect, plan) and the shared escalation protocol
+in SKILL.md. Adds bounded retry logic (max 2 retries) to the merge workflow
+for handling race-condition conflicts when main moves between rebase and merge.
+
+Closes #411"
+```
+
+---
+
+## Testing Plan
+
+### Setup
+- No infrastructure needed — these are markdown file edits
+- The workspace should be on the issue branch with all changes applied
+
+### Health Check
+- All modified files exist: `merge.md`, `SKILL.md`, `architect.md`, `plan.md`
+- `jj diff --stat` shows only the expected files changed
+
+### Verification Steps
+
+1. **Merge retry logic is bounded and uses PR state inspection**
+   - Action: `grep -c "mergeStateStatus" .opencode/skills/legion-worker/workflows/merge.md`
+   - Expected: at least 2 (the `gh pr view` command and the BEHIND/DIRTY condition)
+   - Action: `grep "2 retries\|2 times" .opencode/skills/legion-worker/workflows/merge.md`
+   - Expected: at least 2 matches referencing the retry bound
+   - Tool: grep
+
+2. **Every terminal exit path in merge.md has exactly one notification**
+   - Action: `grep -c "envoy_publish" .opencode/skills/legion-worker/workflows/merge.md`
+   - Expected: at least 7 (1 success + 6 failure)
+   - Action: Read the retry substeps and confirm NO `envoy_publish` inside the retry loop body — only after retry exhaustion
+   - Tool: grep + Read
+
+3. **Shared escalation protocol and non-merge workflows have failure notifications**
+   - Action: `grep -c "envoy_publish" .opencode/skills/legion-worker/SKILL.md`
+   - Expected: at least 1
+   - Action: `grep -c "envoy_publish" .opencode/skills/legion-worker/workflows/architect.md`
+   - Expected: at least 2
+   - Action: `grep -c "envoy_publish" .opencode/skills/legion-worker/workflows/plan.md`
+   - Expected: at least 3
+   - Tool: grep
+
+### Skills to Invoke
+- `verification-before-completion` — verify all acceptance criteria are met before marking done
+
+### Tools Needed
+- grep (for content verification)
+- Read tool (for exit path coverage review)
+- jj (for commit verification)
+
+## Required Skills
+
+The following project-specific skills should be loaded by downstream workers:
+
+| Phase | Skills |
+|-------|--------|
+| Implement | (none beyond standard — markdown file edits) |
+| Test | `verification-before-completion` |
+| Review | (none beyond standard) |
+
+Workers: invoke these skills at the start of your workflow before beginning work.
+If a skill is unavailable in your environment, proceed without it.


### PR DESCRIPTION
Closes #411

## Summary

Adds `envoy_publish` failure notifications at every non-success exit path across worker workflows (merge, architect, plan) and the shared escalation protocol in SKILL.md. Adds bounded retry logic (max 2 retries) to the merge workflow for handling race-condition conflicts when main moves between rebase and merge.

### Changes

- **merge.md**: 6 new failure notifications (already-merged, closed-without-merge, unresolvable-conflict, fundamental-CI, retry-exhausted, other-error) + retry-aware step 6 with PR state inspection (`mergeStateStatus` BEHIND/DIRTY detection)
- **SKILL.md**: 1 new notification in shared "Blocking on User Input" protocol (covers implement, review, test escalation paths)
- **architect.md**: 1 new notification at "If unclear" exit + expanded with GitHub/Linear commands
- **plan.md**: 2 new notifications (unclear requirements exit, review max iterations exit)

### Message format convention

All notifications follow one of three patterns:
- `Worker done:` — success exits
- `Worker failed:` — terminal failure exits
- `Worker blocked:` — user-input-needed exits