### PR TITLE
sjawhar-legion-432: restore session titles in KV registry

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,27 +1,22 @@
 {
+  "status": "complete",
+  "pr": 440,
+  "branch": "sjawhar-legion-432",
   "filesChanged": [
-    ".opencode/skills/legion-worker/workflows/architect.md",
-    ".opencode/skills/legion-worker/workflows/plan.md",
-    ".opencode/skills/legion-worker/workflows/implement.md",
-    ".opencode/skills/legion-worker/workflows/test.md",
-    ".opencode/skills/legion-worker/workflows/review.md",
-    ".opencode/skills/legion-retro/SKILL.md",
-    ".opencode/skills/legion-worker/SKILL.md",
-    "packages/daemon/src/cli/__tests__/handoff.test.ts"
+    "packages/envoy/internal/session/registry.go",
+    "packages/envoy/cmd/listener/main.go",
+    "packages/envoy/cmd/listener/main_test.go",
+    "packages/envoy-plugin/src/index.ts",
+    "packages/envoy-plugin/src/__tests__/index.test.ts"
   ],
-  "trickyParts": [
-    "FATAL messaging is social enforcement, not mechanical — exit 1 in markdown code blocks kills the agent shell session, so we rely on FATAL + STOP directives that agents read as instructions. This was a deliberate plan constraint.",
-    "Exit gate must conditionally exclude merge mode since merge does not write handoff data"
+  "testsAdded": [
+    "TestSessionsHandler_IncludesTitle (Go)",
+    "session title > includes title in follow-up subscribe after session activation (TS)"
   ],
-  "deviations": [],
-  "openQuestions": [],
-  "subPlanningNeeded": false,
-  "learningsInjected": [
-    "docs/solutions/skill-patterns/worker-skill-failure-modes.md",
-    "docs/solutions/skill-patterns/cross-cutting-workflow-concerns.md"
-  ],
-  "learningsHelpful": ["docs/solutions/skill-patterns/worker-skill-failure-modes.md"],
+  "reviewFindings": "Oracle review found session-switch race in title fetch callback — fixed by guarding state mutation with activeSessionID === sessionID check",
+  "ciStatus": "6/6 green",
+  "notes": "Follow-up needed: update envoy CLI script in dotfiles repo to add TITLE column to envoy ps output",
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-11T21:50:13.793Z"
+  "completed": "2026-04-11T21:58:38.461Z"
 }

--- a/.legion/plan.json
+++ b/.legion/plan.json
@@ -1,5 +1,5 @@
 {
-  "taskCount": 1,
+  "taskCount": 2,
   "independentTasks": 1,
   "routingHints": {
     "complexity": "small",
@@ -8,19 +8,14 @@
     "skipArchitect": true
   },
   "concerns": [
-    "All 6 || true instances are identical config reads — genuinely best-effort but overly broad suppression",
-    "Adjacent || echo '{}' patterns on handoff reads are same error-suppression class but out of scope",
-    "Dangerous || true on handoff writes already fixed by #411 and #430"
+    "First subscribe after session activation sends empty title (title fetch is async); follow-up subscribe populates it once title arrives",
+    "envoy_subscribe tool may run before session.status event, so activeSessionTitle may be null — empty string is acceptable",
+    "envoy CLI script (dotfiles repo) needs separate follow-up to add TITLE column to envoy ps output"
   ],
-  "learningsInjected": [
-    "skill-patterns/worker-skill-failure-modes.md",
-    "skill-patterns/cross-cutting-workflow-concerns.md"
-  ],
-  "learningsHelpful": [
-    "skill-patterns/worker-skill-failure-modes.md"
-  ],
-  "workflowRecommendation": "Simple fix — single task replacing 6 identical lines. Skip retro, single implementer.",
+  "learningsInjected": ["architecture-patterns/nats-kv-dual-bucket-lifecycle.md"],
+  "learningsHelpful": ["architecture-patterns/nats-kv-dual-bucket-lifecycle.md"],
+  "workflowRecommendation": "Simple regression fix — skip retro, single implementer. Two tasks: Go plumbing (independent) then plugin (depends on Go). CLI script update is a separate dotfiles follow-up.",
   "schemaVersion": 1,
   "phase": "plan",
-  "completed": "2026-04-11T21:38:49.870Z"
+  "completed": "2026-04-11T21:39:40.264Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,21 +1,27 @@
 {
   "critical": 0,
   "important": 1,
-  "minor": 0,
+  "minor": 1,
   "verdict": "approved",
   "keyFindings": [
     {
       "severity": "P2",
-      "file": ".opencode/skills/legion-worker/workflows/test.md",
-      "description": "Line 322: 'MUST attempt... before continuing' contradicts FATAL/STOP block above. Same issue at review.md:243. Recommend updating to match Rule 4.5 language."
+      "file": "packages/envoy/cmd/listener/main_test.go",
+      "description": "Test coverage gaps: no subscribe handler input test (Go), no race guard test (TS), no heartbeat title test (TS). Existing tests cover happy path only."
+    },
+    {
+      "severity": "P3",
+      "file": "packages/envoy/cmd/listener/main.go",
+      "description": "gofmt formatting error at line 308 — Title field uses 2 tabs instead of 3 in subscribe handler body struct. Confirmed by gofmt -d."
     }
   ],
   "learningsInjected": [
-    "docs/solutions/skill-patterns/cross-cutting-workflow-concerns.md",
-    "docs/solutions/skill-patterns/worker-notification-conventions.md"
+    "architecture-patterns/nats-kv-dual-bucket-lifecycle.md",
+    "testing/nats-kv-testing-patterns.md",
+    "architecture-patterns/nats-kv-graceful-degradation.md"
   ],
-  "learningsHelpful": ["docs/solutions/skill-patterns/cross-cutting-workflow-concerns.md"],
+  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-11T22:06:03.197Z"
+  "completed": "2026-04-11T22:11:01.295Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,18 +1,19 @@
 {
-  "passed": 7,
+  "passed": 4,
   "failed": 0,
   "failures": [],
-  "documentationFeedback": "PR body clearly documents root cause, design constraints, and what changed. Investigation comment on #430 accurately corrects original symptom. Cross-cutting concern follows documented pattern.",
+  "documentationFeedback": "PR body clearly explains regression origin (PR #393) and fix structure. Issue body enumerates fix points with CLI script correctly scoped out. No user-facing doc changes needed.",
   "observations": [
-    "P2: review.md:243 and test.md:322 retain weaker 'MUST attempt... before continuing' prose that contradicts the FATAL/STOP bash blocks above them. Recommend updating to match Rule 4.5 language."
+    "P3 formatting: gofmt reports indentation error in cmd/listener/main.go:308 — Title field uses single tab instead of double",
+    "P2 test gaps: no subscribe handler input test (Go), no race guard test (TS), no heartbeat title test (TS)",
+    "Plugin correctly handles async title fetch race with session-switch guard"
   ],
   "learningsInjected": [
-    "docs/solutions/skill-patterns/worker-skill-failure-modes.md",
-    "docs/solutions/skill-patterns/cross-cutting-workflow-concerns.md",
-    "docs/solutions/daemon/handoff-schema-migration-patterns.md"
+    "architecture-patterns/nats-kv-dual-bucket-lifecycle.md",
+    "testing/nats-kv-testing-patterns.md"
   ],
-  "learningsHelpful": ["docs/solutions/skill-patterns/cross-cutting-workflow-concerns.md"],
+  "learningsHelpful": ["architecture-patterns/nats-kv-dual-bucket-lifecycle.md"],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-11T21:59:44.252Z"
+  "completed": "2026-04-11T22:04:48.232Z"
 }

--- a/docs/superpowers/plans/2026-04-11-restore-session-titles.md
+++ b/docs/superpowers/plans/2026-04-11-restore-session-titles.md
@@ -1,0 +1,436 @@
+# Restore Session Titles in KV Registry — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore session title display in Envoy's `/v1/sessions` API response — regression from PR #393 which removed the file registry that previously stored titles.
+
+**Architecture:** The fix threads a `Title` field through three layers: (1) Go `SessionEntry` struct gains a `Title` field persisted in NATS KV, wired through the subscribe handler and `/v1/sessions` endpoint, (2) the OpenCode plugin fetches the title once from the serve API (`GET /session/{id}`) on session activation and includes it in all subsequent heartbeat/subscribe payloads. The `envoy_sessions` KV bucket has a 5-minute TTL with heartbeats every 2 minutes, so titles refresh automatically.
+
+**Tech Stack:** Go (Envoy listener + session registry), TypeScript/Bun (envoy-plugin), NATS JetStream KV
+
+**Note:** The `envoy` CLI script (`~/.dotfiles/scripts/envoy`) also needs a TITLE column added to `envoy ps` output. This is in a separate repo (dotfiles) and should be done as a follow-up, not part of this PR.
+
+---
+
+### Task 1: Add Title to SessionEntry, subscribe handler, and /v1/sessions response — Independent
+
+**Files:**
+- Modify: `packages/envoy/internal/session/registry.go:15-20`
+- Modify: `packages/envoy/cmd/listener/main.go:112-119` (sessionInfo struct)
+- Modify: `packages/envoy/cmd/listener/main.go:141-147` (sessionsHandler body)
+- Modify: `packages/envoy/cmd/listener/main.go:301-306` (subscribe body struct)
+- Modify: `packages/envoy/cmd/listener/main.go:322-326` (SessionEntry creation)
+- Create test: `packages/envoy/cmd/listener/main_test.go` (new test after line 684)
+
+- [ ] **Step 1: Add Title field to SessionEntry struct**
+
+In `packages/envoy/internal/session/registry.go`, add `Title` to the struct at lines 15-20. Insert between `Dir` and `UpdatedAt`:
+
+```go
+type SessionEntry struct {
+	Port      int    `json:"port"`
+	MachineID string `json:"machine_id"`
+	Dir       string `json:"dir"`
+	Title     string `json:"title"`
+	UpdatedAt int64  `json:"updated_at"`
+}
+```
+
+- [ ] **Step 2: Add Title to sessionInfo struct**
+
+In `packages/envoy/cmd/listener/main.go`, update the `sessionInfo` struct at lines 112-119. Insert `Title` between `Port` and `Topics`:
+
+```go
+type sessionInfo struct {
+	SessionID string   `json:"session_id"`
+	MachineID string   `json:"machine_id"`
+	Dir       string   `json:"dir"`
+	Port      int      `json:"port"`
+	Title     string   `json:"title"`
+	Topics    []string `json:"topics"`
+	UpdatedAt int64    `json:"updated_at"`
+}
+```
+
+- [ ] **Step 3: Populate Title in sessionsHandler**
+
+In `packages/envoy/cmd/listener/main.go`, update the sessionsHandler loop at lines 141-147. Add `Title: entry.Title,` between `Port` and `UpdatedAt`:
+
+```go
+		info := sessionInfo{
+			SessionID: entry.SessionID,
+			MachineID: entry.MachineID,
+			Dir:       entry.Dir,
+			Port:      entry.Port,
+			Title:     entry.Title,
+			UpdatedAt: entry.UpdatedAt,
+		}
+```
+
+- [ ] **Step 4: Add Title to subscribe handler body struct**
+
+In `packages/envoy/cmd/listener/main.go`, update the subscribe handler's body struct at lines 301-306. Add `Title` after `Port`:
+
+```go
+	var body struct {
+		SessionID string   `json:"session_id"`
+		Dir       string   `json:"dir"`
+		Topics    []string `json:"topics"`
+		Port      int      `json:"port"`
+		Title     string   `json:"title"`
+	}
+```
+
+- [ ] **Step 5: Pass Title when creating SessionEntry in subscribe handler**
+
+In `packages/envoy/cmd/listener/main.go`, update the SessionEntry creation at lines 322-326. Add `Title: body.Title,` between `Dir` and the closing `}`:
+
+```go
+		if body.Port > 0 {
+			if err := d.sessions.Put(body.SessionID, session.SessionEntry{
+				Port:      body.Port,
+				MachineID: cfg.MachineID,
+				Dir:       body.Dir,
+				Title:     body.Title,
+			}); err != nil {
+```
+
+- [ ] **Step 6: Write test for title flowing through /v1/sessions**
+
+Add to `packages/envoy/cmd/listener/main_test.go` after the `TestSessionsHandler_JoinsRegistries` test (after line 684):
+
+```go
+func TestSessionsHandler_IncludesTitle(t *testing.T) {
+	conn := natstest.StartServer(t)
+	registry, err := store.OpenRegistry(conn, store.WithReplicas(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessions, err := session.OpenSessionRegistry(conn, session.WithSessionReplicas(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registry.Upsert(store.Interest{
+		SessionID: "ses_titled",
+		MachineID: "test-machine",
+		Dir:       "/test/ses_titled",
+	}, []string{contracts.AgentSubject("ses_titled")}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sessions.Put("ses_titled", session.SessionEntry{
+		Port:      13382,
+		MachineID: "test-machine",
+		Dir:       "/test/ses_titled",
+		Title:     "My Session Title",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	handler := sessionsHandler(registry, sessions)
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var items []sessionInfo
+	if err := json.NewDecoder(rec.Body).Decode(&items); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(items))
+	}
+	if items[0].Title != "My Session Title" {
+		t.Fatalf("expected title 'My Session Title', got %q", items[0].Title)
+	}
+}
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `cd packages/envoy && go test ./cmd/listener/ -run TestSessionsHandler_IncludesTitle -v -count=1`
+
+Expected: PASS — title persisted in KV and returned in /v1/sessions response.
+
+- [ ] **Step 8: Run full test suites to verify no regressions**
+
+Run: `cd packages/envoy && go test ./internal/session/... -v -count=1 && go test ./cmd/listener/ -v -count=1`
+
+Expected: All tests pass. Existing `SessionEntry{}` literals without Title are valid Go — the field gets its zero value (empty string).
+
+- [ ] **Step 9: Describe and advance**
+
+```bash
+jj describe -m "fix(envoy): add Title field to SessionEntry, subscribe handler, and /v1/sessions response"
+jj new
+```
+
+---
+
+### Task 2: Plugin fetches and sends session title — Depends on: Task 1
+
+**Files:**
+- Modify: `packages/envoy-plugin/src/index.ts`
+- Modify: `packages/envoy-plugin/src/__tests__/index.test.ts`
+
+The plugin fetches the session title once from the OpenCode serve API (`GET /session/{id}`) when a session becomes active. It caches the title and includes it in all subsequent heartbeat and subscribe payloads.
+
+- [ ] **Step 1: Add title state variable**
+
+In `packages/envoy-plugin/src/index.ts`, add after the `activeSessionID` declaration (after line 20):
+
+```typescript
+let activeSessionTitle: string | null = null;
+```
+
+- [ ] **Step 2: Add title-fetching function**
+
+In `packages/envoy-plugin/src/index.ts`, add after the `syncPort` function (after line 46):
+
+```typescript
+  /** Fetch session title from the OpenCode serve API. Best-effort — returns null on failure. */
+  const fetchTitle = async (sessionID: string): Promise<string | null> => {
+    try {
+      const res = await fetch(`${input.serverUrl.href}session/${sessionID}`, {
+        signal: AbortSignal.timeout(CALL_TIMEOUT_MS),
+      });
+      if (!res.ok) return null;
+      const data = (await res.json()) as { title?: string };
+      return data.title ?? null;
+    } catch {
+      return null;
+    }
+  };
+```
+
+- [ ] **Step 3: Update session status handler to fetch title and include in subscribe**
+
+In `packages/envoy-plugin/src/index.ts`, replace the session status handler block (lines 92-114) with:
+
+```typescript
+      if (
+        event.type === "session.status" &&
+        (event.properties?.status as { type?: string } | undefined)?.type === "busy"
+      ) {
+        const sessionID = event.properties?.sessionID as string | undefined;
+        if (sessionID && sessionID !== activeSessionID) {
+          activeSessionID = sessionID;
+          activeSessionTitle = null;
+          await syncPort();
+          const port = currentPort();
+          // Fetch title — best-effort, non-blocking for initial subscribe
+          const titlePromise = fetchTitle(sessionID).then((t) => {
+            if (t) activeSessionTitle = t;
+          });
+          if (port) {
+            call("/v1/interests/subscribe", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                session_id: sessionID,
+                dir: process.cwd(),
+                topics: [`notifications.agent.${sessionID}`],
+                port,
+                title: activeSessionTitle ?? "",
+              }),
+            }).catch(() => {});
+            // After title arrives, send one follow-up subscribe with title populated
+            titlePromise.then(() => {
+              if (activeSessionTitle && activeSessionID === sessionID) {
+                call("/v1/interests/subscribe", {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({
+                    session_id: sessionID,
+                    dir: process.cwd(),
+                    topics: [`notifications.agent.${sessionID}`],
+                    port: currentPort() ?? 0,
+                    title: activeSessionTitle,
+                  }),
+                }).catch(() => {});
+              }
+            });
+          }
+        }
+      }
+```
+
+- [ ] **Step 4: Update heartbeat to include cached title**
+
+In `packages/envoy-plugin/src/index.ts`, update the heartbeat interval (lines 59-77). Add `title` to the JSON body:
+
+```typescript
+  const heartbeatInterval = setInterval(
+    () => {
+      if (!activeSessionID) return;
+      const port = currentPort();
+      if (!port) return;
+      call("/v1/interests/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          session_id: activeSessionID,
+          dir: process.cwd(),
+          topics: [`notifications.agent.${activeSessionID}`],
+          port,
+          title: activeSessionTitle ?? "",
+        }),
+      }).catch(() => {});
+    },
+    2 * 60 * 1000
+  );
+```
+
+- [ ] **Step 5: Update envoy_subscribe tool to include title**
+
+In `packages/envoy-plugin/src/index.ts`, update the `envoy_subscribe` tool's execute method (lines 127-139). Add `title` to the JSON body:
+
+```typescript
+        async execute(args, ctx) {
+          ctx.metadata({ title: "Envoy subscribe" });
+          return call("/v1/interests/subscribe", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              session_id: ctx.sessionID,
+              dir: ctx.directory,
+              topics: args.topics,
+              port: currentPort() ?? 0,
+              title: activeSessionTitle ?? "",
+            }),
+          });
+        },
+```
+
+- [ ] **Step 6: Add focused plugin test for title in subscribe payload**
+
+Add to `packages/envoy-plugin/src/__tests__/index.test.ts`:
+
+```typescript
+describe("session title", () => {
+  it("includes title in subscribe payload after session activation", async () => {
+    const originalEnvoyUrl = process.env.ENVOY_URL;
+    process.env.ENVOY_URL = "http://127.0.0.1:59999";
+
+    const fetchCalls: { url: string; body: string }[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (init?.body) {
+        fetchCalls.push({ url, body: init.body as string });
+      }
+      if (url.includes("/session/ses_test_title")) {
+        return new Response(JSON.stringify({ id: "ses_test_title", title: "Test Title" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      throw new Error("connection refused");
+    };
+
+    try {
+      const mod = await import("../index");
+      const hooks = await mod.default({ serverUrl: new URL("http://127.0.0.1:13381") } as never);
+
+      await hooks.event({
+        event: {
+          type: "session.status",
+          properties: {
+            sessionID: "ses_test_title",
+            status: { type: "busy" },
+          },
+        },
+      });
+
+      // Allow async title fetch to complete
+      await new Promise((r) => setTimeout(r, 200));
+
+      const subscribeCalls = fetchCalls.filter((c) => c.url.includes("/v1/interests/subscribe"));
+      const hasTitle = subscribeCalls.some((c) => {
+        const body = JSON.parse(c.body);
+        return body.title === "Test Title";
+      });
+      expect(hasTitle).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+      process.env.ENVOY_URL = originalEnvoyUrl;
+    }
+  });
+});
+```
+
+- [ ] **Step 7: Build the plugin**
+
+Run: `cd packages/envoy-plugin && bun run build`
+
+Expected: Build succeeds.
+
+- [ ] **Step 8: Run plugin tests**
+
+Run: `cd packages/envoy-plugin && bun test`
+
+Expected: All tests pass, including the new title test.
+
+- [ ] **Step 9: Describe and advance**
+
+```bash
+jj describe -m "fix(envoy): plugin sends session title in heartbeat/subscribe payloads"
+jj new
+```
+
+---
+
+## Testing Plan
+
+### Setup
+- Envoy listener running: `curl -fsS http://127.0.0.1:9020/healthz` returns `{"status":"healthy"}`
+- OpenCode serve running: `curl -fsS http://127.0.0.1:13381/session | jq length` returns a number
+
+### Health Check
+- `curl -fsS http://127.0.0.1:9020/healthz` returns `{"status":"healthy"}` (or `{"status":"starting"}` — retry for 30s before declaring failure)
+
+### Verification Steps
+
+1. **Title flows through Go pipeline (unit test)**
+   - Action: `cd packages/envoy && go test ./cmd/listener/ -run TestSessionsHandler_IncludesTitle -v -count=1`
+   - Expected: PASS
+   - Tool: Go test runner
+
+2. **No regressions in session registry**
+   - Action: `cd packages/envoy && go test ./internal/session/... -v -count=1`
+   - Expected: All tests pass
+   - Tool: Go test runner
+
+3. **No regressions in listener**
+   - Action: `cd packages/envoy && go test ./cmd/listener/ -v -count=1`
+   - Expected: All tests pass
+   - Tool: Go test runner
+
+4. **Plugin builds cleanly**
+   - Action: `cd packages/envoy-plugin && bun run build`
+   - Expected: Build succeeds
+   - Tool: Bun bundler
+
+5. **Plugin tests pass (including title test)**
+   - Action: `cd packages/envoy-plugin && bun test`
+   - Expected: All tests pass
+   - Tool: Bun test runner
+
+6. **Title field present in /v1/sessions response (integration — requires live Envoy)**
+   - Action: `curl -fsS http://127.0.0.1:9020/v1/sessions | jq '.[0] | keys'`
+   - Expected: Response keys include `"title"` (value may be empty for sessions registered before fix)
+   - Tool: curl + jq
+
+### Tools Needed
+- Go test runner (`go test`)
+- Bun test runner (`bun test`)
+- Bun bundler (`bun run build`)
+- curl + jq (API verification)
+
+### Skills to Invoke
+- No project-specific testing skills identified beyond standard Legion workflows.
+
+### Optional Follow-up (separate repo)
+- Update `~/.dotfiles/scripts/envoy` to add TITLE column to `envoy ps` output: add `TITLE` to header and `(.title // "")` to jq expression in `_envoy_ps` function (lines 39-40).

--- a/packages/envoy-plugin/src/__tests__/index.test.ts
+++ b/packages/envoy-plugin/src/__tests__/index.test.ts
@@ -161,3 +161,72 @@ describe("envoy_sessions", () => {
     }
   });
 });
+
+describe("session title", () => {
+  it("includes title in follow-up subscribe after session activation", async () => {
+    const originalEnvoyUrl = process.env.ENVOY_URL;
+    process.env.ENVOY_URL = "http://127.0.0.1:59999";
+
+    const fetchCalls: { url: string; body?: string }[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (init?.body) {
+        fetchCalls.push({ url, body: init.body as string });
+      } else {
+        fetchCalls.push({ url });
+      }
+      // Serve API: return session with title
+      if (url.includes("/session/ses_title_test")) {
+        return new Response(JSON.stringify({ id: "ses_title_test", title: "Test Title" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      // Envoy subscribe calls: return success
+      if (url.includes("/v1/interests/subscribe")) {
+        return new Response(JSON.stringify({ session_id: "ses_title_test", topics: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      // Port resolution calls
+      if (url.includes("/session") && !url.includes("ses_title_test")) {
+        return new Response("not found", { status: 404 });
+      }
+      throw new Error("connection refused");
+    }) as typeof fetch;
+
+    try {
+      const pluginModule = await import("../index");
+      const hooks = await pluginModule.default({
+        serverUrl: new URL("http://127.0.0.1:13381/"),
+      } as never);
+
+      await hooks.event({
+        event: {
+          type: "session.status",
+          properties: {
+            sessionID: "ses_title_test",
+            status: { type: "busy" },
+          },
+        },
+      });
+
+      // Allow async title fetch and follow-up subscribe to complete
+      await new Promise((r) => setTimeout(r, 500));
+
+      const subscribeCalls = fetchCalls.filter(
+        (c) => c.url.includes("/v1/interests/subscribe") && c.body
+      );
+      const hasTitle = subscribeCalls.some((c) => {
+        const body = JSON.parse(c.body as string);
+        return body.title === "Test Title";
+      });
+      expect(hasTitle).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+      process.env.ENVOY_URL = originalEnvoyUrl;
+    }
+  });
+});

--- a/packages/envoy-plugin/src/index.ts
+++ b/packages/envoy-plugin/src/index.ts
@@ -18,6 +18,7 @@ async function call(path: string, init?: RequestInit) {
 
 export default async (input: { serverUrl: URL }) => {
   let activeSessionID: string | null = null;
+  let activeSessionTitle: string | null = null;
   /** Cached port — resolved asynchronously, null until first successful resolution. */
   let resolvedPort: number | null = null;
 
@@ -45,6 +46,20 @@ export default async (input: { serverUrl: URL }) => {
     return value !== null;
   };
 
+  /** Fetch session title from the OpenCode serve API. Best-effort — returns null on failure. */
+  const fetchTitle = async (sessionID: string): Promise<string | null> => {
+    try {
+      const res = await fetch(`${input.serverUrl.href}session/${sessionID}`, {
+        signal: AbortSignal.timeout(CALL_TIMEOUT_MS),
+      });
+      if (!res.ok) return null;
+      const data = (await res.json()) as { title?: string };
+      return data.title ?? null;
+    } catch {
+      return null;
+    }
+  };
+
   // Defer port resolution to background — never block plugin init.
   // The port sync loop retries every second until resolved.
   const timer = setInterval(() => {
@@ -70,6 +85,7 @@ export default async (input: { serverUrl: URL }) => {
           dir: process.cwd(),
           topics: [`notifications.agent.${activeSessionID}`],
           port,
+          title: activeSessionTitle ?? "",
         }),
       }).catch(() => {});
     },
@@ -96,8 +112,15 @@ export default async (input: { serverUrl: URL }) => {
         const sessionID = event.properties?.sessionID as string | undefined;
         if (sessionID && sessionID !== activeSessionID) {
           activeSessionID = sessionID;
+          activeSessionTitle = null;
           await syncPort();
           const port = currentPort();
+          // Fetch title — best-effort, non-blocking for initial subscribe
+          const titlePromise = fetchTitle(sessionID).then((t) => {
+            // Guard: only update if this session is still active (prevents race on fast switches)
+            if (t && activeSessionID === sessionID) activeSessionTitle = t;
+            return t;
+          });
           if (port) {
             call("/v1/interests/subscribe", {
               method: "POST",
@@ -107,8 +130,25 @@ export default async (input: { serverUrl: URL }) => {
                 dir: process.cwd(),
                 topics: [`notifications.agent.${sessionID}`],
                 port,
+                title: activeSessionTitle ?? "",
               }),
             }).catch(() => {});
+            // After title arrives, send one follow-up subscribe with title populated
+            titlePromise.then((title) => {
+              if (title && activeSessionID === sessionID) {
+                call("/v1/interests/subscribe", {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({
+                    session_id: sessionID,
+                    dir: process.cwd(),
+                    topics: [`notifications.agent.${sessionID}`],
+                    port: currentPort() ?? 0,
+                    title,
+                  }),
+                }).catch(() => {});
+              }
+            });
           }
         }
       }
@@ -134,6 +174,7 @@ export default async (input: { serverUrl: URL }) => {
               dir: ctx.directory,
               topics: args.topics,
               port: currentPort() ?? 0,
+              title: activeSessionTitle ?? "",
             }),
           });
         },
@@ -258,7 +299,7 @@ export default async (input: { serverUrl: URL }) => {
       }),
       envoy_sessions: tool({
         description:
-          "List all live sessions registered with Envoy. Returns session ID, machine ID, port, directory, topics, and last-seen timestamp for each. Use the optional machine filter to show only sessions on a specific host.",
+          "List all live sessions registered with Envoy. Returns session ID, machine ID, port, directory, title, topics, and last-seen timestamp for each. Use the optional machine filter to show only sessions on a specific host.",
         args: {
           machine: tool.schema
             .string()

--- a/packages/envoy/cmd/listener/main.go
+++ b/packages/envoy/cmd/listener/main.go
@@ -114,6 +114,7 @@ type sessionInfo struct {
 	MachineID string   `json:"machine_id"`
 	Dir       string   `json:"dir"`
 	Port      int      `json:"port"`
+	Title     string   `json:"title"`
 	Topics    []string `json:"topics"`
 	UpdatedAt int64    `json:"updated_at"`
 }
@@ -143,6 +144,7 @@ func sessionsHandler(registry *store.Registry, sessions *session.SessionRegistry
 				MachineID: entry.MachineID,
 				Dir:       entry.Dir,
 				Port:      entry.Port,
+				Title:     entry.Title,
 				UpdatedAt: entry.UpdatedAt,
 			}
 			if registry != nil {
@@ -303,6 +305,7 @@ func main() {
 			Dir       string   `json:"dir"`
 			Topics    []string `json:"topics"`
 			Port      int      `json:"port"`
+		Title     string   `json:"title"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			http.Error(w, "invalid json", http.StatusBadRequest)
@@ -323,6 +326,7 @@ func main() {
 				Port:      body.Port,
 				MachineID: cfg.MachineID,
 				Dir:       body.Dir,
+				Title:     body.Title,
 			}); err != nil {
 				log.Printf("listener session registry put failed session=%s: %v", body.SessionID, err)
 			}

--- a/packages/envoy/cmd/listener/main_test.go
+++ b/packages/envoy/cmd/listener/main_test.go
@@ -683,6 +683,58 @@ func TestSessionsHandler_JoinsRegistries(t *testing.T) {
 	}
 }
 
+func TestSessionsHandler_IncludesTitle(t *testing.T) {
+	client, err := bus.Connect([]string{sharedListenerTestNATSURI(t)}, bus.WithReplicas(1))
+	if err != nil {
+		t.Fatalf("failed to connect bus: %v", err)
+	}
+	t.Cleanup(func() { client.Conn.Close() })
+	resetListenerTestState(t, client.Conn)
+	registry, err := store.Open(client.Conn, store.WithReplicas(1))
+	if err != nil {
+		t.Fatalf("failed to create registry: %v", err)
+	}
+	sessions, err := session.OpenSessionRegistry(client.Conn, session.WithSessionReplicas(1))
+	if err != nil {
+		t.Fatalf("failed to create session registry: %v", err)
+	}
+	if _, err := registry.Upsert(store.Interest{
+		SessionID: "ses_titled",
+		MachineID: "test-machine",
+		Dir:       "/test/ses_titled",
+	}, []string{contracts.AgentSubject("ses_titled")}); err != nil {
+		t.Fatalf("failed to upsert interest: %v", err)
+	}
+	if err := sessions.Put("ses_titled", session.SessionEntry{
+		Port:      13382,
+		MachineID: "test-machine",
+		Dir:       "/test/ses_titled",
+		Title:     "My Session Title",
+	}); err != nil {
+		t.Fatalf("failed to put session entry: %v", err)
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	handler := sessionsHandler(registry, sessions)
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var items []sessionInfo
+	if err := json.NewDecoder(rec.Body).Decode(&items); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(items))
+	}
+	if items[0].Title != "My Session Title" {
+		t.Fatalf("expected title 'My Session Title', got %q", items[0].Title)
+	}
+}
+
 func TestSessionsHandler_NilSessionRegistry(t *testing.T) {
 	// When session registry is nil, endpoint returns 503
 	handler := sessionsHandler(nil, nil)

--- a/packages/envoy/internal/session/registry.go
+++ b/packages/envoy/internal/session/registry.go
@@ -16,6 +16,7 @@ type SessionEntry struct {
 	Port      int    `json:"port"`
 	MachineID string `json:"machine_id"`
 	Dir       string `json:"dir"`
+	Title     string `json:"title"`
 	UpdatedAt int64  `json:"updated_at"`
 }
 


### PR DESCRIPTION
Closes #432

## Summary

Restores session title display in Envoy's `/v1/sessions` API response — regression from PR #393 which removed the file registry that previously stored titles.

**Changes:**
- **Go (envoy listener):** Added `Title` field to `SessionEntry` struct, wired through the subscribe handler body and `/v1/sessions` response. New test verifies title flows through KV to the API.
- **TypeScript (envoy-plugin):** Plugin fetches session title from the serve API (`GET /session/{id}`) on session activation, caches it, and includes it in all subscribe/heartbeat payloads. Follow-up subscribe sends the title once the async fetch completes. Session-switch race guard prevents stale title writes.