### PR TITLE
sjawhar-legion-416: remove stale ENVOY_REGISTRY_DIR references from docs

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,36 +1,13 @@
 {
   "filesChanged": [
-    "packages/daemon/src/state/types.ts",
-    "packages/daemon/src/state/__tests__/types.test.ts",
-    "packages/daemon/src/daemon/server.ts",
-    "packages/daemon/src/daemon/__tests__/server.test.ts",
-    "packages/daemon/src/cli/index.ts",
-    "packages/daemon/src/cli/__tests__/index.test.ts"
+    "packages/envoy/infra/README.md",
+    "packages/envoy/deploy/README.md"
   ],
-  "trickyParts": [
-    "Duplicate session guard placement: moved to right before workers.set() to minimize any race window between check and insert",
-    "OC registry scanning requires defensive parsing — external contract in ~/.dotfiles/scripts/oc may change format",
-    "No CI checks configured for PR branches — all verification done locally (bun test, biome check, tsc)"
-  ],
-  "deviations": [
-    "Analyze agent added defensive improvements: path traversal validation in scanOcRegistry, safer null checks in registryEntry handling, narrower type guards for activity fields and legionId cast in server.ts dashboard handler — kept as boy scout cleanup since they're in files we're already modifying"
-  ],
-  "openQuestions": [
-    "No CI runs triggered on this branch — tester should verify tests pass in their environment",
-    "SIGHUP cleanup and prompt queue-order behavior are manual verification items per the plan (not CI-testable)"
-  ],
+  "trickyParts": [],
+  "deviations": [],
+  "openQuestions": [],
   "subPlanningNeeded": false,
-  "learningsInjected": [
-    "docs/solutions/deterministic-session-ids.md",
-    "docs/solutions/daemon/server-side-dispatch-validation.md",
-    "docs/solutions/daemon/prompt-delivery-bootstrap-delay.md"
-  ],
-  "learningsHelpful": [
-    "docs/solutions/deterministic-session-ids.md",
-    "docs/solutions/daemon/server-side-dispatch-validation.md",
-    "docs/solutions/daemon/prompt-delivery-bootstrap-delay.md"
-  ],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-11T14:03:05.251Z"
+  "completed": "2026-04-11T17:02:52.172Z"
 }

--- a/.legion/plan.json
+++ b/.legion/plan.json
@@ -1,37 +1,18 @@
 {
-  "taskCount": 6,
+  "taskCount": 2,
   "independentTasks": 1,
   "routingHints": {
-    "complexity": "none",
-    "estimatedImplementers": 0,
+    "complexity": "small",
+    "estimatedImplementers": 1,
     "skipRetro": true,
     "skipArchitect": true
   },
   "concerns": [
-    "Instance bootstrap on shared serve: adopted sessions exist in SQLite but may not have in-memory Instance — sendPrompt readiness-wait pattern handles this via existing SESSION_READY_DELAY_MS + retry",
-    "Duplicate session adoption guard must scan ALL live worker entries for matching sessionId, not just workerId conflict check",
-    "OC registry contract is external (in ~/.dotfiles/scripts/oc) — parse defensively, tolerate missing/malformed entries",
-    "422 for invalid sessionId format is intentional (semantic validation) — document this API choice",
-    "SIGHUP PID is transient CLI concern only — do NOT persist in WorkerEntry or workers.json",
-    "DuplicateIDError idempotent success is handled by existing serve-manager.ts code (lines 119-129) — no new code needed for this acceptance criterion"
+    "Active infra code files (services.ts, machines.ts, Pulumi.prod.yaml, compose) are already clean — only README documentation references remain",
+    "Issue description names code files that are already clean; implementer should not fabricate edits to those files"
   ],
-  "learningsInjected": [
-    "deterministic-session-ids.md",
-    "daemon/server-side-dispatch-validation.md",
-    "daemon/prompt-delivery-bootstrap-delay.md"
-  ],
-  "learningsHelpful": [
-    "deterministic-session-ids.md",
-    "daemon/server-side-dispatch-validation.md",
-    "daemon/prompt-delivery-bootstrap-delay.md"
-  ],
-  "workflowRecommendation": "Standard pipeline — all phases needed. Single implementer, TDD for server changes, mock-based CLI tests.",
-  "requiredSkills": {
-    "implement": ["test-driven-development", "envoy"],
-    "test": ["verification-before-completion"],
-    "review": []
-  },
+  "workflowRecommendation": "Simple doc cleanup — skip retro, single implementer, skip architect",
   "schemaVersion": 1,
   "phase": "plan",
-  "completed": "2026-04-11T13:35:40.624Z"
+  "completed": "2026-04-11T16:54:15.356Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,39 +1,10 @@
 {
   "critical": 0,
   "important": 0,
-  "minor": 4,
+  "minor": 0,
   "verdict": "approved",
-  "keyFindings": [
-    {
-      "severity": "P3",
-      "file": "packages/daemon/src/daemon/server.ts",
-      "description": "Duplicate session guard runs after createSession() — functionally correct (idempotent), but cleaner if moved before"
-    },
-    {
-      "severity": "P3",
-      "file": "packages/daemon/src/cli/__tests__/index.test.ts",
-      "description": "Missing test for workspace resolution failure path in cmdAdopt (CliError when --workspace not provided and registry returns null)"
-    },
-    {
-      "severity": "P3",
-      "file": "packages/daemon/src/cli/__tests__/index.test.ts",
-      "description": "Missing test for path traversal validation in scanOcRegistry (entryDir with '..' should be skipped)"
-    },
-    {
-      "severity": "P3",
-      "file": "packages/daemon/src/cli/index.ts",
-      "description": "No warning when OC registry lookup is skipped due to explicit --workspace — original standalone process may remain running"
-    }
-  ],
-  "learningsInjected": [
-    "docs/solutions/deterministic-session-ids.md",
-    "docs/solutions/daemon/server-side-dispatch-validation.md",
-    "docs/solutions/daemon/prompt-delivery-bootstrap-delay.md"
-  ],
-  "learningsHelpful": [
-    "docs/solutions/daemon/server-side-dispatch-validation.md"
-  ],
+  "keyFindings": [],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-11T16:47:43.441Z"
+  "completed": "2026-04-11T17:14:04.046Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,26 +1,15 @@
 {
-  "passed": 11,
+  "passed": 6,
   "failed": 0,
   "failures": [],
-  "documentationFeedback": "Implementation plan (docs/plans/2026-04-11-session-adoption.md) is comprehensive. PR description accurately reflects changes. No user-facing docs needed — CLI has inline descriptions.",
+  "documentationFeedback": "Both READMEs read cleanly after removals. infra/README.md machine config table flows naturally. deploy/README.md env list and example are coherent and consistent.",
   "observations": [
-    "P2: No warning emitted when OC registry lookup is skipped (--workspace provided externally) — original standalone process may remain running without user awareness",
-    "P2: Duplicate session guard runs after createSession() — not harmful due to idempotency, but placing guard before createSession() would be cleaner",
-    "P2: No test for CliError when --workspace not provided and registry lookup fails",
-    "P2: No test for path traversal validation in scanOcRegistry",
-    "Pre-existing: 3 test failures unrelated to this PR (2 @pulumi/docker, 1 daemon entry env vars)"
+    "listener.registryDir was marked Required:Yes in infra README — correct to remove since file registry no longer exists",
+    "Planner correctly identified that named code files were already clean; only doc refs remained"
   ],
-  "learningsInjected": [
-    "docs/solutions/deterministic-session-ids.md",
-    "docs/solutions/daemon/server-side-dispatch-validation.md",
-    "docs/solutions/daemon/prompt-delivery-bootstrap-delay.md",
-    "docs/solutions/testing/bun-fetch-mocking-patterns.md"
-  ],
-  "learningsHelpful": [
-    "docs/solutions/daemon/prompt-delivery-bootstrap-delay.md",
-    "docs/solutions/testing/bun-fetch-mocking-patterns.md"
-  ],
+  "learningsInjected": [],
+  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-11T16:38:57.294Z"
+  "completed": "2026-04-11T17:11:02.612Z"
 }

--- a/packages/envoy/deploy/README.md
+++ b/packages/envoy/deploy/README.md
@@ -71,7 +71,6 @@ deploy/scripts/up-nats-peer.sh
 - `ENVOY_MACHINE_ID`
 - `NATS_URLS`
 - `ENVOY_HOME`
-- `ENVOY_REGISTRY_DIR`
 - `ENVOY_OPENCODE_BIN`
 
 Example:
@@ -80,7 +79,6 @@ Example:
 export ENVOY_MACHINE_ID=sami-agents-mx
 export NATS_URLS=nats://127.0.0.1:4222,nats://sami:4222,nats://sami-claude:4222
 export ENVOY_HOME=/home/ubuntu
-export ENVOY_REGISTRY_DIR=/tmp/opencode-1000
 export ENVOY_OPENCODE_BIN=/home/ubuntu/.mise/installs/github-sjawhar-opencode/1.3.2-sami.20260328-035401/opencode
 deploy/scripts/up-listener.sh
 ```

--- a/packages/envoy/infra/README.md
+++ b/packages/envoy/infra/README.md
@@ -105,7 +105,6 @@ Each machine in the `envoy:machines` array:
 | `machineId` | Yes | Machine ID passed to Envoy services as `ENVOY_MACHINE_ID` |
 | `sshHost` | No | SSH URI for Docker provider (e.g. `ssh://user@host`). **Omit for the local machine** — Docker uses the local socket instead. |
 | `nats.serverName` | No | NATS server name. Omit to skip NATS peer on this machine. |
-| `listener.registryDir` | Yes | Path to the OpenCode session registry directory on the machine |
 | `listener.tsnet.hostname` | No | Tailscale hostname for the listener's tsnet node (e.g., `envoy-listener-sami-agents-mx`). When set, enables tsnet: `/v1/*` served over TLS on the tsnet interface, legacy port restricted to `/healthz`. |
 | `listener.tsnet.stateDir` | No | Persistent state directory for the tsnet node (must be unique per service per machine, e.g., `/var/lib/envoy-tsnet/listener-sami-agents-mx/`) |
 | `receivers.github` | No | Deploy GitHub webhook receiver on this machine |


### PR DESCRIPTION
Closes #416

## Summary

Removes 3 stale `ENVOY_REGISTRY_DIR`/`registryDir` references from Envoy documentation:

- `packages/envoy/infra/README.md`: removed `listener.registryDir` row from machine config table
- `packages/envoy/deploy/README.md`: removed `ENVOY_REGISTRY_DIR` from env var list and example block

The file registry was removed in PR #393 but these doc references remained. Active infra code (`services.ts`, `machines.ts`, `Pulumi.prod.yaml`, compose files) was already clean.