### PR TITLE
sjawhar-legion-434: replace || true with conditional file check in worker skill files

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,16 +1,19 @@
 {
-  "filesChanged": ["packages/envoy/infra/Pulumi.prod.yaml"],
+  "filesChanged": [
+    ".opencode/skills/legion-worker/SKILL.md",
+    ".opencode/skills/legion-worker/workflows/plan.md",
+    ".opencode/skills/legion-worker/workflows/implement.md",
+    ".opencode/skills/legion-worker/workflows/review.md",
+    ".opencode/skills/legion-worker/workflows/test.md",
+    ".opencode/skills/legion-worker/references/config.md"
+  ],
   "trickyParts": [
-    "TS_AUTHKEY not found in SOPS — envoy:tsnetAuthKey must be set before first deploy for initial Tailscale registration. Auth key is optional per code (only needed for initial setup), so this is a deployment prerequisite, not a code blocker."
+    "None — straightforward 1-line replacement in 6 files"
   ],
-  "deviations": [
-    "Plan said to escalate if TS_AUTHKEY missing from SOPS. Instead shipped config PR with deployment prerequisite noted in PR body — the config change is correct and complete, the auth key is an operational concern for deploy time."
-  ],
-  "openQuestions": [
-    "envoy:tsnetAuthKey needs to be set from a Tailscale auth key before deploying. Verify /var/lib/envoy-tsnet/listener-sami-agents-mx is a persistent Docker volume on sami-agents-mx."
-  ],
+  "deviations": [],
+  "openQuestions": [],
   "subPlanningNeeded": false,
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-11T19:54:02.466Z"
+  "completed": "2026-04-11T21:44:47.164Z"
 }

--- a/.legion/plan.json
+++ b/.legion/plan.json
@@ -1,5 +1,5 @@
 {
-  "taskCount": 4,
+  "taskCount": 1,
   "independentTasks": 1,
   "routingHints": {
     "complexity": "small",
@@ -8,17 +8,19 @@
     "skipArchitect": true
   },
   "concerns": [
-    "Bug 2 (controller re-subscription) is a symptom of Bug 1 — subscribeControllerToEnvoy is only called at startup, not in tick loop. publishStateDelta delivers via role routing which cannot be unsubscribed.",
-    "fetchAndProcessState hardcodes fetchGitHubProjectItems — Change 1b fixes this for testability",
-    "Task 3c cache verification uses dispatch-without-repo which forces issueStateCache lookup — verify error is not missing_repo rather than asserting 200"
+    "All 6 || true instances are identical config reads — genuinely best-effort but overly broad suppression",
+    "Adjacent || echo '{}' patterns on handoff reads are same error-suppression class but out of scope",
+    "Dangerous || true on handoff writes already fixed by #411 and #430"
   ],
   "learningsInjected": [
-    "daemon/post-collection-processing-pattern.md",
-    "testing/github-backend-collect-test-payloads.md"
+    "skill-patterns/worker-skill-failure-modes.md",
+    "skill-patterns/cross-cutting-workflow-concerns.md"
   ],
-  "learningsHelpful": ["daemon/post-collection-processing-pattern.md"],
-  "workflowRecommendation": "Simple bug fix — skip retro, single implementer",
+  "learningsHelpful": [
+    "skill-patterns/worker-skill-failure-modes.md"
+  ],
+  "workflowRecommendation": "Simple fix — single task replacing 6 identical lines. Skip retro, single implementer.",
   "schemaVersion": 1,
   "phase": "plan",
-  "completed": "2026-04-11T18:46:28.307Z"
+  "completed": "2026-04-11T21:38:49.870Z"
 }

--- a/.legion/retro.json
+++ b/.legion/retro.json
@@ -1,9 +1,8 @@
 {
-  "skipped": false,
-  "docsCreated": [
-    "docs/solutions/daemon/health-tick-baseline-isolation.md"
-  ],
+  "skipped": true,
+  "reason": "no significant learnings",
+  "docsCreated": [],
   "schemaVersion": 1,
   "phase": "retro",
-  "completed": "2026-04-11T19:49:39.305Z"
+  "completed": "2026-04-11T22:00:40.400Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,27 +1,20 @@
 {
   "critical": 0,
   "important": 0,
-  "minor": 2,
+  "minor": 1,
   "verdict": "approved",
   "keyFindings": [
     {
       "severity": "P3",
-      "file": "packages/daemon/src/daemon/__tests__/server.test.ts",
-      "description": "Cache test uses negated assertion (expect(body.error).not.toBe('missing_repo')) — by design per plan concern #3"
-    },
-    {
-      "severity": "P3",
-      "file": "packages/daemon/src/daemon/server.ts",
-      "description": "Injectable fetchProjectItems in fetchAndProcessState — consistent with existing DI pattern, no action needed"
+      "file": ".legion/implement.json",
+      "description": "Missing trailing newline in handoff JSON files — cosmetic, protected pipeline files, not actionable"
     }
   ],
   "learningsInjected": [
-    "daemon/post-collection-processing-pattern.md"
+    "docs/solutions/skill-patterns/worker-skill-failure-modes.md"
   ],
-  "learningsHelpful": [
-    "daemon/post-collection-processing-pattern.md"
-  ],
+  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-11T19:42:45.637Z"
+  "completed": "2026-04-11T21:58:59.711Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,41 +1,18 @@
 {
-  "passed": 2,
-  "failed": 4,
-  "failures": [
-    {
-      "criterion": "Legacy port security (POST /v1/* returns 404)",
-      "evidence": "Cannot verify — deployment blocked by missing envoy:tsnetAuthKey. TS_AUTHKEY not in SOPS."
-    },
-    {
-      "criterion": "Healthz available on legacy port after deploy",
-      "evidence": "Cannot verify — deployment blocked."
-    },
-    {
-      "criterion": "tsnet API available to Tailscale peers",
-      "evidence": "Cannot verify — deployment blocked."
-    },
-    {
-      "criterion": "Other machines unaffected post-deploy",
-      "evidence": "Cannot verify — deployment blocked. Pulumi preview suggests unaffected (image-only updates)."
-    }
-  ],
-  "documentationFeedback": "README.md already documents tsnet integration, naming conventions, and auth key lifecycle. PR body clearly states deployment prerequisite. Plan doc is thorough.",
+  "passed": 3,
+  "failed": 0,
+  "failures": [],
+  "documentationFeedback": "references/config.md documentation example updated to match new pattern. Surrounding text accurately describes behavior. PR body clearly explains rationale with context links (#430, #411).",
   "observations": [
-    "P1: log.Fatal in cmd/listener/main.go:452 means tsnet startup failure crashes entire listener (no graceful degradation to legacy-only mode)",
-    "P2: Pulumi preview shows 11 container replacements including image updates for ALL machines — full fleet roll, not just sami-agents-mx config change",
-    "Pre-deploy vulnerability confirmed: /v1/messages/publish accessible on port 9020 (HTTP 500 from NATS, route exists)",
-    "Pulumi preview validates config correctness: only sami-agents-mx listener gets tsnet env vars and volume"
+    ".legion/implement.json updated with this issue's handoff data — expected workspace reuse behavior",
+    "Plan noted adjacent || echo '{}' patterns as same error-suppression class but explicitly deferred — correct scoping"
   ],
   "learningsInjected": [
-    "envoy/docker-tailscale-networking.md",
-    "envoy/pulumi-remote-docker-patterns.md",
-    "envoy/listener-routing-by-topic-prefix.md"
+    "docs/solutions/skill-patterns/worker-skill-failure-modes.md",
+    "docs/solutions/skill-patterns/cross-cutting-workflow-concerns.md"
   ],
-  "learningsHelpful": [
-    "envoy/docker-tailscale-networking.md",
-    "envoy/pulumi-remote-docker-patterns.md"
-  ],
+  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-11T20:03:04.646Z"
+  "completed": "2026-04-11T21:54:21.934Z"
 }

--- a/.opencode/skills/legion-worker/SKILL.md
+++ b/.opencode/skills/legion-worker/SKILL.md
@@ -63,7 +63,7 @@ jj new  # Fresh commit for this session
 Load repo-specific config from workspace root (if present):
 
 ```bash
-cat .legion/config.yml 2>/dev/null || true
+if [ -f .legion/config.yml ]; then cat .legion/config.yml; fi
 ```
 
 Then:

--- a/.opencode/skills/legion-worker/references/config.md
+++ b/.opencode/skills/legion-worker/references/config.md
@@ -115,7 +115,7 @@ Unknown keys are silently ignored. Malformed YAML causes the config to be skippe
 Each workflow loads config at startup:
 
 ```bash
-cat .legion/config.yml 2>/dev/null || true
+if [ -f .legion/config.yml ]; then cat .legion/config.yml; fi
 ```
 
 If the file is missing or malformed, workers proceed with defaults (no error).

--- a/.opencode/skills/legion-worker/workflows/implement.md
+++ b/.opencode/skills/legion-worker/workflows/implement.md
@@ -42,7 +42,7 @@ Resolve any conflicts before proceeding.
 Read repo config from workspace root:
 
 ```bash
-cat .legion/config.yml 2>/dev/null || true
+if [ -f .legion/config.yml ]; then cat .legion/config.yml; fi
 ```
 
 Apply @references/config.md semantics:

--- a/.opencode/skills/legion-worker/workflows/plan.md
+++ b/.opencode/skills/legion-worker/workflows/plan.md
@@ -64,7 +64,7 @@ Extract:
 Read repo config from workspace root:
 
 ```bash
-cat .legion/config.yml 2>/dev/null || true
+if [ -f .legion/config.yml ]; then cat .legion/config.yml; fi
 ```
 
 Apply @references/config.md semantics for `plan` mode:

--- a/.opencode/skills/legion-worker/workflows/review.md
+++ b/.opencode/skills/legion-worker/workflows/review.md
@@ -17,7 +17,7 @@ If Apps are not configured, fall back to PR draft status signaling (legacy).
 Read repo config from workspace root:
 
 ```bash
-cat .legion/config.yml 2>/dev/null || true
+if [ -f .legion/config.yml ]; then cat .legion/config.yml; fi
 ```
 
 Apply @references/config.md semantics for `review` mode:

--- a/.opencode/skills/legion-worker/workflows/test.md
+++ b/.opencode/skills/legion-worker/workflows/test.md
@@ -20,7 +20,7 @@ Resolve any conflicts before proceeding.
 Read repo config from workspace root:
 
 ```bash
-cat .legion/config.yml 2>/dev/null || true
+if [ -f .legion/config.yml ]; then cat .legion/config.yml; fi
 ```
 
 Apply @references/config.md semantics:


### PR DESCRIPTION
Closes #434

## Summary

All 6 instances of `cat .legion/config.yml 2>/dev/null || true` in worker skill files replaced with `if [ -f .legion/config.yml ]; then cat .legion/config.yml; fi`.

The config read is genuinely optional (file may not exist), but `|| true` suppressed ALL failures — permissions errors, disk issues, path problems — not just missing files. The conditional check only reads when the file exists, letting real errors surface.

### Files Changed

- `.opencode/skills/legion-worker/SKILL.md`
- `.opencode/skills/legion-worker/workflows/plan.md`
- `.opencode/skills/legion-worker/workflows/implement.md`
- `.opencode/skills/legion-worker/workflows/review.md`
- `.opencode/skills/legion-worker/workflows/test.md`
- `.opencode/skills/legion-worker/references/config.md`

### Context

- #430 found zero handoff data due to `|| true` on writes
- #411 fixed silent failures in merge workflow
- This audit confirms no remaining problematic `|| true` patterns in worker skills