### PR TITLE
sjawhar-legion-420: fix(daemon): prevent health tick from overwriting state delta baseline

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,21 +1,20 @@
 {
   "filesChanged": [
-    "packages/envoy-plugin/src/index.ts",
-    "packages/envoy-plugin/src/__tests__/index.test.ts",
-    "packages/envoy-plugin/AGENTS.md"
+    "packages/daemon/src/daemon/server.ts",
+    "packages/daemon/src/daemon/__tests__/server.test.ts"
   ],
   "trickyParts": [
-    "Cross-family review caught CLI publish using invalid source value 'cli' — Envoy contracts only allow agent/github/slack/whatsapp/ghostwispr. Fixed by omitting source (defaults to 'agent'). Also caught whoami returning string 'not yet resolved' for port instead of null — fixed to return currentPort() directly."
+    "The function closing brace was consumed during the replace edit and needed to be re-added manually"
   ],
   "deviations": [
-    "CLI publish payload: removed source:'cli' per Envoy contract validation (plan had it, but it would 400)",
-    "whoami port: returns null instead of 'not yet resolved' string for type consistency with spec"
+    "Added positive regression test for fetch-and-collect delta publishing per Oracle cross-family review feedback",
+    "Hardened test assertions with expect(serverFetchAndProcessState).not.toBeNull() per Oracle review"
   ],
   "openQuestions": [],
   "subPlanningNeeded": false,
-  "learningsInjected": [],
-  "learningsHelpful": [],
+  "learningsInjected": ["daemon/post-collection-processing-pattern.md"],
+  "learningsHelpful": ["daemon/post-collection-processing-pattern.md"],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-11T18:18:01.159Z"
+  "completed": "2026-04-11T19:02:53.124Z"
 }

--- a/.legion/plan.json
+++ b/.legion/plan.json
@@ -1,6 +1,6 @@
 {
-  "taskCount": 3,
-  "independentTasks": 2,
+  "taskCount": 4,
+  "independentTasks": 1,
   "routingHints": {
     "complexity": "small",
     "estimatedImplementers": 1,
@@ -8,20 +8,17 @@
     "skipArchitect": true
   },
   "concerns": [
-    "CLI change (~/.dotfiles/scripts/envoy) is in a separate repo from plugin changes — two separate commits needed",
-    "ses_* prefix heuristic for CLI send: any topic literally starting with 'ses_' would be treated as direct send"
+    "Bug 2 (controller re-subscription) is a symptom of Bug 1 — subscribeControllerToEnvoy is only called at startup, not in tick loop. publishStateDelta delivers via role routing which cannot be unsubscribed.",
+    "fetchAndProcessState hardcodes fetchGitHubProjectItems — Change 1b fixes this for testability",
+    "Task 3c cache verification uses dispatch-without-repo which forces issueStateCache lookup — verify error is not missing_repo rather than asserting 200"
   ],
-  "learningsInjected": [],
-  "learningsHelpful": [],
-  "workflowRecommendation": "Simple feature additions — skip retro, single implementer. Two parallel lanes: plugin (Task 1) and CLI (Task 2) merge at verify (Task 3).",
-  "requiredSkills": {
-    "implement": [
-      "envoy"
-    ],
-    "test": [],
-    "review": []
-  },
+  "learningsInjected": [
+    "daemon/post-collection-processing-pattern.md",
+    "testing/github-backend-collect-test-payloads.md"
+  ],
+  "learningsHelpful": ["daemon/post-collection-processing-pattern.md"],
+  "workflowRecommendation": "Simple bug fix — skip retro, single implementer",
   "schemaVersion": 1,
   "phase": "plan",
-  "completed": "2026-04-11T18:01:00.971Z"
+  "completed": "2026-04-11T18:46:28.307Z"
 }

--- a/.legion/retro.json
+++ b/.legion/retro.json
@@ -1,9 +1,9 @@
 {
   "skipped": false,
   "docsCreated": [
-    "docs/solutions/envoy/publish-payload-source-validation.md"
+    "docs/solutions/daemon/health-tick-baseline-isolation.md"
   ],
   "schemaVersion": 1,
   "phase": "retro",
-  "completed": "2026-04-11T18:36:46.284Z"
+  "completed": "2026-04-11T19:49:39.305Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -6,18 +6,22 @@
   "keyFindings": [
     {
       "severity": "P3",
-      "file": "packages/envoy-plugin/src/__tests__/index.test.ts",
-      "description": "No unit test for envoy_sessions machine filter path (client-side filter logic untested). Trivial one-liner, low risk."
+      "file": "packages/daemon/src/daemon/__tests__/server.test.ts",
+      "description": "Cache test uses negated assertion (expect(body.error).not.toBe('missing_repo')) — by design per plan concern #3"
     },
     {
       "severity": "P3",
-      "file": "packages/envoy-plugin/src/__tests__/index.test.ts",
-      "description": "No happy-path tests for envoy_whoami with topics or envoy_sessions unfiltered. Requires live Envoy — acknowledged design constraint."
+      "file": "packages/daemon/src/daemon/server.ts",
+      "description": "Injectable fetchProjectItems in fetchAndProcessState — consistent with existing DI pattern, no action needed"
     }
   ],
-  "learningsInjected": [],
-  "learningsHelpful": [],
+  "learningsInjected": [
+    "daemon/post-collection-processing-pattern.md"
+  ],
+  "learningsHelpful": [
+    "daemon/post-collection-processing-pattern.md"
+  ],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-11T18:32:06.993Z"
+  "completed": "2026-04-11T19:42:45.637Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,16 +1,16 @@
 {
-  "passed": 6,
+  "passed": 5,
   "failed": 0,
   "failures": [],
-  "documentationFeedback": "AGENTS.md tool table updated with all 8 tools. Tool descriptions are self-documenting. CLI header comment and usage output are clear. No gaps for this scope.",
+  "documentationFeedback": "PR body clearly explains fix strategy. No user-facing doc changes needed — internal daemon behavior. AGENTS.md daemon architecture docs adequate.",
   "observations": [
-    "P2: Missing unit test for envoy_sessions machine filter path (client-side filter logic untested)",
-    "P2: Missing happy-path unit tests for envoy_whoami with topics present and envoy_sessions unfiltered",
-    "ses_* prefix heuristic for CLI routing is a documented design choice — acceptable for current use case"
+    "opts.fetchProjectItems injection is unrequested but narrowly scoped testability support — acceptable extra work",
+    "Criterion 2 passes under plan clarification (symptom not root cause) — no per-tick subscription call existed to move",
+    "3 pre-existing test failures on main: index.test.ts 'passes controller env vars' + 2 envoy infra missing @pulumi/docker"
   ],
   "learningsInjected": [],
   "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-11T18:25:11.098Z"
+  "completed": "2026-04-11T19:37:09.972Z"
 }

--- a/docs/solutions/daemon/health-tick-baseline-isolation.md
+++ b/docs/solutions/daemon/health-tick-baseline-isolation.md
@@ -1,0 +1,72 @@
+---
+title: "Health Tick Baseline Isolation: Preventing Shared Mutable State Oscillation"
+category: daemon
+tags:
+  - health-tick
+  - state-delta
+  - shared-mutable-state
+  - baseline-oscillation
+  - cache-only-mode
+  - dependency-injection
+date: 2026-04-11
+status: active
+module: daemon
+related_issues:
+  - "420"
+symptoms:
+  - "state delta notifications spam controller with repeated issues every tick"
+  - "same issues cycling through state deltas every 40-60 seconds"
+  - "envoy_unsubscribe from notifications.role.legion-controller gets overridden within seconds"
+  - "false new/removed deltas on every health tick"
+---
+
+# Health Tick Baseline Isolation
+
+## Problem
+
+`runPostCollectionProcessing()` in `server.ts` maintains a `previousIssueState` baseline for computing state deltas. Three code paths call this function:
+
+1. `POST /state/collect` — controller-initiated
+2. `POST /state/fetch-and-collect` — controller-initiated, may include extra projects
+3. `fetchAndProcessState()` — daemon health tick, every ~60s, fetches only from `opts.legionId`
+
+When the health tick fetches a different issue set than the controller (e.g., single board vs multi-board, or timing differences), it overwrites `previousIssueState`. The next controller collection then computes a delta against the health tick's baseline, producing false "new"/"removed" deltas every tick.
+
+This also caused a secondary symptom: the controller appeared to be "re-subscribed" on every tick. In reality, `subscribeControllerToEnvoy()` was only called at startup — the spam came from `publishStateDelta()` delivering via `notifications.role.legion-controller` role routing on every tick because each tick produced a (false) delta.
+
+## Root Cause Pattern
+
+**Two callers with different semantics sharing one mutable baseline.** The health tick needs cache warming (for dispatch validation), not delta computation. But `runPostCollectionProcessing` unconditionally did both, and whoever called it last owned the baseline.
+
+## Solution: `skipDelta` Option
+
+Add an optional `{ skipDelta?: boolean }` parameter to `runPostCollectionProcessing()`:
+
+- **Cache updates always run** — `issueStateCache` and `issueTitleCache` are populated regardless of `skipDelta`, because dispatch validation depends on them
+- **Delta computation only runs when `!skipDelta`** — `computeStateDelta`, `publishStateDelta`, and the `previousIssueState = currentDict` baseline update are all gated behind `!options?.skipDelta`
+- **Health tick passes `{ skipDelta: true }`** — cache-only mode
+- **HTTP handler call sites pass nothing** — delta behavior unchanged for controller paths
+
+This keeps `runPostCollectionProcessing` as a single entry point rather than splitting into separate cache/delta functions, avoiding duplication of the `state.issues` iteration.
+
+## Key Decisions
+
+1. **Single function with mode flag, not two functions.** The shared setup (iterating `state.issues`, populating caches) would be duplicated if split. The `skipDelta` flag makes caller intent explicit at the call site.
+
+2. **Bug 2 was a symptom, not independent.** The "re-subscription on every tick" was actually `publishStateDelta` delivering via role routing because the oscillating baseline produced a delta every time. No subscription code was in the tick loop.
+
+3. **Injectable fetcher for testability.** `fetchAndProcessState` hardcoded `fetchGitHubProjectItems`. Changed to `opts.fetchProjectItems ?? fetchGitHubProjectItems` to match the existing DI pattern already used by `/state/fetch-and-collect`.
+
+## Testing Pattern
+
+For "stop emitting X when Y" fixes, test both directions:
+
+- **Negative cases**: Health tick interleaving produces zero false deltas (same issue set AND different issue set)
+- **Positive regression**: Controller-initiated `fetch-and-collect` still publishes real deltas when data changes
+- **Cache verification**: Health tick still populates `issueStateCache` (the behavior it's supposed to have)
+
+Expose the tick function (`fetchAndProcessState`) from `startServer()` for deterministic test orchestration — prefer this over mocking `setInterval`/`setTimeout`.
+
+## Generalization
+
+When adding a function that mutates shared state (baseline, cursor, counter), ask: **does every caller intend to advance that state?** If not, the function needs a mode flag or separate state per caller. This applies to any future processing hooks added to `runPostCollectionProcessing` or similar shared paths.

--- a/docs/solutions/index.json
+++ b/docs/solutions/index.json
@@ -13,8 +13,8 @@
       "daemon/controller-retro-20h-bug-pipeline-optimization.md",
       "controller/controller-session-anti-patterns.md",
       "daemon/server-side-dispatch-validation.md",
-      "daemon/state-machine-action-display-mismatch.md"
-      "daemon/session-adoption-api-pattern.md",
+      "daemon/state-machine-action-display-mismatch.md",
+      "daemon/session-adoption-api-pattern.md"
     ],
     "packages/daemon/src/daemon/serve-manager": [
       "daemon/opencode-serve-lifecycle.md",
@@ -46,8 +46,9 @@
       "daemon/codebase-index-file-placement.md",
       "testing/bun-mock-module-global-leak.md",
       "daemon/post-collection-processing-pattern.md",
-      "testing/ci-merge-type-compatibility.md"
+      "testing/ci-merge-type-compatibility.md",
       "daemon/session-adoption-api-pattern.md",
+      "daemon/health-tick-baseline-isolation.md"
     ],
     "packages/daemon/src/cli": [
       "daemon/controller-lifecycle-separation.md",
@@ -56,7 +57,7 @@
       "daemon/server-side-dispatch-validation.md",
       "daemon/prompt-delivery-bootstrap-delay.md",
       "daemon/handoff-schema-migration-patterns.md",
-      "daemon/state-machine-action-display-mismatch.md"
+      "daemon/state-machine-action-display-mismatch.md",
       "daemon/session-adoption-api-pattern.md"
     ],
     "packages/daemon": [
@@ -372,13 +373,13 @@
       "daemon/envoy-auto-subscription-patterns.md",
       "testing/bun-fetch-mocking-patterns.md",
       "envoy/listener-routing-by-topic-prefix.md",
-      "envoy/nats-bus-client-self-healing.md"
+      "envoy/nats-bus-client-self-healing.md",
       "envoy/publish-payload-source-validation.md"
     ],
     "packages/envoy/internal/contracts": [
       "envoy/structured-json-summary-patterns.md",
       "envoy/contracts-and-handler-patterns.md",
-      "envoy/adding-resource-level-subject-helpers.md"
+      "envoy/adding-resource-level-subject-helpers.md",
       "envoy/publish-payload-source-validation.md"
     ],
     "tag:session-registry": [
@@ -455,6 +456,15 @@
     "tag:github-api": [
       "skill-patterns/merge-retry-race-condition-pattern.md",
       "github-api/graphql-org-user-fallback.md"
+    ],
+    "tag:health-tick": [
+      "daemon/health-tick-baseline-isolation.md"
+    ],
+    "tag:state-delta": [
+      "daemon/health-tick-baseline-isolation.md"
+    ],
+    "tag:baseline-oscillation": [
+      "daemon/health-tick-baseline-isolation.md"
     ]
   }
 }

--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -17,6 +17,7 @@ describe("daemon server", () => {
   let tempDir: string | null = null;
   let stopServer: (() => void) | null = null;
   let baseUrl = "";
+  let serverFetchAndProcessState: (() => Promise<void>) | null = null;
   let createSessionCalls: Array<{ sessionId: string; workspace: string }> = [];
   let deleteSessionCalls: string[] = [];
   let sessionStatusHandler:
@@ -89,7 +90,7 @@ describe("daemon server", () => {
     if (options?.state) {
       await writeStateFile(stateFilePath, options.state);
     }
-    const { server, stop } = startServer({
+    const { server, stop, fetchAndProcessState } = startServer({
       port: 0,
       hostname: "127.0.0.1",
       legionId: options?.legionId ?? legionId,
@@ -105,6 +106,7 @@ describe("daemon server", () => {
       getControllerState: options?.getControllerState,
       fetchProjectItems: options?.fetchProjectItems,
     });
+    serverFetchAndProcessState = fetchAndProcessState;
     stopServer = stop;
     baseUrl = `http://127.0.0.1:${server.port}`;
   }
@@ -199,6 +201,7 @@ describe("daemon server", () => {
     globalThis.fetch = originalFetch;
     console.warn = originalConsoleWarn;
     sessionStatusHandler = null;
+    serverFetchAndProcessState = null;
     if (stopServer) {
       stopServer();
       stopServer = null;
@@ -1395,6 +1398,142 @@ describe("daemon server", () => {
       await Bun.sleep(50);
 
       expect(publishCalls.length).toBe(0);
+    });
+
+    it("health tick interleaving does not produce false deltas", async () => {
+      const publishCalls: CapturedPublish[] = [];
+      mockFetchForPublish(publishCalls);
+      await startTestServer({
+        legionId: "acme/123",
+        getControllerState: () => ({ sessionId: "ses_ctrl" }),
+        fetchProjectItems: async () => [createGitHubProjectItem({ status: "Todo" })],
+      });
+
+      // Establish baseline via controller-initiated /state/collect
+      const firstResponse = await requestJson("/state/collect", {
+        method: "POST",
+        body: JSON.stringify({
+          backend: "github",
+          issues: [createGitHubProjectItem({ status: "Todo" })],
+        }),
+      });
+      expect(firstResponse.status).toBe(200);
+      await Bun.sleep(50);
+
+      // Run health tick (fetchAndProcessState) — should NOT affect baseline
+      expect(serverFetchAndProcessState).not.toBeNull();
+      await serverFetchAndProcessState?.();
+      await Bun.sleep(50);
+
+      // Re-collect identical data via controller — should produce zero deltas
+      const secondResponse = await requestJson("/state/collect", {
+        method: "POST",
+        body: JSON.stringify({
+          backend: "github",
+          issues: [createGitHubProjectItem({ status: "Todo" })],
+        }),
+      });
+      expect(secondResponse.status).toBe(200);
+      await Bun.sleep(50);
+
+      expect(publishCalls.length).toBe(0);
+    });
+
+    it("health tick with different issue set does not produce false deltas", async () => {
+      const publishCalls: CapturedPublish[] = [];
+      mockFetchForPublish(publishCalls);
+      await startTestServer({
+        legionId: "acme/123",
+        getControllerState: () => ({ sessionId: "ses_ctrl" }),
+        fetchProjectItems: async () => [
+          createGitHubProjectItem({ number: 99, status: "In Progress" }),
+        ],
+      });
+
+      // Establish baseline via controller with issue 42
+      const firstResponse = await requestJson("/state/collect", {
+        method: "POST",
+        body: JSON.stringify({
+          backend: "github",
+          issues: [createGitHubProjectItem({ status: "Todo" })],
+        }),
+      });
+      expect(firstResponse.status).toBe(200);
+      await Bun.sleep(50);
+
+      // Health tick fetches different issue set (number: 99) — should NOT corrupt baseline
+      expect(serverFetchAndProcessState).not.toBeNull();
+      await serverFetchAndProcessState?.();
+      await Bun.sleep(50);
+
+      // Re-collect same original data — should produce zero deltas
+      const secondResponse = await requestJson("/state/collect", {
+        method: "POST",
+        body: JSON.stringify({
+          backend: "github",
+          issues: [createGitHubProjectItem({ status: "Todo" })],
+        }),
+      });
+      expect(secondResponse.status).toBe(200);
+      await Bun.sleep(50);
+
+      expect(publishCalls.length).toBe(0);
+    });
+
+    it("health tick still populates issueStateCache for dispatch", async () => {
+      await startTestServer({
+        legionId: "acme/123",
+        fetchProjectItems: async () => [createGitHubProjectItem({ status: "Todo" })],
+      });
+
+      // Run health tick to populate cache
+      expect(serverFetchAndProcessState).not.toBeNull();
+      await serverFetchAndProcessState?.();
+      await Bun.sleep(50);
+
+      // Dispatch without repo — should succeed via cache auto-resolution
+      const response = await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({
+          issueId: "acme-widgets-42",
+          mode: "implement",
+        }),
+      });
+
+      // Should NOT fail with missing_repo — cache provides the repo
+      const body = (await response.json()) as { error?: string; id?: string };
+      expect(body.error).not.toBe("missing_repo");
+    });
+
+    it("fetch-and-collect still publishes delta on changed second collection", async () => {
+      const publishCalls: CapturedPublish[] = [];
+      mockFetchForPublish(publishCalls);
+      let fetchStatus = "Todo";
+      await startTestServer({
+        legionId: "acme/123",
+        getControllerState: () => ({ sessionId: "ses_ctrl" }),
+        fetchProjectItems: async () => [createGitHubProjectItem({ status: fetchStatus })],
+      });
+
+      // First fetch-and-collect establishes baseline
+      const firstResponse = await requestJson("/state/fetch-and-collect", {
+        method: "POST",
+        body: JSON.stringify({ backend: "github" }),
+      });
+      expect(firstResponse.status).toBe(200);
+      await Bun.sleep(50);
+      expect(publishCalls.length).toBe(0);
+
+      // Change fetcher response and fetch again — should publish delta
+      fetchStatus = "In Progress";
+      const secondResponse = await requestJson("/state/fetch-and-collect", {
+        method: "POST",
+        body: JSON.stringify({ backend: "github" }),
+      });
+      expect(secondResponse.status).toBe(200);
+      await Bun.sleep(50);
+
+      expect(publishCalls.length).toBe(1);
     });
   });
 

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -373,7 +373,11 @@ export function startServer(opts: ServerOptions): {
     }
   };
 
-  function runPostCollectionProcessing(state: CollectedState, titles?: Map<string, string>): void {
+  function runPostCollectionProcessing(
+    state: CollectedState,
+    titles?: Map<string, string>,
+    options?: { skipDelta?: boolean }
+  ): void {
     for (const [issueId, issueState] of Object.entries(state.issues)) {
       issueStateCache.set(issueId.toLowerCase(), issueState);
     }
@@ -384,19 +388,22 @@ export function startServer(opts: ServerOptions): {
       }
     }
 
-    const currentDict: Record<string, IssueStateDict> = {};
-    for (const [issueId, issueState] of Object.entries(state.issues)) {
-      currentDict[issueId] = IssueState.toDict(issueState);
-    }
-
-    if (previousIssueState !== null) {
-      const delta = computeStateDelta(previousIssueState, currentDict);
-      if (delta && opts.getControllerState?.()?.sessionId) {
-        publishStateDelta(delta);
+    // Delta computation — only for controller-initiated collections
+    if (!options?.skipDelta) {
+      const currentDict: Record<string, IssueStateDict> = {};
+      for (const [issueId, issueState] of Object.entries(state.issues)) {
+        currentDict[issueId] = IssueState.toDict(issueState);
       }
-    }
 
-    previousIssueState = currentDict;
+      if (previousIssueState !== null) {
+        const delta = computeStateDelta(previousIssueState, currentDict);
+        if (delta && opts.getControllerState?.()?.sessionId) {
+          publishStateDelta(delta);
+        }
+      }
+
+      previousIssueState = currentDict;
+    }
   }
 
   const stateLoaded = loadState();
@@ -1563,10 +1570,11 @@ export function startServer(opts: ServerOptions): {
       return;
     }
 
-    const rawIssues = await fetchGitHubProjectItems(owner, projectNumber);
+    const fetchFn = opts.fetchProjectItems ?? fetchGitHubProjectItems;
+    const rawIssues = await fetchFn(owner, projectNumber);
     const { state, titles: extractedTitles } = await fetchAndCollectState("github", rawIssues);
 
-    runPostCollectionProcessing(state, extractedTitles);
+    runPostCollectionProcessing(state, extractedTitles, { skipDelta: true });
 
     cleanupDoneIssueWorkers(state).catch((err) =>
       console.error("[auto-cleanup] failed:", err instanceof Error ? err.message : String(err))


### PR DESCRIPTION
Closes #420

## Summary

The health tick's `fetchAndProcessState()` shared `previousIssueState` with controller collection paths (`/state/collect`, `/state/fetch-and-collect`). When the health tick fetched a different issue set than the controller, it overwrote the baseline, causing false "new"/"removed" deltas every ~60s and spamming the controller via role-based Envoy routing.

**Fix:**
- Add `skipDelta` option to `runPostCollectionProcessing()` — health tick passes `skipDelta: true` for cache-only mode (cache updates still run for dispatch validation)
- Controller-initiated HTTP paths compute and publish deltas as before
- Fix `fetchAndProcessState` to use injectable `opts.fetchProjectItems` for testability

**Tests added:**
- Health tick interleaving does not produce false deltas (same issue set)
- Health tick with different issue set does not corrupt baseline
- Health tick still populates `issueStateCache` for dispatch
- `fetch-and-collect` still publishes deltas on changed second collection (positive regression)