### PR TITLE
sjawhar-legion-218: Knowledge compounding — inject learnings + feedback tracking

### DIFF
--- a/.legion/architect.json
+++ b/.legion/architect.json
@@ -1,37 +1,41 @@
 {
-  "schemaVersion": 1,
-  "phase": "architect",
-  "completed": "2026-04-11T03:38:56.123Z",
-  "learningsInjected": [
-    "docs/solutions/daemon/controller-observability.md",
-    "docs/solutions/daemon/envoy-auto-subscription-patterns.md",
-    "docs/solutions/daemon/state-machine-action-display-mismatch.md",
-    "docs/solutions/daemon/controller-lifecycle-separation.md"
-  ],
-  "learningsHelpful": [
-    "docs/solutions/daemon/controller-observability.md",
-    "docs/solutions/daemon/envoy-auto-subscription-patterns.md",
-    "docs/solutions/daemon/controller-lifecycle-separation.md"
-  ],
   "scope": "medium",
   "components": [
-    "packages/daemon/src/daemon/server.ts",
-    "packages/daemon/src/daemon/index.ts",
-    "packages/daemon/src/daemon/state-delta.ts",
-    "packages/daemon/src/state/types.ts"
+    ".opencode/skills/legion-worker/workflows/architect.md",
+    ".opencode/skills/legion-worker/workflows/plan.md",
+    ".opencode/skills/legion-worker/workflows/implement.md",
+    ".opencode/skills/legion-worker/workflows/test.md",
+    ".opencode/skills/legion-worker/workflows/review.md",
+    ".opencode/skills/legion-worker/references/knowledge-injection.md",
+    "packages/daemon/src/handoff/types.ts",
+    "packages/daemon/src/handoff/schema.ts"
   ],
-  "subIssues": [],
+  "subIssues": [
+    "sjawhar-legion-238",
+    "sjawhar-legion-239",
+    "sjawhar-legion-240"
+  ],
   "routingHints": {
     "complexity": "medium",
     "estimatedImplementers": 1,
-    "skipRetro": false
+    "skipRetro": true
   },
   "concerns": [
-    "Extract fetchAndCollectState() as a shared helper — do NOT self-call the daemon HTTP endpoint from the health tick (per controller-lifecycle-separation.md pattern)",
-    "Labels must be compared as sorted unique sets — raw array order must not trigger false positives",
-    "Delta payload includes full IssueStateDict for new/changed issues — changedFields is advisory for logging only, not for state reconstruction",
-    "previousIssueState baseline only advances on successful collection — failed fetches preserve last-known-good baseline",
-    "Envoy publish is fire-and-forget and best-effort — no subscriber (between daemon restart and controller spin-up) is expected and non-fatal",
-    "First cycle (previousIssueState is null) establishes baseline without publishing — prevents spurious everything-is-new notification on daemon startup"
-  ]
+    "Sub-issues #238 and #239 are already CLOSED (implemented, tested, merged). No further implementation needed.",
+    "Sub-issue #240 (index evolution) is intentionally blocked until 20+ issues accumulate feedback data — do NOT attempt to implement.",
+    "The cross-cutting-workflow-concerns learning (shared reference + inline config tables) was the pattern used for #238 — confirmed working.",
+    "Handoff schema migration pattern (learningsUsed → learningsInjected) uses Zod transform for backward compat — tested in ledger.test.ts."
+  ],
+  "learningsInjected": [
+    "skill-patterns/cross-cutting-workflow-concerns.md",
+    "daemon/handoff-schema-migration-patterns.md",
+    "skill-patterns/worker-skill-failure-modes.md"
+  ],
+  "learningsHelpful": [
+    "skill-patterns/cross-cutting-workflow-concerns.md",
+    "daemon/handoff-schema-migration-patterns.md"
+  ],
+  "schemaVersion": 1,
+  "phase": "architect",
+  "completed": "2026-04-11T12:57:56.111Z"
 }

--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,14 +1,16 @@
 {
-  "filesChanged": ["packages/envoy/internal/mcpbridge/http_server_test.go"],
+  "filesChanged": [],
   "trickyParts": [
-    "Race condition in test mock: sseWriter/sseConn were set AFTER writing the endpoint event, but the client reads the event and immediately POSTs to /message. On slow CI, sendSSE() found nil fields and silently dropped the initialize response, causing a 30s timeout."
+    "No implementation needed — all implementable sub-issues (#238, #239) were already completed and merged before this dispatch"
   ],
   "deviations": [
-    "Fix is in test mock only (not production code) — the race was in the test helper, not the HTTPServer implementation"
+    "No-op implementation phase: architect and planner both confirmed no remaining work. #240 (index evolution) is intentionally deferred until 20+ issues accumulate feedback data."
   ],
-  "openQuestions": [],
+  "openQuestions": [
+    "#240 remains open and blocked on data accumulation — should #218 be closed since Changes 1 and 2 are complete?"
+  ],
   "subPlanningNeeded": false,
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-10T23:50:29.040Z"
+  "completed": "2026-04-11T13:07:41.264Z"
 }

--- a/.legion/plan.json
+++ b/.legion/plan.json
@@ -1,38 +1,24 @@
 {
-  "schemaVersion": 1,
-  "phase": "plan",
-  "completed": "2026-04-11T03:54:19.565Z",
-  "taskCount": 8,
-  "independentTasks": 3,
+  "taskCount": 0,
+  "independentTasks": 0,
   "routingHints": {
-    "complexity": "medium",
-    "estimatedImplementers": 1,
-    "skipRetro": false,
-    "skipArchitect": false
+    "complexity": "none",
+    "estimatedImplementers": 0,
+    "skipRetro": true,
+    "skipArchitect": true
   },
   "concerns": [
-    "fetchAndCollectState helper references server.port — implementer needs to handle forward declaration or use opts.port",
-    "previousIssueState uses IssueStateDict (serialized form) not IssueState — must convert via IssueState.toDict()",
-    "publishStateDelta is fire-and-forget — must not affect fetch-and-collect response",
-    "Label comparison must use sorted unique sets, not raw array equality",
-    "First cycle must not publish (baseline establishment)",
-    "Health tick guard: serveHealthy && !restartReason — skip when serve just restarted",
-    "Both /state/collect and /state/fetch-and-collect handlers need delta integration"
+    "All implementable sub-issues (#238, #239) are already CLOSED with worker-done and test-passed labels.",
+    "Sub-issue #240 (index evolution) is intentionally blocked until 20+ issues accumulate feedback data — do NOT attempt to implement.",
+    "No plan produced — nothing remains to implement for #218."
   ],
   "learningsInjected": [
-    "daemon/controller-lifecycle-separation.md",
-    "daemon/envoy-auto-subscription-patterns.md",
-    "testing/bun-fetch-mocking-patterns.md"
+    "skill-patterns/cross-cutting-workflow-concerns.md",
+    "daemon/handoff-schema-migration-patterns.md"
   ],
-  "learningsHelpful": [
-    "daemon/controller-lifecycle-separation.md",
-    "daemon/envoy-auto-subscription-patterns.md",
-    "testing/bun-fetch-mocking-patterns.md"
-  ],
-  "workflowRecommendation": "Standard pipeline — all phases needed. Single implementer, TDD for pure function, integration tests for publish and health tick.",
-  "requiredSkills": {
-    "implement": ["test-driven-development", "envoy"],
-    "test": ["verification-before-completion"],
-    "review": []
-  }
+  "learningsHelpful": [],
+  "workflowRecommendation": "No implementation needed — close #218 as completed. #240 remains open as separate tracking ticket.",
+  "schemaVersion": 1,
+  "phase": "plan",
+  "completed": "2026-04-11T13:02:16.603Z"
 }

--- a/.legion/retro.json
+++ b/.legion/retro.json
@@ -1,7 +1,7 @@
 {
-  "skipped": false,
-  "docsCreated": ["docs/solutions/testing/sse-mock-initialization-order.md"],
+  "skipped": true,
+  "reason": "no significant learnings — implement phase was a no-op (sub-issues #238/#239 already complete)",
   "schemaVersion": 1,
   "phase": "retro",
-  "completed": "2026-04-11T00:08:06.342Z"
+  "completed": "2026-04-11T13:31:56.968Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,36 +1,24 @@
 {
   "critical": 0,
-  "important": 2,
-  "minor": 2,
+  "important": 1,
+  "minor": 0,
   "verdict": "approved",
   "keyFindings": [
     {
       "severity": "P2",
-      "file": "packages/envoy/deploy/README.md",
-      "description": "Lines 74, 83 still reference ENVOY_REGISTRY_DIR which was removed in this PR. Deployers following docs will try to set non-existent config."
-    },
-    {
-      "severity": "P2",
-      "file": "packages/envoy/infra/README.md",
-      "description": "Line 108 still documents listener.registryDir as required config, but the field was removed from ListenerConfig interface."
-    },
-    {
-      "severity": "P3",
-      "file": "packages/envoy/cmd/listener/main.go",
-      "description": "listenerDeps.sessions uses concrete *SessionRegistry instead of SessionLookup interface. Pragmatic for List() needed by /v1/sessions, acceptable trade-off."
-    },
-    {
-      "severity": "P3",
-      "file": "packages/envoy/internal/mcpbridge/http_server_test.go",
-      "description": "Race condition fix is correct — sseWriter/sseConn now set before endpoint event write."
+      "file": ".opencode/skills/legion-worker/references/knowledge-injection.md",
+      "description": "Line 91 references deprecated `learningsUsed` field instead of canonical `learningsInjected`. Stale cross-reference missed during #239 field rename. The learning doc daemon/handoff-schema-migration-patterns.md (line 81) explicitly warned about this class of bug."
     }
   ],
   "learningsInjected": [
-    "docs/solutions/testing/nats-kv-testing-patterns.md",
-    "docs/solutions/architecture-patterns/nats-kv-dual-bucket-lifecycle.md"
+    "skill-patterns/cross-cutting-workflow-concerns.md",
+    "daemon/handoff-schema-migration-patterns.md",
+    "skill-patterns/worker-skill-failure-modes.md"
   ],
-  "learningsHelpful": ["docs/solutions/testing/nats-kv-testing-patterns.md"],
+  "learningsHelpful": [
+    "daemon/handoff-schema-migration-patterns.md"
+  ],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-11T00:03:37.343Z"
+  "completed": "2026-04-11T13:29:34.440Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,22 +1,23 @@
 {
-  "passed": 5,
+  "passed": 12,
   "failed": 0,
   "failures": [],
-  "documentationFeedback": "PR description is excellent with clear sub-item separation. Two README files have stale references: deploy/README.md still lists ENVOY_REGISTRY_DIR as a required env var, infra/README.md still documents listener.registryDir as required. These should be cleaned up to avoid confusing deployers.",
+  "documentationFeedback": "knowledge-injection.md is clear and comprehensive (91 lines). P2: line 91 refers to deprecated `learningsUsed` instead of canonical `learningsInjected` — inconsistency introduced when #239 renamed the field but didn't update the reference file.",
   "observations": [
-    "P2: packages/envoy/deploy/README.md (lines 74, 83) still references ENVOY_REGISTRY_DIR",
-    "P2: packages/envoy/infra/README.md (line 108) still documents listener.registryDir as required",
-    "P2: No explicit negative test for file registry removal (implicitly tested by absence of file-based infrastructure)",
-    "Minor: listenerDeps.sessions uses concrete *SessionRegistry instead of SessionLookup interface (pragmatic — needed for List() on /v1/sessions)",
-    "Sub-item (3) oc ps changes are external to this repo (in ~/.dotfiles/scripts/oc) — marked N/A, not failed"
+    "P2: references/knowledge-injection.md line 91 says `learningsUsed` but canonical field is `learningsInjected` (renamed in #239)",
+    "Production evidence: #218's own architect handoff includes learningsInjected/learningsHelpful with real values, proving end-to-end functionality",
+    "Pre-existing test failures (3/1154): 2 from @pulumi/docker infra tests, 1 from daemon env var test — unrelated to #218"
   ],
   "learningsInjected": [
-    "testing/nats-kv-testing-patterns.md",
-    "architecture-patterns/nats-kv-dual-bucket-lifecycle.md",
-    "architecture-patterns/nats-kv-graceful-degradation.md"
+    "skill-patterns/cross-cutting-workflow-concerns.md",
+    "daemon/handoff-schema-migration-patterns.md",
+    "skill-patterns/worker-skill-failure-modes.md"
   ],
-  "learningsHelpful": ["testing/nats-kv-testing-patterns.md"],
+  "learningsHelpful": [
+    "skill-patterns/cross-cutting-workflow-concerns.md",
+    "daemon/handoff-schema-migration-patterns.md"
+  ],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-10T23:56:46.858Z"
+  "completed": "2026-04-11T13:18:59.785Z"
 }

--- a/.opencode/skills/legion-worker/references/knowledge-injection.md
+++ b/.opencode/skills/legion-worker/references/knowledge-injection.md
@@ -88,4 +88,4 @@ When a keyword source is unavailable (missing handoff data, empty fields, missin
 
 ## Integration with Handoffs
 
-If the phase writes handoff data, include a `learningsUsed` field listing the `docs/solutions/` relative paths of all injected learnings. This enables downstream phases to see what knowledge was available and supports future aggregation.
+If the phase writes handoff data, include a `learningsInjected` field listing the `docs/solutions/` relative paths of all injected learnings. This enables downstream phases to see what knowledge was available and supports future aggregation.


### PR DESCRIPTION
Closes #218

## Summary

All implementable work for #218 was completed via sub-issues:

- **#238** — Extended knowledge injection to all 5 worker phases (architect, plan, implement, test, review). Added shared `references/knowledge-injection.md` algorithm. ✅ CLOSED
- **#239** — Added `learningsInjected`/`learningsHelpful` tracking to handoff schema (`BaseHandoff`), migrated deprecated `learningsUsed` field with backward-compat Zod transform. ✅ CLOSED
- **#240** — Index evolution consolidation. Intentionally deferred until 20+ issues accumulate feedback data. OPEN (`user-input-needed`)

## P2 Fix (merge phase)

Fixed stale field reference in `knowledge-injection.md` line 91: `learningsUsed` → `learningsInjected` (flagged by both tester and reviewer).