### PR TITLE
sjawhar-legion-436: refactor(daemon): add --config flag with YAML config file, replace env vars

### DIFF
--- a/.legion/architect.json
+++ b/.legion/architect.json
@@ -1,19 +1,10 @@
 {
   "scope": "medium",
   "components": [
-    "packages/envoy/cmd/listener/main.go",
-    "packages/envoy/cmd/github/main.go",
-    "packages/envoy/cmd/slack/main.go",
-    "packages/envoy/cmd/ghostwispr/main.go",
-    "packages/envoy/internal/webhook/",
-    "packages/envoy/internal/verify/",
-    "packages/envoy/internal/config/config.go",
-    "packages/envoy/docker/Dockerfile",
-    "packages/envoy/deploy/compose/",
-    "packages/envoy/infra/services.ts",
-    "packages/envoy/infra/machines.ts",
-    "packages/envoy/infra/index.ts",
-    "packages/envoy/AGENTS.md"
+    "packages/daemon/src/daemon/config.ts",
+    "packages/daemon/src/cli/index.ts",
+    "packages/daemon/src/daemon/index.ts",
+    "packages/daemon/src/daemon/server.ts"
   ],
   "subIssues": [],
   "routingHints": {
@@ -22,23 +13,22 @@
     "skipRetro": false
   },
   "concerns": [
-    "Config-gated activation (ENVOY_WEBHOOKS env var) replaces secret-gated activation — enabled provider + missing required secret = startup failure",
-    "Ghost Wispr must be explicitly enabled via ENVOY_WEBHOOKS, not 'always registered' — prevents unintended exposure on non-receiver machines",
-    "Webhook handlers must take publisher interface, not atomic.Pointer[listenerDeps] — follow Ghost Wispr envelopePublisher pattern for testability",
-    "Startup readiness: listener binds port before NATS connects; webhook handlers behind readinessGate return 503 until NATS ready — acceptable because Docker healthcheck gates traffic",
-    "Migration requires parallel operation: old receivers stay running on 9010/9011/9012 while new listener serves 9020; switch webhook URLs at providers then remove old containers",
-    "Duplicate delivery risk during overlap is low: dedupe keys are source-derived (github.<delivery>, slack.<event_id>, ghostwispr.<delivery>)",
-    "When ENVOY_TSNET_ENABLED=false, /v1/* still served on public port (existing fallback behavior) — spec does not change this"
+    "startDaemon() currently overrides config.daemonPort via registry allocation — port from config must be authoritative",
+    "ENVOY_URL and LEGION_FEEDBACK_* are read directly from process.env outside loadConfig() — must migrate to config object",
+    "Relative paths in YAML (workspace, private_key_path) must resolve relative to config file directory, not cwd",
+    "extra_projects is GitHub-multi-board only — Linear backend with extra_projects should error",
+    "Deprecation warnings should only fire when env var is the effective value, not when overridden",
+    "Unknown key warnings must cover full key paths (nested), not just top-level keys"
   ],
   "learningsInjected": [
-    "envoy/listener-routing-by-topic-prefix.md",
-    "envoy/docker-tailscale-networking.md",
-    "envoy/contracts-and-handler-patterns.md"
+    "delegation/hardening-patterns.md",
+    "daemon/controller-lifecycle-separation.md",
+    "daemon/shared-serve-refactor.md"
   ],
   "learningsHelpful": [
-    "envoy/contracts-and-handler-patterns.md"
+    "daemon/shared-serve-refactor.md"
   ],
   "schemaVersion": 1,
   "phase": "architect",
-  "completed": "2026-04-11T20:21:30.953Z"
+  "completed": "2026-04-11T21:45:53.294Z"
 }

--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,17 +1,19 @@
 {
-  "prNumber": 429,
-  "prUrl": "https://github.com/sjawhar/legion/pull/429",
-  "branch": "sjawhar-legion-427",
-  "summary": "Consolidated 3 standalone webhook receiver binaries into the listener process. Extracted handlers to internal/webhook/ behind Publisher interface, config-gated via ENVOY_WEBHOOKS env var. 42 new tests. Removed old cmd/, compose, Pulumi receiver infrastructure.",
-  "filesChanged": 28,
-  "testsAdded": 42,
-  "reviewFindings": [
-    "Added TrimSpace to config.go for env parity with old receivers",
-    "Made Pulumi secrets conditional (getSecret vs requireSecret)",
-    "Added whitespace-only secret regression tests"
+  "filesChanged": [
+    "packages/daemon/src/daemon/config.ts",
+    "packages/daemon/src/cli/index.ts",
+    "packages/daemon/src/daemon/index.ts",
+    "packages/daemon/src/daemon/server.ts"
   ],
-  "deploymentNotes": "Migration requires parallel operation: old receivers stay running while new listener serves webhooks on port 9020. Switch webhook URLs at providers, then remove old containers.",
+  "trickyParts": [
+    "startDaemon() signature change required updating all callers",
+    "extra_projects validation now applies to env-sourced values too",
+    "validateBackend/validateRuntime exported for CLI validation"
+  ],
+  "testResults": "861 pass, 0 fail across 41 files",
+  "ciStatus": "all green",
+  "prNumber": 442,
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-11T21:11:23.875Z"
+  "completed": "2026-04-11T23:07:21.136Z"
 }

--- a/.legion/plan.json
+++ b/.legion/plan.json
@@ -1,35 +1,31 @@
 {
-  "taskCount": 5,
-  "independentTasks": 3,
+  "taskCount": 3,
+  "independentTasks": 1,
   "routingHints": {
     "complexity": "medium",
     "estimatedImplementers": 1,
-    "skipRetro": false,
-    "skipArchitect": false
+    "skipRetro": false
   },
   "concerns": [
-    "Ghost Wispr secret is optional even when provider is enabled — different from GitHub/Slack which require secrets",
-    "Webhook handlers use contracts.{GithubEnvelopes,SlackEnvelopes,GhostWisprEnvelope} for envelope creation — do NOT hand-build envelopes",
-    "GitHub mention fan-out produces 3 envelopes (base + resource-specific mention + repo-wide mention), not 2",
-    "Slack url_verification must happen BEFORE signature verification",
-    "Slack handler skips invalid envelopes with continue, not error — preserves current behavior",
-    "Non-POST requests return 200 for all handlers, not 405",
-    "Pulumi secrets (githubWebhookSecret, slackSigningSecret) remain requireSecret at config level — config-gated activation is at Go level only",
-    "Pulumi.prod.yaml must be updated to move receivers to listener.webhooks"
+    "startDaemon() shallow merge must be replaced with single resolved-config contract",
+    "Port authority: explicit config port must bypass registry allocation",
+    "ENVOY_URL and LEGION_FEEDBACK_* must migrate from process.env to config object",
+    "Relative paths in YAML must resolve against config file directory not cwd",
+    "Deprecation warnings only fire when env var is the effective value",
+    "Unknown-key warnings use full dotted paths via simple recursive walker",
+    "getDaemonPort() in non-start CLI commands may remain as env read"
   ],
   "learningsInjected": [
-    "envoy/contracts-and-handler-patterns.md",
-    "envoy/listener-routing-by-topic-prefix.md",
-    "envoy/docker-tailscale-networking.md"
+    "delegation/hardening-patterns.md",
+    "daemon/shared-serve-refactor.md",
+    "daemon/controller-lifecycle-separation.md"
   ],
-  "learningsHelpful": ["envoy/contracts-and-handler-patterns.md"],
-  "workflowRecommendation": "Standard pipeline — all phases needed. Tasks 2+3 can run in parallel after Task 1. Medium complexity, single implementer.",
-  "requiredSkills": {
-    "implement": ["envoy"],
-    "test": [],
-    "review": []
-  },
+  "learningsHelpful": [
+    "delegation/hardening-patterns.md",
+    "daemon/controller-lifecycle-separation.md"
+  ],
+  "workflowRecommendation": "Standard pipeline. Medium complexity, single implementer. 3 waves: W1 config resolver (independent), W2 CLI+daemon+server integration (depends W1), W3 audit+verification (depends W1+W2).",
   "schemaVersion": 1,
   "phase": "plan",
-  "completed": "2026-04-11T20:43:31.451Z"
+  "completed": "2026-04-11T22:17:54.461Z"
 }

--- a/.legion/retro.json
+++ b/.legion/retro.json
@@ -1,10 +1,9 @@
 {
   "skipped": false,
   "docsCreated": [
-    "docs/solutions/envoy/multi-layer-service-consolidation.md",
-    "docs/solutions/envoy/webhook-handler-extraction-and-testing.md"
+    "docs/solutions/daemon/config-resolution-patterns.md"
   ],
   "schemaVersion": 1,
   "phase": "retro",
-  "completed": "2026-04-11T21:46:32.192Z"
+  "completed": "2026-04-11T23:52:25.336Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,27 +1,17 @@
 {
   "critical": 0,
-  "important": 1,
-  "minor": 1,
+  "important": 2,
+  "minor": 2,
   "verdict": "approved",
   "keyFindings": [
-    {
-      "severity": "P2",
-      "file": "packages/envoy/cmd/listener/main_test.go",
-      "description": "Test coverage gaps: no subscribe handler input test (Go), no race guard test (TS), no heartbeat title test (TS). Existing tests cover happy path only."
-    },
-    {
-      "severity": "P3",
-      "file": "packages/envoy/cmd/listener/main.go",
-      "description": "gofmt formatting error at line 308 — Title field uses 2 tabs instead of 3 in subscribe handler body struct. Confirmed by gofmt -d."
-    }
+    {"severity": "P2", "file": "packages/daemon/src/daemon/config.ts", "description": "loadGitHubApps() (env-based, L312-329) still silently ignores partial GitHub App role config. Plan says 'Make partial GitHub App role config a hard error' — YAML path validates correctly but env path does not."},
+    {"severity": "P2", "file": "packages/daemon/src/cli/index.ts", "description": "L243: config.stateFilePath mutation after resolveDaemonConfig() breaks 'resolve once, use everywhere' contract. Value is redundant with what resolveDaemonConfig already computes."},
+    {"severity": "P3", "file": "packages/daemon/src/daemon/index.ts", "description": "Dual daemonPortExplicit sources (DaemonConfig and DaemonStartOptions) without documenting the override chain."},
+    {"severity": "P3", "file": "packages/daemon/src/cli/__tests__/index.test.ts", "description": "Missing integration-level error-path tests for cmdStart with missing config file and invalid YAML (unit-level coverage exists in loadConfigFromFile tests)."}
   ],
-  "learningsInjected": [
-    "architecture-patterns/nats-kv-dual-bucket-lifecycle.md",
-    "testing/nats-kv-testing-patterns.md",
-    "architecture-patterns/nats-kv-graceful-degradation.md"
-  ],
+  "learningsInjected": [],
   "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-11T22:11:01.295Z"
+  "completed": "2026-04-11T23:45:00.000Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,19 +1,22 @@
 {
-  "passed": 4,
+  "passed": 22,
   "failed": 0,
   "failures": [],
-  "documentationFeedback": "PR body clearly explains regression origin (PR #393) and fix structure. Issue body enumerates fix points with CLI script correctly scoped out. No user-facing doc changes needed.",
+  "documentationFeedback": "PR body provides clear usage examples and verification stats. Issue body has comprehensive YAML schema reference. No dedicated docs file updated — appropriate for a refactor PR. Follow-up legion init command would benefit from generating commented config template.",
   "observations": [
-    "P3 formatting: gofmt reports indentation error in cmd/listener/main.go:308 — Title field uses single tab instead of double",
-    "P2 test gaps: no subscribe handler input test (Go), no race guard test (TS), no heartbeat title test (TS)",
-    "Plugin correctly handles async title fetch race with session-switch guard"
+    "P2: CLI test file missing error-path tests for cmdStart with missing config file and invalid YAML (tested at unit level in loadConfigFromFile)",
+    "P2: No explicit env-mutation regression test asserting process.env unchanged after cmdStart()",
+    "Test count increased from 861 to 862 due to main branch changes between implementation and testing"
   ],
   "learningsInjected": [
-    "architecture-patterns/nats-kv-dual-bucket-lifecycle.md",
-    "testing/nats-kv-testing-patterns.md"
+    "testing/bun-fetch-mocking-patterns.md",
+    "testing/bun-mock-module-global-leak.md",
+    "delegation/hardening-patterns.md"
   ],
-  "learningsHelpful": ["architecture-patterns/nats-kv-dual-bucket-lifecycle.md"],
+  "learningsHelpful": [
+    "testing/bun-mock-module-global-leak.md"
+  ],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-11T22:04:48.232Z"
+  "completed": "2026-04-11T23:17:03.392Z"
 }

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "packages/daemon": {
       "name": "legion",
-      "version": "0.10.1",
+      "version": "0.16.0",
       "bin": {
         "legion": "src/cli/index.ts",
       },
@@ -27,6 +27,7 @@
         "@opencode-ai/sdk": "https://github.com/sjawhar/opencode/releases/download/v1.2.4-post.2/opencode-ai-sdk-1.2.4-post.1.tgz",
         "citty": "^0.2.0",
         "uuid": "^9.0.0",
+        "yaml": "^2.8.3",
         "zod": "^3.24.4",
       },
       "devDependencies": {
@@ -37,7 +38,7 @@
     },
     "packages/envoy-plugin": {
       "name": "@sjawhar/opencode-legion-envoy",
-      "version": "0.1.0-alpha.0",
+      "version": "0.15.0",
       "dependencies": {
         "@opencode-ai/plugin": "^1.1.19",
       },
@@ -49,7 +50,7 @@
     },
     "packages/opencode-plugin": {
       "name": "opencode-legion",
-      "version": "0.10.1",
+      "version": "0.16.0",
       "bin": {
         "opencode-legion": "./src/cli/index.ts",
       },
@@ -119,13 +120,15 @@
 
     "vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
 
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@opencode-ai/plugin/@opencode-ai/sdk": ["@opencode-ai/sdk@1.2.27", "", {}, "sha512-Wk0o/I+Fo+wE3zgvlJDs8Fb67KlKqX0PrV8dK5adSDkANq6r4Z25zXJg2iOir+a8ntg3rAcpel1OY4FV/TwRUA=="],
 
     "@opencode-ai/plugin/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
 
-    "legion/@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+    "legion/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "legion/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -135,7 +138,7 @@
 
     "vscode-languageserver-protocol/vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
 
-    "legion/@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+    "legion/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "opencode-legion/@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
   }

--- a/docs/solutions/daemon/config-resolution-patterns.md
+++ b/docs/solutions/daemon/config-resolution-patterns.md
@@ -1,0 +1,113 @@
+---
+title: "Config Resolution Patterns: Multi-Source Precedence with Deprecation Tracking"
+category: daemon
+tags:
+  - config-schema
+  - dependency-injection
+  - deprecation
+  - testing
+  - validation
+date: 2026-04-11
+status: active
+module: daemon
+related_issues:
+  - "sjawhar-legion-436"
+symptoms:
+  - "env var deprecation warnings"
+  - "config file vs env var precedence"
+  - "unknown YAML key warning"
+  - "startDaemon signature change broke tests"
+---
+
+# Config Resolution Patterns: Multi-Source Precedence with Deprecation Tracking
+
+Learnings from adding YAML config file support to the daemon (#436), replacing scattered `process.env` reads with a layered resolution system.
+
+## Pattern 1: `resolveValue<T>` with Source Tracking
+
+The core abstraction: a generic function that takes values from each source layer and returns both the winning value and which source it came from.
+
+```typescript
+type ValueSource = "cli" | "config" | "env" | "default";
+
+function resolveValue<T>(
+  cliValue: T | undefined,
+  configValue: T | undefined,
+  envValue: T | undefined,
+  defaultValue: T
+): { value: T; source: ValueSource }
+```
+
+**Why source tracking matters:** Deprecation warnings should only fire when the env var is the *effective* value — not when it's set but overridden by config or CLI. The `source` field makes this a simple `source === "env"` check. An early draft checked `env[envVar] !== undefined` instead, which incorrectly warned even when the user had migrated to config.
+
+**Gotcha — three places per new field:** Adding a new config field requires updates in (1) `loadConfigFromFile()` for YAML→fields mapping, (2) `resolveDaemonConfig()` for the `resolveValue()` call, and (3) `CONFIG_SCHEMA` for unknown-key detection. Missing any one causes silent bugs or spurious warnings.
+
+## Pattern 2: Two-Phase Config Loading
+
+Separate YAML parsing from precedence resolution:
+
+1. **Phase 1** (`loadConfigFromFile`): Parse YAML → produce `{ fields: Record<string, unknown>, warnings: string[] }`. Validates syntax, enums, path normalization, GitHub App completeness. No knowledge of env vars.
+2. **Phase 2** (`resolveDaemonConfig`): Merge `configFile.fields` with env values and CLI overrides using `resolveValue()` for each field. Produces fully typed `DaemonConfig` plus deprecation warnings.
+
+**Why this separation matters:** Each phase is independently testable. CLI tests can inject a fake `configFile` without touching YAML. Config file tests validate parsing without env var setup. The `LoadedConfigFile` type is the clean boundary.
+
+**Note:** `LoadedConfigFile.fields` uses TypeScript-side names (camelCase), not YAML keys. The `loadConfigFromFile()` function handles the snake_case→camelCase mapping.
+
+## Pattern 3: Schema-Driven Unknown-Key Detection
+
+A recursive `CONFIG_SCHEMA` constant defines the known YAML structure:
+
+```typescript
+const CONFIG_SCHEMA: ConfigSchema = {
+  project: null,        // null = leaf node
+  controller: {         // object = nested section
+    session_id: null,
+    prompt: null,
+  },
+  // ...
+};
+```
+
+A `collectUnknownKeys()` walker traverses parsed YAML against this schema and emits dotted-path warnings like `github_apps.impl.extra_field`.
+
+**Why not Zod:** We wanted warnings (non-fatal) for unknown keys, not errors. Zod's `strict()` throws. The schema walker is ~15 lines and produces exactly the UX we need.
+
+**Sync gotcha:** The schema must stay in sync with the parsing logic. If you add a YAML key to `loadConfigFromFile()` but forget `CONFIG_SCHEMA`, users get spurious warnings.
+
+## Pattern 4: Test Helpers After API Signature Changes
+
+Changing `startDaemon()` from `Partial<DaemonConfig>` overrides to a fully resolved `DaemonConfig` broke ~30 tests. The fix: a `buildConfig()` / `startDaemonForTest()` helper that calls `resolveDaemonConfig()` to construct a valid base, then spreads test-specific overrides.
+
+```typescript
+function buildConfig(paths, stateFilePath, overrides = {}) {
+  const { config } = resolveDaemonConfig({ env: { LEGION_ID: "acme/widgets" } });
+  return { ...config, paths, legionId: "acme/widgets", stateFilePath, ...overrides };
+}
+```
+
+**Lesson:** When changing a function from "partial with defaults" to "fully resolved", plan for a test helper that constructs valid instances. Don't make every test build the full object from scratch — that creates fragile tests that break on every new required field.
+
+## Pattern 5: Validation Parity Across Code Paths
+
+**The bug:** The env-based `loadConfig()` silently accepted `extra_projects` with `backend: linear`. The YAML-based `loadConfigFromFile()` correctly rejected it. Review caught this — the env path was written before the validation requirement existed and was never audited.
+
+**The fix:** Move the validation into `resolveDaemonConfig()` where it applies regardless of source.
+
+**Lesson:** When adding validation to a new code path (YAML parser), always audit existing code paths (env parser) for the same field. Two entry points for the same data → two places that need the same validation. The safest approach: validate in the resolver (Phase 2), not the parser (Phase 1), so all sources get the same treatment.
+
+## Pattern 6: CLI DI with Sentinel Abort
+
+`cmdStart()` accepts a `deps` parameter for `startDaemon` and `resolveLegionId`. Tests inject mocks that capture args and throw a sentinel to abort cleanly:
+
+```typescript
+const START_DAEMON_ABORT = "__start-daemon-abort__";
+await cmdStart(undefined, { config: configPath }, {
+  startDaemon: async (config) => {
+    calls.push(config);
+    throw new Error(START_DAEMON_ABORT);
+  },
+  resolveLegionId: async (team) => team,
+});
+```
+
+This tests CLI wiring without running the actual daemon. Cleaner than module mocking because the DI seam is explicit in the function signature.

--- a/docs/solutions/index.json
+++ b/docs/solutions/index.json
@@ -49,6 +49,7 @@
       "testing/ci-merge-type-compatibility.md",
       "daemon/session-adoption-api-pattern.md",
       "daemon/health-tick-baseline-isolation.md"
+      "daemon/config-resolution-patterns.md"
     ],
     "packages/daemon/src/cli": [
       "daemon/controller-lifecycle-separation.md",
@@ -60,6 +61,7 @@
       "daemon/state-machine-action-display-mismatch.md",
       "daemon/session-adoption-api-pattern.md",
       "skill-patterns/agent-workflow-enforcement-patterns.md"
+      "daemon/config-resolution-patterns.md"
     ],
     "packages/daemon": [
       "architecture-patterns/plugin-migration-assessment.md",
@@ -142,6 +144,7 @@
     "tag:code-review": ["daemon/deferred-review-comments-pattern.md"],
     "tag:concurrency": ["delegation/delegation-hardening-retro.md"],
     "tag:config-schema": ["delegation/hardening-patterns.md"],
+    "tag:deprecation": ["daemon/config-resolution-patterns.md"],
     "tag:controller": [
       "daemon/controller-observability.md",
       "integration-patterns/controller-worker-protocol.md",
@@ -161,6 +164,7 @@
       "architecture-patterns/sync-to-async-modular-refactoring.md",
       "daemon/shared-serve-refactor.md",
       "daemon/shared-serve-retro.md"
+      "daemon/config-resolution-patterns.md"
     ],
     "tag:directory-resolution": ["daemon/worker-directory-fix.md"],
     "tag:dispatch": ["integration-patterns/controller-worker-protocol.md"],
@@ -295,6 +299,7 @@
     ],
     "tag:tmux": ["integration-patterns/tmux-askuserquestion-navigation.md"],
     "tag:validation": ["daemon/workspace-validation-retro.md"],
+      "daemon/config-resolution-patterns.md"
     "tag:worker": ["integration-patterns/controller-worker-protocol.md"],
     "tag:worker-isolation": ["daemon/worker-directory-resolution.md"],
     "tag:worker-lifecycle": [

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -17,6 +17,7 @@
     "@opencode-ai/sdk": "https://github.com/sjawhar/opencode/releases/download/v1.2.4-post.2/opencode-ai-sdk-1.2.4-post.1.tgz",
     "citty": "^0.2.0",
     "uuid": "^9.0.0",
+    "yaml": "^2.8.3",
     "zod": "^3.24.4"
   },
   "devDependencies": {

--- a/packages/daemon/src/cli/__tests__/index.test.ts
+++ b/packages/daemon/src/cli/__tests__/index.test.ts
@@ -35,6 +35,7 @@ import {
   cmdDispatch,
   cmdPrompt,
   cmdResetCrashes,
+  cmdStart,
   dispatchCommand,
   getDaemonPort,
   legionsCommand,
@@ -191,6 +192,164 @@ describe("scanOcRegistry", () => {
   });
 });
 
+describe("cmdStart config wiring", () => {
+  const originalLog = console.log;
+  const originalError = console.error;
+  const startDaemonCalls: Array<Record<string, unknown>> = [];
+  const resolveLegionIdCalls: Array<{ team: string; backend?: string }> = [];
+  let resolveLegionIdResult: string | undefined;
+  const START_DAEMON_ABORT = "__start-daemon-abort__";
+
+  function readBackendArg(
+    opts: string | { cacheDir?: string; backend?: string } | undefined
+  ): string | undefined {
+    return opts && typeof opts === "object" ? opts.backend : undefined;
+  }
+
+  beforeEach(() => {
+    startDaemonCalls.length = 0;
+    resolveLegionIdCalls.length = 0;
+    resolveLegionIdResult = undefined;
+    console.log = mock(() => {}) as typeof console.log;
+    console.error = mock(() => {}) as typeof console.error;
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+    console.error = originalError;
+  });
+
+  it("starts from --config without positional team when config provides project", async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "legion-start-config-"));
+    const configPath = path.join(tempDir, "legion.yml");
+
+    try {
+      await writeFile(
+        configPath,
+        ["project: acme/12", "workspace: /tmp/config-workspace", "port: 15432"].join("\n")
+      );
+
+      try {
+        await cmdStart(
+          undefined,
+          { config: configPath },
+          {
+            startDaemon: async (config) => {
+              startDaemonCalls.push(config as unknown as Record<string, unknown>);
+              throw new Error(START_DAEMON_ABORT);
+            },
+            resolveLegionId: async (team, opts) => {
+              resolveLegionIdCalls.push({ team, backend: readBackendArg(opts) });
+              return resolveLegionIdResult ?? team;
+            },
+          }
+        );
+        throw new Error("Expected cmdStart to reject");
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toContain(START_DAEMON_ABORT);
+      }
+
+      expect(resolveLegionIdCalls).toHaveLength(0);
+      expect(startDaemonCalls).toHaveLength(1);
+      expect(startDaemonCalls[0]).toEqual(
+        expect.objectContaining({
+          legionId: "acme/12",
+          legionDir: "/tmp/config-workspace",
+          daemonPort: 15432,
+          daemonPortExplicit: true,
+        })
+      );
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers positional team over config project", async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "legion-start-config-"));
+    const configPath = path.join(tempDir, "legion.yml");
+    resolveLegionIdResult = "resolved/team";
+
+    try {
+      await writeFile(configPath, "project: from-config/99\nworkspace: /tmp/config-workspace\n");
+
+      try {
+        await cmdStart(
+          "cli-team",
+          { config: configPath },
+          {
+            startDaemon: async (config) => {
+              startDaemonCalls.push(config as unknown as Record<string, unknown>);
+              throw new Error(START_DAEMON_ABORT);
+            },
+            resolveLegionId: async (team, opts) => {
+              resolveLegionIdCalls.push({ team, backend: readBackendArg(opts) });
+              return resolveLegionIdResult ?? team;
+            },
+          }
+        );
+        throw new Error("Expected cmdStart to reject");
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toContain(START_DAEMON_ABORT);
+      }
+
+      expect(resolveLegionIdCalls).toEqual([{ team: "cli-team", backend: undefined }]);
+      expect(startDaemonCalls).toHaveLength(1);
+      expect(startDaemonCalls[0]).toEqual(
+        expect.objectContaining({
+          legionId: "resolved/team",
+          legionDir: "/tmp/config-workspace",
+        })
+      );
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails when neither positional team nor config project is provided", async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "legion-start-config-"));
+    const configPath = path.join(tempDir, "legion.yml");
+    const originalLegionId = process.env.LEGION_ID;
+
+    try {
+      delete process.env.LEGION_ID;
+      await writeFile(configPath, "backend: github\nworkspace: /tmp/config-workspace\n");
+
+      try {
+        await cmdStart(
+          undefined,
+          { config: configPath },
+          {
+            startDaemon: async (config) => {
+              startDaemonCalls.push(config as unknown as Record<string, unknown>);
+              throw new Error(START_DAEMON_ABORT);
+            },
+            resolveLegionId: async (team, opts) => {
+              resolveLegionIdCalls.push({ team, backend: readBackendArg(opts) });
+              return resolveLegionIdResult ?? team;
+            },
+          }
+        );
+        throw new Error("Expected cmdStart to reject");
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toContain(
+          "Missing project: provide positional team arg or 'project' in config file"
+        );
+      }
+      expect(startDaemonCalls).toHaveLength(0);
+    } finally {
+      if (originalLegionId === undefined) {
+        delete process.env.LEGION_ID;
+      } else {
+        process.env.LEGION_ID = originalLegionId;
+      }
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("adoptCommand", () => {
   it("has correct meta", async () => {
     const meta = await Promise.resolve(adoptCommand.meta);
@@ -317,13 +476,15 @@ describe("citty command definitions", () => {
   test("start command args are defined", async () => {
     const args = await resolveArgs(startCommand);
     const team = args.team as PositionalArg;
+    const config = args.config as StringArg;
     const workspace = args.workspace as StringArg;
     const stateDir = args["state-dir"] as StringArg;
     expect(team.type).toBe("positional");
-    expect(team.required).toBe(true);
+    expect(team.required).toBe(false);
+    expect(config).toEqual(expect.objectContaining({ type: "string", alias: "c" }));
     expect(workspace.type).toBe("string");
     expect(workspace.alias).toBe("w");
-    expect(workspace.default).toBe(process.cwd());
+    expect(workspace.default).toBeUndefined();
     expect(stateDir.type).toBe("string");
   });
 

--- a/packages/daemon/src/cli/index.ts
+++ b/packages/daemon/src/cli/index.ts
@@ -5,7 +5,13 @@ import { readdir, readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { defineCommand, runMain } from "citty";
-import { type DaemonConfig, validateControllerPrompt } from "../daemon/config";
+import {
+  type DaemonConfig,
+  type LoadedConfigFile,
+  loadConfigFromFile,
+  resolveDaemonConfig,
+  validateControllerPrompt,
+} from "../daemon/config";
 import { startDaemon } from "../daemon/index";
 import { findLegionByProjectId } from "../daemon/legions-registry";
 import { resolveLegionPaths } from "../daemon/paths";
@@ -161,45 +167,82 @@ export function loadLegionsCache(
 }
 
 interface StartOptions {
-  workspace: string;
+  workspace?: string;
   prompt?: string;
   backend?: string;
   runtime?: string;
+  config?: string;
 }
 
-async function cmdStart(team: string, opts: StartOptions): Promise<void> {
-  const legionId = await resolveLegionId(team, { backend: opts.backend });
-  const instancePaths = resolveLegionPaths(process.env, os.homedir()).forLegion(legionId);
+interface StartDependencies {
+  startDaemon: typeof startDaemon;
+  resolveLegionId: typeof resolveLegionId;
+}
 
+export async function cmdStart(
+  team: string | undefined,
+  opts: StartOptions,
+  deps: StartDependencies = { startDaemon, resolveLegionId }
+): Promise<void> {
   validateControllerPrompt(opts.prompt);
 
-  console.log(`Starting legion: ${legionId}`);
-  console.log(`Workspace: ${opts.workspace}`);
+  let configFile: LoadedConfigFile | undefined;
+  if (opts.config) {
+    const configPath = path.resolve(process.cwd(), opts.config);
+    let yamlText: string;
+    try {
+      yamlText = fs.readFileSync(configPath, "utf-8");
+    } catch {
+      throw new CliError(`Config file not found: ${configPath}`);
+    }
+    configFile = loadConfigFromFile(yamlText, path.dirname(configPath));
+  }
+
+  const cliOverrides: Partial<DaemonConfig> = {};
+  if (opts.workspace) {
+    cliOverrides.legionDir = opts.workspace;
+  }
+  if (opts.prompt !== undefined) {
+    cliOverrides.controllerPrompt = opts.prompt;
+  }
+  if (opts.backend) {
+    cliOverrides.issueBackend = opts.backend as DaemonConfig["issueBackend"];
+  }
+  if (opts.runtime) {
+    cliOverrides.runtime = opts.runtime as DaemonConfig["runtime"];
+  }
+  if (team) {
+    cliOverrides.legionId = await deps.resolveLegionId(team, { backend: opts.backend });
+  }
+
+  const { config, warnings } = resolveDaemonConfig({
+    env: process.env,
+    configFile,
+    cliOverrides,
+  });
+
+  if (!config.legionId) {
+    throw new CliError("Missing project: provide positional team arg or 'project' in config file");
+  }
+
+  for (const warning of warnings) {
+    console.error(`Warning: ${warning}`);
+  }
+
+  const instancePaths = config.paths.forLegion(config.legionId);
+
+  console.log(`Starting legion: ${config.legionId}`);
+  console.log(`Workspace: ${config.legionDir ?? process.cwd()}`);
   console.log(`State directory: ${instancePaths.legionStateDir}`);
 
   fs.mkdirSync(instancePaths.legionStateDir, { recursive: true });
+  config.stateFilePath = instancePaths.workersFile;
 
-  if (opts.backend) {
-    process.env.LEGION_ISSUE_BACKEND = opts.backend;
-  }
-
-  if (opts.runtime) {
-    process.env.LEGION_RUNTIME = opts.runtime;
-  }
-  const overrides: Partial<DaemonConfig> = {
-    legionId,
-    legionDir: opts.workspace,
-    stateFilePath: instancePaths.workersFile,
-  };
-  if (opts.prompt !== undefined) {
-    overrides.controllerPrompt = opts.prompt;
-  }
-
-  const handle = await startDaemon(overrides);
+  const handle = await deps.startDaemon(config);
 
   console.log(`Daemon started on port ${handle.config.daemonPort}`);
-  console.log(`\nTo check status: legion status ${team}`);
-  console.log(`To stop: legion stop ${team}`);
+  console.log(`\nTo check status: legion status ${team ?? config.legionId}`);
+  console.log(`To stop: legion stop ${team ?? config.legionId}`);
 
   await new Promise(() => {});
 }
@@ -893,12 +936,11 @@ function parseHandoffData(data: string | undefined): Record<string, unknown> {
 export const startCommand = defineCommand({
   meta: { name: "start", description: "Start the Legion swarm" },
   args: {
-    team: { type: "positional", description: "Legion key or UUID", required: true },
+    team: { type: "positional", description: "Legion key or UUID", required: false },
     workspace: {
       type: "string",
       alias: "w",
       description: "Workspace path",
-      default: process.cwd(),
     },
     "state-dir": { type: "string", description: "State directory path" },
     prompt: {
@@ -916,6 +958,7 @@ export const startCommand = defineCommand({
       alias: "r",
       description: "Agent runtime (opencode or claude-code)",
     },
+    config: { type: "string", alias: "c", description: "Config file path" },
   },
   async run({ args }) {
     await cmdStart(args.team, {
@@ -923,6 +966,7 @@ export const startCommand = defineCommand({
       prompt: args.prompt,
       backend: args.backend,
       runtime: args.runtime,
+      config: args.config,
     });
   },
 });

--- a/packages/daemon/src/cli/index.ts
+++ b/packages/daemon/src/cli/index.ts
@@ -10,7 +10,9 @@ import {
   type LoadedConfigFile,
   loadConfigFromFile,
   resolveDaemonConfig,
+  validateBackend,
   validateControllerPrompt,
+  validateRuntime,
 } from "../daemon/config";
 import { startDaemon } from "../daemon/index";
 import { findLegionByProjectId } from "../daemon/legions-registry";
@@ -206,10 +208,12 @@ export async function cmdStart(
     cliOverrides.controllerPrompt = opts.prompt;
   }
   if (opts.backend) {
-    cliOverrides.issueBackend = opts.backend as DaemonConfig["issueBackend"];
+    const validated = validateBackend(opts.backend, "--backend");
+    if (validated) cliOverrides.issueBackend = validated;
   }
   if (opts.runtime) {
-    cliOverrides.runtime = opts.runtime as DaemonConfig["runtime"];
+    const validated = validateRuntime(opts.runtime, "--runtime");
+    if (validated) cliOverrides.runtime = validated;
   }
   if (team) {
     cliOverrides.legionId = await deps.resolveLegionId(team, { backend: opts.backend });

--- a/packages/daemon/src/daemon/__tests__/config.test.ts
+++ b/packages/daemon/src/daemon/__tests__/config.test.ts
@@ -201,25 +201,37 @@ describe("daemon config", () => {
     });
 
     it("parses single valid entry", () => {
-      const config = loadConfig({ LEGION_EXTRA_PROJECTS: "acme/12" });
+      const config = loadConfig({
+        LEGION_EXTRA_PROJECTS: "acme/12",
+        LEGION_ISSUE_BACKEND: "github",
+      });
 
       expect(config.extraProjects).toEqual(["acme/12"]);
     });
 
     it("parses multiple comma-separated entries", () => {
-      const config = loadConfig({ LEGION_EXTRA_PROJECTS: "acme/12,globex/34,initech/56" });
+      const config = loadConfig({
+        LEGION_EXTRA_PROJECTS: "acme/12,globex/34,initech/56",
+        LEGION_ISSUE_BACKEND: "github",
+      });
 
       expect(config.extraProjects).toEqual(["acme/12", "globex/34", "initech/56"]);
     });
 
     it("trims whitespace from entries", () => {
-      const config = loadConfig({ LEGION_EXTRA_PROJECTS: "  acme/12 ,\tglobex/34\n" });
+      const config = loadConfig({
+        LEGION_EXTRA_PROJECTS: "  acme/12 ,\tglobex/34\n",
+        LEGION_ISSUE_BACKEND: "github",
+      });
 
       expect(config.extraProjects).toEqual(["acme/12", "globex/34"]);
     });
 
     it("ignores empty segments from trailing and double commas", () => {
-      const config = loadConfig({ LEGION_EXTRA_PROJECTS: "acme/12,,globex/34," });
+      const config = loadConfig({
+        LEGION_EXTRA_PROJECTS: "acme/12,,globex/34,",
+        LEGION_ISSUE_BACKEND: "github",
+      });
 
       expect(config.extraProjects).toEqual(["acme/12", "globex/34"]);
     });
@@ -227,6 +239,7 @@ describe("daemon config", () => {
     it("deduplicates entries preserving order", () => {
       const config = loadConfig({
         LEGION_EXTRA_PROJECTS: "acme/12,globex/34,acme/12,initech/56,globex/34",
+        LEGION_ISSUE_BACKEND: "github",
       });
 
       expect(config.extraProjects).toEqual(["acme/12", "globex/34", "initech/56"]);

--- a/packages/daemon/src/daemon/__tests__/config.test.ts
+++ b/packages/daemon/src/daemon/__tests__/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import os from "node:os";
 import path from "node:path";
-import { loadConfig } from "../config";
+import { loadConfig, loadConfigFromFile, resolveDaemonConfig } from "../config";
 
 describe("daemon config", () => {
   it("loads defaults when env missing", () => {
@@ -293,6 +293,292 @@ describe("daemon config", () => {
     it("falls back to default for invalid OPENCODE_RSS_CHECK_INTERVAL", () => {
       const config = loadConfig({ OPENCODE_RSS_CHECK_INTERVAL: "abc" });
       expect(config.rssCheckIntervalMs).toBe(60_000);
+    });
+  });
+
+  describe("loadConfigFromFile", () => {
+    it("maps YAML fields to flattened config fields", () => {
+      const result = loadConfigFromFile(
+        [
+          "project: team-123",
+          "workspace: ./workspace",
+          "port: 14000",
+          "backend: github",
+          "runtime: claude-code",
+          "controller:",
+          "  session_id: ses_controller",
+          "  prompt: keep going",
+          "memory:",
+          "  max_rss_gb: 10",
+          "  rss_check_interval_seconds: 120",
+          "envoy_url: http://127.0.0.1:9999",
+          "feedback:",
+          "  disabled: true",
+          "  max_bytes: 2048",
+        ].join("\n"),
+        "/tmp/x"
+      );
+
+      expect(result.fields).toMatchObject({
+        legionId: "team-123",
+        legionDir: "/tmp/x/workspace",
+        daemonPort: 14000,
+        controllerSessionId: "ses_controller",
+        controllerPrompt: "keep going",
+        maxRssBytes: 10 * 1024 * 1024 * 1024,
+        rssCheckIntervalMs: 120_000,
+        envoyUrl: "http://127.0.0.1:9999",
+        feedbackDisabled: true,
+        feedbackMaxBytes: 2048,
+        issueBackend: "github",
+        runtime: "claude-code",
+      });
+      expect(result.warnings).toEqual([]);
+    });
+
+    it("maps GitHub App fields for each role", () => {
+      const result = loadConfigFromFile(
+        [
+          "github_apps:",
+          "  impl:",
+          "    app_id: impl-app",
+          "    private_key_path: ./impl.pem",
+          "    installation_id: impl-install",
+          "  review:",
+          "    app_id: review-app",
+          "    private_key_path: /keys/review.pem",
+          "    installation_id: review-install",
+        ].join("\n"),
+        "/tmp/legion"
+      );
+
+      expect(result.fields).toMatchObject({
+        githubApps: {
+          impl: {
+            appId: "impl-app",
+            privateKeyPath: "/tmp/legion/impl.pem",
+            installationId: "impl-install",
+          },
+          review: {
+            appId: "review-app",
+            privateKeyPath: "/keys/review.pem",
+            installationId: "review-install",
+          },
+        },
+      });
+    });
+
+    it("normalizes relative paths against configDir and leaves absolute paths unchanged", () => {
+      const relativeWorkspace = loadConfigFromFile("workspace: ./workspace\n", "/tmp/x");
+      const absoluteWorkspace = loadConfigFromFile("workspace: /srv/legion\n", "/tmp/x");
+
+      expect(relativeWorkspace.fields.legionDir).toBe("/tmp/x/workspace");
+      expect(absoluteWorkspace.fields.legionDir).toBe("/srv/legion");
+    });
+
+    it("maps extra_projects arrays", () => {
+      const result = loadConfigFromFile(
+        ["backend: github", "extra_projects:", "  - acme/12", "  - globex/34"].join("\n"),
+        "/tmp/x"
+      );
+
+      expect(result.fields.extraProjects).toEqual(["acme/12", "globex/34"]);
+    });
+
+    it("throws with parse context for invalid YAML syntax", () => {
+      expect(() => loadConfigFromFile("controller: [unterminated\n", "/tmp/x")).toThrow(
+        /YAML|Parse/
+      );
+    });
+
+    it("throws for invalid backend values", () => {
+      expect(() => loadConfigFromFile("backend: jira\n", "/tmp/x")).toThrow(/backend/i);
+    });
+
+    it("throws for invalid runtime values", () => {
+      expect(() => loadConfigFromFile("runtime: invalid\n", "/tmp/x")).toThrow(/runtime/i);
+    });
+
+    it("throws for invalid controller.session_id values", () => {
+      expect(() => loadConfigFromFile("controller:\n  session_id: bad_value\n", "/tmp/x")).toThrow(
+        /session_id.*ses_/
+      );
+    });
+
+    it("throws for prompts longer than 10000 chars", () => {
+      const prompt = "a".repeat(10001);
+      expect(() => loadConfigFromFile(`controller:\n  prompt: ${prompt}\n`, "/tmp/x")).toThrow(
+        /10000/
+      );
+    });
+
+    it("throws for prompts with control characters", () => {
+      expect(() =>
+        loadConfigFromFile('controller:\n  prompt: "bad\u0007prompt"\n', "/tmp/x")
+      ).toThrow(/control characters/i);
+    });
+
+    it("throws when a GitHub App role is partial and lists missing fields", () => {
+      expect(() =>
+        loadConfigFromFile(["github_apps:", "  impl:", "    app_id: impl-app"].join("\n"), "/tmp/x")
+      ).toThrow(/github_apps\.impl.*private_key_path.*installation_id/i);
+    });
+
+    it("throws when extra_projects is set for linear backend", () => {
+      expect(() =>
+        loadConfigFromFile(
+          ["backend: linear", "extra_projects:", "  - acme/12"].join("\n"),
+          "/tmp/x"
+        )
+      ).toThrow(/extra_projects.*github/i);
+    });
+
+    it("throws when extra_projects entries do not match owner/number", () => {
+      expect(() =>
+        loadConfigFromFile(
+          ["backend: github", "extra_projects:", "  - bad-entry"].join("\n"),
+          "/tmp/x"
+        )
+      ).toThrow(/owner\/number/i);
+    });
+
+    it("warns on root unknown keys", () => {
+      const result = loadConfigFromFile("project: team-123\nextra_key: value\n", "/tmp/x");
+
+      expect(result.warnings).toContainEqual(expect.stringMatching(/extra_key/));
+    });
+
+    it("warns on nested unknown keys with full dotted paths", () => {
+      const result = loadConfigFromFile(
+        [
+          "github_apps:",
+          "  impl:",
+          "    app_id: impl-app",
+          "    private_key_path: ./impl.pem",
+          "    installation_id: impl-install",
+          "    extra_field: value",
+        ].join("\n"),
+        "/tmp/x"
+      );
+
+      expect(result.warnings).toContainEqual(
+        expect.stringMatching(/github_apps\.impl\.extra_field/)
+      );
+    });
+
+    it("keeps known sibling values when warnings are emitted", () => {
+      const result = loadConfigFromFile(
+        ["project: team-123", "feedback:", "  disabled: true", "  extra_field: value"].join("\n"),
+        "/tmp/x"
+      );
+
+      expect(result.fields).toMatchObject({
+        legionId: "team-123",
+        feedbackDisabled: true,
+      });
+      expect(result.warnings).toContainEqual(expect.stringMatching(/feedback\.extra_field/));
+    });
+  });
+
+  describe("resolveDaemonConfig", () => {
+    it("prefers config file values over env vars for the same field", () => {
+      const result = resolveDaemonConfig({
+        env: { LEGION_RUNTIME: "opencode" },
+        configFile: { fields: { runtime: "claude-code" }, warnings: [] },
+      });
+
+      expect(result.config.runtime).toBe("claude-code");
+    });
+
+    it("prefers CLI overrides over config file values", () => {
+      const result = resolveDaemonConfig({
+        configFile: { fields: { daemonPort: 14000 }, warnings: [] },
+        cliOverrides: { daemonPort: 15000 },
+      });
+
+      expect(result.config.daemonPort).toBe(15000);
+    });
+
+    it("fills defaults for absent fields", () => {
+      const result = resolveDaemonConfig({});
+
+      expect(result.config).toMatchObject({
+        daemonPort: 13370,
+        issueBackend: "linear",
+        runtime: "opencode",
+        envoyUrl: "http://127.0.0.1:9020",
+        feedbackDisabled: false,
+        feedbackMaxBytes: 50 * 1024 * 1024,
+        maxRssBytes: 20 * 1024 * 1024 * 1024,
+        rssCheckIntervalMs: 60_000,
+      });
+    });
+
+    it("sets daemonPortExplicit true for CLI or config values and false for defaults", () => {
+      expect(
+        resolveDaemonConfig({ cliOverrides: { daemonPort: 15000 } }).config.daemonPortExplicit
+      ).toBe(true);
+      expect(
+        resolveDaemonConfig({ configFile: { fields: { daemonPort: 14000 }, warnings: [] } }).config
+          .daemonPortExplicit
+      ).toBe(true);
+      expect(resolveDaemonConfig({}).config.daemonPortExplicit).toBe(false);
+      expect(
+        resolveDaemonConfig({ env: { LEGION_DAEMON_PORT: "16000" } }).config.daemonPortExplicit
+      ).toBe(false);
+    });
+
+    it.each([
+      ["ENVOY_URL", "envoyUrl", "http://127.0.0.1:9999"],
+      ["LEGION_FEEDBACK_DISABLED", "feedbackDisabled", "true"],
+      ["LEGION_FEEDBACK_MAX_BYTES", "feedbackMaxBytes", "1234"],
+      ["LEGION_ISSUE_BACKEND", "issueBackend", "github"],
+      ["LEGION_RUNTIME", "runtime", "claude-code"],
+      ["LEGION_DAEMON_PORT", "daemonPort", "14444"],
+    ])("emits deprecation warning when %s is the effective value", (envVar, fieldName, value) => {
+      const result = resolveDaemonConfig({
+        env: { [envVar]: value },
+      });
+
+      expect(result.warnings).toContainEqual(expect.stringMatching(new RegExp(envVar)));
+      expect(result.warnings).toContainEqual(expect.stringMatching(/deprecated/i));
+      expect(result.config).toHaveProperty(fieldName);
+    });
+
+    it.each([
+      ["ENVOY_URL", "envoyUrl", "http://127.0.0.1:9999", "http://127.0.0.1:7777"],
+      ["LEGION_FEEDBACK_DISABLED", "feedbackDisabled", "true", false],
+      ["LEGION_FEEDBACK_MAX_BYTES", "feedbackMaxBytes", "1234", 4321],
+      ["LEGION_ISSUE_BACKEND", "issueBackend", "github", "linear"],
+      ["LEGION_RUNTIME", "runtime", "claude-code", "opencode"],
+      ["LEGION_DAEMON_PORT", "daemonPort", "14444", 15555],
+    ])("does not emit deprecation warning when config file overrides %s", (envVar, fieldName, envValue, configValue) => {
+      const result = resolveDaemonConfig({
+        env: { [envVar]: envValue },
+        configFile: { fields: { [fieldName]: configValue }, warnings: [] },
+      });
+
+      expect(result.warnings.some((warning) => warning.includes(envVar))).toBe(false);
+      expect(result.config).toHaveProperty(fieldName, configValue);
+    });
+  });
+
+  describe("env compatibility for new fields", () => {
+    it("reads ENVOY_URL and defaults when unset", () => {
+      expect(loadConfig({ ENVOY_URL: "http://127.0.0.1:9999" }).envoyUrl).toBe(
+        "http://127.0.0.1:9999"
+      );
+      expect(loadConfig({}).envoyUrl).toBe("http://127.0.0.1:9020");
+    });
+
+    it("reads LEGION_FEEDBACK_DISABLED and defaults when unset", () => {
+      expect(loadConfig({ LEGION_FEEDBACK_DISABLED: "true" }).feedbackDisabled).toBe(true);
+      expect(loadConfig({}).feedbackDisabled).toBe(false);
+    });
+
+    it("reads LEGION_FEEDBACK_MAX_BYTES and defaults when unset", () => {
+      expect(loadConfig({ LEGION_FEEDBACK_MAX_BYTES: "1234" }).feedbackMaxBytes).toBe(1234);
+      expect(loadConfig({}).feedbackMaxBytes).toBe(50 * 1024 * 1024);
     });
   });
 });

--- a/packages/daemon/src/daemon/__tests__/feedback.integration.test.ts
+++ b/packages/daemon/src/daemon/__tests__/feedback.integration.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { resolveDaemonConfig, type DaemonConfig } from "../config";
+import { type DaemonConfig, resolveDaemonConfig } from "../config";
 import { type FeedbackEvent, FeedbackEventSchema } from "../feedback";
 import { type DaemonHandle, startDaemon } from "../index";
 import { resolveLegionPaths } from "../paths";

--- a/packages/daemon/src/daemon/__tests__/feedback.integration.test.ts
+++ b/packages/daemon/src/daemon/__tests__/feedback.integration.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import { resolveDaemonConfig, type DaemonConfig } from "../config";
 import { type FeedbackEvent, FeedbackEventSchema } from "../feedback";
 import { type DaemonHandle, startDaemon } from "../index";
 import { resolveLegionPaths } from "../paths";
@@ -31,14 +32,28 @@ function readJsonl(contents: string): FeedbackEvent[] {
     .map((line) => JSON.parse(line) as FeedbackEvent);
 }
 
+function buildConfig(
+  paths: ReturnType<typeof resolveLegionPaths>,
+  stateFilePath: string,
+  overrides: Partial<DaemonConfig> = {}
+): DaemonConfig {
+  const { config } = resolveDaemonConfig({ env: { LEGION_ID: "acme/widgets" } });
+  return {
+    ...config,
+    paths,
+    legionId: "acme/widgets",
+    stateFilePath,
+    daemonPort: 0,
+    controllerSessionId: "ses_test",
+    ...overrides,
+  };
+}
+
 describe("feedback logging integration", () => {
   let tempHome: string | null = null;
   let handle: DaemonHandle | null = null;
 
   afterEach(async () => {
-    process.env.LEGION_FEEDBACK_DISABLED = undefined;
-    process.env.LEGION_FEEDBACK_MAX_BYTES = undefined;
-
     if (handle) {
       await handle.stop();
       handle = null;
@@ -57,18 +72,9 @@ describe("feedback logging integration", () => {
     mkdirSync(paths.stateDir, { recursive: true });
 
     const stateFilePath = path.join(tempHome, "workers.json");
-    handle = await startDaemon(
-      {
-        legionId: "acme/widgets",
-        paths,
-        stateFilePath,
-        daemonPort: 0,
-        controllerSessionId: "ses_test",
-      },
-      {
-        adapter: makeAdapter(),
-      }
-    );
+    handle = await startDaemon(buildConfig(paths, stateFilePath), {
+      deps: { adapter: makeAdapter() },
+    });
 
     const baseUrl = `http://127.0.0.1:${handle.server.port}`;
     const workspace = path.join(tempHome, "workspace-one");
@@ -153,22 +159,12 @@ describe("feedback logging integration", () => {
   it("does not create feedback.jsonl when feedback logging is disabled", async () => {
     tempHome = await mkdtemp(path.join(os.tmpdir(), "feedback-integration-"));
     const paths = resolveLegionPaths({}, tempHome);
-    process.env.LEGION_FEEDBACK_DISABLED = "1";
     mkdirSync(paths.stateDir, { recursive: true });
 
     const stateFilePath = path.join(tempHome, "workers.json");
-    handle = await startDaemon(
-      {
-        legionId: "acme/widgets",
-        paths,
-        stateFilePath,
-        daemonPort: 0,
-        controllerSessionId: "ses_test",
-      },
-      {
-        adapter: makeAdapter(),
-      }
-    );
+    handle = await startDaemon(buildConfig(paths, stateFilePath, { feedbackDisabled: true }), {
+      deps: { adapter: makeAdapter() },
+    });
 
     const baseUrl = `http://127.0.0.1:${handle.server.port}`;
     const response = await fetch(`${baseUrl}/state/collect`, {
@@ -189,25 +185,15 @@ describe("feedback logging integration", () => {
     expect(feedbackStat).toBeNull();
   });
 
-  it("rotates feedback.jsonl when LEGION_FEEDBACK_MAX_BYTES is very small", async () => {
+  it("rotates feedback.jsonl when feedbackMaxBytes is very small", async () => {
     tempHome = await mkdtemp(path.join(os.tmpdir(), "feedback-integration-"));
     const paths = resolveLegionPaths({}, tempHome);
-    process.env.LEGION_FEEDBACK_MAX_BYTES = "100";
     mkdirSync(paths.stateDir, { recursive: true });
 
     const stateFilePath = path.join(tempHome, "workers.json");
-    handle = await startDaemon(
-      {
-        legionId: "acme/widgets",
-        paths,
-        stateFilePath,
-        daemonPort: 0,
-        controllerSessionId: "ses_test",
-      },
-      {
-        adapter: makeAdapter(),
-      }
-    );
+    handle = await startDaemon(buildConfig(paths, stateFilePath, { feedbackMaxBytes: 100 }), {
+      deps: { adapter: makeAdapter() },
+    });
 
     const baseUrl = `http://127.0.0.1:${handle.server.port}`;
 

--- a/packages/daemon/src/daemon/__tests__/index.test.ts
+++ b/packages/daemon/src/daemon/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, describe, expect, it, mock } from "bun:test";
 import { createServer } from "node:net";
+import { resolveDaemonConfig, type DaemonConfig } from "../config";
 import { resolveLegionPaths } from "../paths";
 import type { RuntimeAdapter } from "../runtime/types";
 import type { WorkerEntry } from "../serve-manager";
@@ -83,6 +84,9 @@ const silentSetTimeout: typeof setTimeout = Object.assign(
 );
 const noopClearTimeout = (() => {}) as typeof clearTimeout;
 
+type DaemonStartOpts = NonNullable<Parameters<typeof startDaemon>[1]>;
+type DaemonDepsOverride = NonNullable<DaemonStartOpts["deps"]>;
+
 function filterControllerPrompts(
   prompts: Array<{ sessionID: string; parts: unknown[] }>
 ): Array<{ sessionID: string; parts: unknown[] }> {
@@ -152,35 +156,51 @@ async function getFreePort(): Promise<number> {
 }
 
 function startDaemonForTest(
-  overrides: Parameters<typeof startDaemon>[0],
-  deps?: Parameters<typeof startDaemon>[1]
+  overrides: Partial<DaemonConfig>,
+  deps?: Partial<DaemonDepsOverride>,
+  startOpts?: Omit<DaemonStartOpts, "deps">
 ): Promise<Awaited<ReturnType<typeof startDaemon>>> {
-  return startDaemon(
-    {
-      paths: TEST_PATHS,
-      readLegionsRegistry: async () => mockedRegistry,
-      cleanupStaleServes: async () => {},
-      allocatePort: () => mockedAllocatedPorts,
-      writeLegionEntry: async (
-        filePath: string,
-        projectId: string,
-        entry: {
-          port: number;
-          servePort: number;
-          pid: number;
-          servePid?: number;
-          startedAt: string;
-        }
-      ) => {
-        writeLegionEntryCalls.push({ filePath, projectId, entry });
-      },
-      removeLegionEntry: async (filePath: string, projectId: string) => {
-        removeLegionEntryCalls.push({ filePath, projectId });
-      },
-      ...overrides,
+  const legionId = overrides.legionId ?? TEAM_ID;
+  const instancePaths = TEST_PATHS.forLegion(legionId);
+  const { config: baseConfig } = resolveDaemonConfig({
+    env: {
+      LEGION_ID: legionId,
+      XDG_DATA_HOME: "/tmp/legion-test-data",
+      XDG_STATE_HOME: "/tmp/legion-test-state",
     },
-    deps
-  );
+  });
+  const config: DaemonConfig = {
+    ...baseConfig,
+    paths: TEST_PATHS,
+    legionId,
+    logDir: instancePaths.logDir,
+    stateFilePath: overrides.stateFilePath ?? instancePaths.workersFile,
+    ...overrides,
+  };
+
+  return startDaemon(config, {
+    readLegionsRegistry: async () => mockedRegistry,
+    cleanupStaleServes: async () => {},
+    allocatePort: () => mockedAllocatedPorts,
+    writeLegionEntry: async (
+      filePath: string,
+      projectId: string,
+      entry: {
+        port: number;
+        servePort: number;
+        pid: number;
+        servePid?: number;
+        startedAt: string;
+      }
+    ) => {
+      writeLegionEntryCalls.push({ filePath, projectId, entry });
+    },
+    removeLegionEntry: async (filePath: string, projectId: string) => {
+      removeLegionEntryCalls.push({ filePath, projectId });
+    },
+    ...startOpts,
+    deps,
+  });
 }
 
 describe("daemon entry", () => {
@@ -200,11 +220,93 @@ describe("daemon entry", () => {
     mockedRegistry = {};
     mockedAllocatedPorts = { daemonPort: 13370, servePort: 13381 };
     startServerCalls.length = 0;
-    process.env.LEGION_FEEDBACK_DISABLED = undefined;
-    process.env.LEGION_FEEDBACK_MAX_BYTES = undefined;
   });
 
   describe("port allocation", () => {
+    it("uses the exact explicit daemon port when it is free", async () => {
+      const explicitPort = await getFreePort();
+      const startServerCalls: ServerOptions[] = [];
+
+      await startDaemonForTest(
+        {
+          stateFilePath: "/tmp/daemon-workers.json",
+          legionId: TEAM_ID,
+          controllerSessionId: "ses_test",
+          daemonPort: explicitPort,
+          daemonPortExplicit: true,
+        },
+        {
+          readStateFile: async () => ({ workers: {}, crashHistory: {} }),
+          writeStateFile: async () => {},
+          adapter: makeAdapter(),
+          startServer: (opts) => {
+            startServerCalls.push(opts);
+            return {
+              server: { port: opts.port } as ReturnType<typeof Bun.serve>,
+              stop: () => {},
+              fetchAndProcessState: async () => {},
+            };
+          },
+          setTimeout: silentSetTimeout,
+          clearTimeout: noopClearTimeout,
+          fetch: originalFetch,
+        }
+      );
+
+      expect(startServerCalls).toHaveLength(1);
+      expect(startServerCalls[0].port).toBe(explicitPort);
+      expect(writeLegionEntryCalls[0].entry.port).toBe(explicitPort);
+    });
+
+    it("throws when the explicit daemon port is occupied", async () => {
+      const occupiedPort = await getFreePort();
+      const blocker = createServer();
+      await new Promise<void>((resolve, reject) => {
+        blocker.once("error", reject);
+        blocker.listen(occupiedPort, "127.0.0.1", () => resolve());
+      });
+
+      try {
+        try {
+          await startDaemonForTest(
+            {
+              stateFilePath: "/tmp/daemon-workers.json",
+              legionId: TEAM_ID,
+              controllerSessionId: "ses_test",
+              daemonPort: occupiedPort,
+              daemonPortExplicit: true,
+            },
+            {
+              readStateFile: async () => ({ workers: {}, crashHistory: {} }),
+              writeStateFile: async () => {},
+              adapter: makeAdapter(),
+              startServer: (opts) => ({
+                server: { port: opts.port } as ReturnType<typeof Bun.serve>,
+                stop: () => {},
+                fetchAndProcessState: async () => {},
+              }),
+              setTimeout: silentSetTimeout,
+              clearTimeout: noopClearTimeout,
+              fetch: originalFetch,
+            }
+          );
+          throw new Error("Expected startDaemonForTest to reject");
+        } catch (error) {
+          expect(error).toBeInstanceOf(Error);
+        }
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          blocker.close((error) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            resolve();
+          });
+        });
+      }
+    });
+
     it("starts on base port 13370 when registry is empty", async () => {
       const basePort = await getFreePort();
       mockedRegistry = {};
@@ -239,6 +341,43 @@ describe("daemon entry", () => {
       expect(startServerCalls).toHaveLength(1);
       expect(startServerCalls[0].port).toBe(basePort);
       expect(writeLegionEntryCalls[0].entry.port).toBe(basePort);
+    });
+
+    it("keeps allocation behavior when daemon port is not explicit", async () => {
+      const allocatedPort = await getFreePort();
+      mockedAllocatedPorts = { daemonPort: allocatedPort, servePort: allocatedPort + 100 };
+
+      const startServerCalls: ServerOptions[] = [];
+
+      await startDaemonForTest(
+        {
+          stateFilePath: "/tmp/daemon-workers.json",
+          legionId: TEAM_ID,
+          controllerSessionId: "ses_test",
+          daemonPort: allocatedPort - 10,
+          daemonPortExplicit: false,
+        },
+        {
+          readStateFile: async () => ({ workers: {}, crashHistory: {} }),
+          writeStateFile: async () => {},
+          adapter: makeAdapter(),
+          startServer: (opts) => {
+            startServerCalls.push(opts);
+            return {
+              server: { port: opts.port } as ReturnType<typeof Bun.serve>,
+              stop: () => {},
+              fetchAndProcessState: async () => {},
+            };
+          },
+          setTimeout: silentSetTimeout,
+          clearTimeout: noopClearTimeout,
+          fetch: originalFetch,
+        }
+      );
+
+      expect(startServerCalls).toHaveLength(1);
+      expect(startServerCalls[0].port).toBe(allocatedPort);
+      expect(writeLegionEntryCalls[0].entry.port).toBe(allocatedPort);
     });
 
     it("starts on 13371 when registry already uses 13370", async () => {
@@ -337,9 +476,6 @@ describe("daemon entry", () => {
           stateFilePath: "/tmp/daemon-workers.json",
           legionId: TEAM_ID,
           controllerSessionId: "ses_test",
-          cleanupStaleServes: async (filePath: string, legionId: string) => {
-            cleanupCalls.push({ filePath, legionId });
-          },
         },
         {
           readStateFile: async () => ({ workers: {}, crashHistory: {} }),
@@ -353,6 +489,11 @@ describe("daemon entry", () => {
           setTimeout: silentSetTimeout,
           clearTimeout: noopClearTimeout,
           fetch: originalFetch,
+        },
+        {
+          cleanupStaleServes: async (filePath: string, legionId: string) => {
+            cleanupCalls.push({ filePath, legionId });
+          },
         }
       );
 
@@ -1451,14 +1592,13 @@ describe("daemon entry", () => {
       await handle.stop();
     });
 
-    it("skips feedback logger creation when LEGION_FEEDBACK_DISABLED=1", async () => {
-      process.env.LEGION_FEEDBACK_DISABLED = "1";
-
+    it("skips feedback logger creation when feedback is disabled in config", async () => {
       const handle = await startDaemonForTest(
         {
           stateFilePath: "/tmp/daemon-workers.json",
           legionId: TEAM_ID,
           controllerSessionId: "ses_test",
+          feedbackDisabled: true,
         },
         {
           readStateFile: async () => ({ workers: {}, crashHistory: {} }),

--- a/packages/daemon/src/daemon/__tests__/index.test.ts
+++ b/packages/daemon/src/daemon/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, describe, expect, it, mock } from "bun:test";
 import { createServer } from "node:net";
-import { resolveDaemonConfig, type DaemonConfig } from "../config";
+import { type DaemonConfig, resolveDaemonConfig } from "../config";
 import { resolveLegionPaths } from "../paths";
 import type { RuntimeAdapter } from "../runtime/types";
 import type { WorkerEntry } from "../serve-manager";

--- a/packages/daemon/src/daemon/config.ts
+++ b/packages/daemon/src/daemon/config.ts
@@ -205,7 +205,7 @@ export function validateControllerPrompt(prompt: string | undefined): void {
   }
 }
 
-function validateBackend(
+export function validateBackend(
   value: string | undefined,
   sourceName: string
 ): "linear" | "github" | undefined {
@@ -218,7 +218,7 @@ function validateBackend(
   return value;
 }
 
-function validateRuntime(
+export function validateRuntime(
   value: string | undefined,
   sourceName: string
 ): "opencode" | "claude-code" | undefined {
@@ -703,11 +703,7 @@ export function resolveDaemonConfig(
     DEFAULT_FEEDBACK_MAX_BYTES
   );
 
-  if (
-    extraProjects.value !== undefined &&
-    extraProjects.source !== "env" &&
-    issueBackend.value !== "github"
-  ) {
+  if (extraProjects.value !== undefined && issueBackend.value !== "github") {
     throw new Error("extra_projects requires backend: github");
   }
 

--- a/packages/daemon/src/daemon/config.ts
+++ b/packages/daemon/src/daemon/config.ts
@@ -1,5 +1,6 @@
 import os from "node:os";
 import path from "node:path";
+import { parse } from "yaml";
 import type { LegionPaths } from "./paths";
 import { resolveLegionPaths } from "./paths";
 
@@ -15,6 +16,7 @@ export type GitHubAppsConfig = Partial<Record<GitHubAppRole, GitHubAppRoleConfig
 
 export interface DaemonConfig {
   daemonPort: number;
+  daemonPortExplicit: boolean;
   legionId?: string;
   legionDir?: string;
   paths: LegionPaths;
@@ -28,28 +30,155 @@ export interface DaemonConfig {
   extraProjects?: string[];
   runtime: "opencode" | "claude-code";
   githubApps?: GitHubAppsConfig;
+  envoyUrl: string;
+  feedbackDisabled: boolean;
+  feedbackMaxBytes: number;
   /** RSS threshold in bytes; serve restarts when exceeded. 0 = disabled. */
   maxRssBytes: number;
   /** Minimum interval between RSS checks in ms. */
   rssCheckIntervalMs: number;
 }
 
+export interface LoadedConfigFile {
+  fields: Record<string, unknown>;
+  warnings: string[];
+}
+
+export interface ResolveDaemonConfigOptions {
+  env?: Record<string, string | undefined>;
+  configFile?: LoadedConfigFile;
+  cliOverrides?: Partial<DaemonConfig>;
+}
+
+export interface ResolveDaemonConfigResult {
+  config: DaemonConfig;
+  warnings: string[];
+}
+
+interface ConfigSchema {
+  [key: string]: ConfigSchema | null;
+}
+type ValueSource = "cli" | "config" | "env" | "default";
+
 const BASE_DAEMON_PORT = 13370;
 const DEFAULT_CHECK_INTERVAL_MS = 60_000;
 const DEFAULT_BASE_WORKER_PORT = 13381;
 const DEFAULT_MAX_RSS_GB = 20;
 const DEFAULT_RSS_CHECK_INTERVAL_S = 60;
+const DEFAULT_ENVOY_URL = "http://127.0.0.1:9020";
+const DEFAULT_FEEDBACK_MAX_BYTES = 50 * 1024 * 1024;
 const EXTRA_PROJECT_PATTERN = /^[^/]+\/\d+$/;
+const GITHUB_APP_ROLES: GitHubAppRole[] = ["impl", "review"];
+const GITHUB_APP_FIELD_NAMES = ["app_id", "private_key_path", "installation_id"] as const;
+const CONFIG_SCHEMA: ConfigSchema = {
+  project: null,
+  extra_projects: null,
+  backend: null,
+  runtime: null,
+  workspace: null,
+  port: null,
+  controller: {
+    session_id: null,
+    prompt: null,
+  },
+  github_apps: {
+    impl: {
+      app_id: null,
+      private_key_path: null,
+      installation_id: null,
+    },
+    review: {
+      app_id: null,
+      private_key_path: null,
+      installation_id: null,
+    },
+  },
+  memory: {
+    max_rss_gb: null,
+    rss_check_interval_seconds: null,
+  },
+  envoy_url: null,
+  feedback: {
+    disabled: null,
+    max_bytes: null,
+  },
+};
 
-function parseNumber(value: string | undefined, fallback: number): number {
-  if (!value) {
-    return fallback;
+function parseOptionalNumber(value: string | undefined): number | undefined {
+  if (value === undefined || value === "") {
+    return undefined;
   }
   const parsed = Number(value);
-  if (!Number.isFinite(parsed)) {
-    return fallback;
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseOptionalBoolean(value: string | undefined): boolean | undefined {
+  if (value === undefined || value === "") {
+    return undefined;
   }
-  return parsed;
+  if (value === "true" || value === "1") {
+    return true;
+  }
+  if (value === "false" || value === "0") {
+    return false;
+  }
+  return undefined;
+}
+
+function resolveValue<T>(
+  cliValue: T | undefined,
+  configValue: T | undefined,
+  envValue: T | undefined,
+  defaultValue: T
+): { value: T; source: ValueSource } {
+  if (cliValue !== undefined) {
+    return { value: cliValue, source: "cli" };
+  }
+  if (configValue !== undefined) {
+    return { value: configValue, source: "config" };
+  }
+  if (envValue !== undefined) {
+    return { value: envValue, source: "env" };
+  }
+  return { value: defaultValue, source: "default" };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown, fieldPath: string): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new Error(`${fieldPath} must be a string`);
+  }
+  return value;
+}
+
+function readNumber(value: unknown, fieldPath: string): number | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${fieldPath} must be a number`);
+  }
+  return value;
+}
+
+function readBoolean(value: unknown, fieldPath: string): boolean | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== "boolean") {
+    throw new Error(`${fieldPath} must be a boolean`);
+  }
+  return value;
+}
+
+function normalizeConfigPath(value: string, configDir: string): string {
+  return path.isAbsolute(value) ? value : path.resolve(configDir, value);
 }
 
 export function validateControllerPrompt(prompt: string | undefined): void {
@@ -74,6 +203,45 @@ export function validateControllerPrompt(prompt: string | undefined): void {
   if (hasControlChars) {
     throw new Error("Controller prompt contains invalid control characters");
   }
+}
+
+function validateBackend(
+  value: string | undefined,
+  sourceName: string
+): "linear" | "github" | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value !== "linear" && value !== "github") {
+    throw new Error(`${sourceName} must be 'linear' or 'github' (got: ${value})`);
+  }
+  return value;
+}
+
+function validateRuntime(
+  value: string | undefined,
+  sourceName: string
+): "opencode" | "claude-code" | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value !== "opencode" && value !== "claude-code") {
+    throw new Error(`${sourceName} must be 'opencode' or 'claude-code' (got: ${value})`);
+  }
+  return value;
+}
+
+function validateControllerSessionId(
+  value: string | undefined,
+  sourceName: string
+): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  if (!value.startsWith("ses_")) {
+    throw new Error(`${sourceName} must start with 'ses_' (got: ${value})`);
+  }
+  return value;
 }
 
 function parseExtraProjects(value: string | undefined): string[] | undefined {
@@ -101,72 +269,47 @@ function parseExtraProjects(value: string | undefined): string[] | undefined {
   return extraProjects.length > 0 ? extraProjects : undefined;
 }
 
-export function loadConfig(env: NodeJS.ProcessEnv = process.env): DaemonConfig {
-  const legionDir = env.LEGION_DIR;
-  const legionId = env.LEGION_ID;
-  const paths = resolveLegionPaths(env, os.homedir());
-  const stateFilePath = legionId
-    ? paths.forLegion(legionId).workersFile
-    : path.join(paths.stateDir, "daemon", "workers.json");
-  const logDir = legionId
-    ? paths.forLegion(legionId).logDir
-    : path.join(paths.stateDir, "daemon", "logs");
-  const controllerSessionId = env.LEGION_CONTROLLER_SESSION_ID || undefined;
-  const controllerPrompt = env.LEGION_CONTROLLER_PROMPT || undefined;
-
-  if (controllerSessionId && !controllerSessionId.startsWith("ses_")) {
-    throw new Error(
-      `LEGION_CONTROLLER_SESSION_ID must start with 'ses_' (got: ${controllerSessionId})`
-    );
+function parseExtraProjectsArray(value: unknown): string[] | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (!Array.isArray(value)) {
+    throw new Error("extra_projects must be an array");
   }
 
-  validateControllerPrompt(controllerPrompt);
-
-  const rawBackend = env.LEGION_ISSUE_BACKEND;
-  if (rawBackend !== undefined && rawBackend !== "linear" && rawBackend !== "github") {
-    throw new Error(`LEGION_ISSUE_BACKEND must be 'linear' or 'github' (got: ${rawBackend})`);
+  const extraProjects: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== "string") {
+      throw new Error("extra_projects entries must be strings matching owner/number");
+    }
+    if (!EXTRA_PROJECT_PATTERN.test(entry)) {
+      throw new Error(`extra_projects entries must match owner/number (got: ${entry})`);
+    }
+    if (!seen.has(entry)) {
+      seen.add(entry);
+      extraProjects.push(entry);
+    }
   }
-  const issueBackend = rawBackend === "github" ? "github" : "linear";
 
-  const rawRuntime = env.LEGION_RUNTIME;
-  if (rawRuntime !== undefined && rawRuntime !== "opencode" && rawRuntime !== "claude-code") {
-    throw new Error(`LEGION_RUNTIME must be 'opencode' or 'claude-code' (got: ${rawRuntime})`);
-  }
-  const runtime = rawRuntime === "claude-code" ? "claude-code" : "opencode";
-  const githubApps = loadGitHubApps(env);
-  const extraProjects = parseExtraProjects(env.LEGION_EXTRA_PROJECTS);
-  const maxRssGb = parseNumber(env.OPENCODE_MAX_RSS_GB, DEFAULT_MAX_RSS_GB);
-  const maxRssBytes = maxRssGb > 0 ? maxRssGb * 1024 * 1024 * 1024 : 0;
-  const rssCheckIntervalS = parseNumber(
-    env.OPENCODE_RSS_CHECK_INTERVAL,
-    DEFAULT_RSS_CHECK_INTERVAL_S
-  );
-  const rssCheckIntervalMs =
-    rssCheckIntervalS > 0 ? rssCheckIntervalS * 1000 : DEFAULT_RSS_CHECK_INTERVAL_S * 1000;
-
-  return {
-    daemonPort: parseNumber(env.LEGION_DAEMON_PORT, BASE_DAEMON_PORT),
-    legionId,
-    legionDir,
-    paths,
-    checkIntervalMs: DEFAULT_CHECK_INTERVAL_MS,
-    baseWorkerPort: DEFAULT_BASE_WORKER_PORT,
-    maxRssBytes,
-    rssCheckIntervalMs,
-    stateFilePath,
-    logDir,
-    controllerSessionId,
-    controllerPrompt,
-    issueBackend,
-    extraProjects,
-    runtime,
-    githubApps,
-  };
+  return extraProjects.length > 0 ? extraProjects : undefined;
 }
 
-const GITHUB_APP_ROLES: GitHubAppRole[] = ["impl", "review"];
+function parseMaxRssBytesFromGb(maxRssGb: number | undefined): number | undefined {
+  if (maxRssGb === undefined) {
+    return undefined;
+  }
+  return maxRssGb > 0 ? maxRssGb * 1024 * 1024 * 1024 : 0;
+}
 
-function loadGitHubApps(env: NodeJS.ProcessEnv): GitHubAppsConfig | undefined {
+function parseRssCheckIntervalMsFromSeconds(seconds: number | undefined): number | undefined {
+  if (seconds === undefined || seconds <= 0) {
+    return undefined;
+  }
+  return seconds * 1000;
+}
+
+function loadGitHubApps(env: Record<string, string | undefined>): GitHubAppsConfig | undefined {
   const config: GitHubAppsConfig = {};
   let hasAny = false;
 
@@ -183,4 +326,509 @@ function loadGitHubApps(env: NodeJS.ProcessEnv): GitHubAppsConfig | undefined {
   }
 
   return hasAny ? config : undefined;
+}
+
+function collectUnknownKeys(
+  value: unknown,
+  schema: ConfigSchema | null,
+  pathParts: string[],
+  warnings: string[]
+): void {
+  if (!schema || !isRecord(value)) {
+    return;
+  }
+
+  for (const [key, childValue] of Object.entries(value)) {
+    const childSchema = schema[key];
+    if (childSchema === undefined) {
+      warnings.push(`Unknown config key: ${[...pathParts, key].join(".")}`);
+      continue;
+    }
+    collectUnknownKeys(childValue, childSchema, [...pathParts, key], warnings);
+  }
+}
+
+function loadGitHubAppsFromFile(value: unknown, configDir: string): GitHubAppsConfig | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    throw new Error("github_apps must be a mapping");
+  }
+
+  const config: GitHubAppsConfig = {};
+  let hasAny = false;
+
+  for (const role of GITHUB_APP_ROLES) {
+    const roleValue = value[role];
+    if (roleValue === undefined || roleValue === null) {
+      continue;
+    }
+    if (!isRecord(roleValue)) {
+      throw new Error(`github_apps.${role} must be a mapping`);
+    }
+
+    const appId = readString(roleValue.app_id, `github_apps.${role}.app_id`);
+    const privateKeyPath = readString(
+      roleValue.private_key_path,
+      `github_apps.${role}.private_key_path`
+    );
+    const installationId = readString(
+      roleValue.installation_id,
+      `github_apps.${role}.installation_id`
+    );
+
+    const missing = GITHUB_APP_FIELD_NAMES.filter((fieldName) => {
+      const fieldValue = roleValue[fieldName];
+      return fieldValue === undefined || fieldValue === null || fieldValue === "";
+    });
+    const hasAnyField = GITHUB_APP_FIELD_NAMES.some((fieldName) => {
+      const fieldValue = roleValue[fieldName];
+      return fieldValue !== undefined && fieldValue !== null && fieldValue !== "";
+    });
+
+    if (!hasAnyField) {
+      continue;
+    }
+    if (missing.length > 0) {
+      throw new Error(`github_apps.${role} is missing required fields: ${missing.join(", ")}`);
+    }
+
+    config[role] = {
+      appId: appId as string,
+      privateKeyPath: normalizeConfigPath(privateKeyPath as string, configDir),
+      installationId: installationId as string,
+    };
+    hasAny = true;
+  }
+
+  return hasAny ? config : undefined;
+}
+
+function maybeReadStringField(fields: Record<string, unknown>, key: string): string | undefined {
+  const value = fields[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function maybeReadNumberField(fields: Record<string, unknown>, key: string): number | undefined {
+  const value = fields[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function maybeReadBooleanField(fields: Record<string, unknown>, key: string): boolean | undefined {
+  const value = fields[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function maybeReadStringArrayField(
+  fields: Record<string, unknown>,
+  key: string
+): string[] | undefined {
+  const value = fields[key];
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string")
+    ? value
+    : undefined;
+}
+
+function maybeReadIssueBackend(
+  fields: Record<string, unknown>,
+  key: string
+): "linear" | "github" | undefined {
+  const value = fields[key];
+  return value === "linear" || value === "github" ? value : undefined;
+}
+
+function maybeReadRuntime(
+  fields: Record<string, unknown>,
+  key: string
+): "opencode" | "claude-code" | undefined {
+  const value = fields[key];
+  return value === "opencode" || value === "claude-code" ? value : undefined;
+}
+
+function maybeReadGitHubApps(
+  fields: Record<string, unknown>,
+  key: string
+): GitHubAppsConfig | undefined {
+  const value = fields[key];
+  return isRecord(value) ? (value as GitHubAppsConfig) : undefined;
+}
+
+function pushEnvDeprecationWarning(
+  warnings: string[],
+  source: ValueSource,
+  env: Record<string, string | undefined>,
+  envVar: string,
+  yamlKey: string
+): void {
+  if (source === "env" && env[envVar] !== undefined) {
+    warnings.push(`${envVar} is deprecated; move this value to legion.yaml as '${yamlKey}'.`);
+  }
+}
+
+export function loadConfigFromFile(yamlText: string, configDir: string): LoadedConfigFile {
+  let parsed: unknown;
+  try {
+    parsed = parse(yamlText);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid YAML config: ${message}`);
+  }
+
+  if (parsed === undefined || parsed === null) {
+    return { fields: {}, warnings: [] };
+  }
+  if (!isRecord(parsed)) {
+    throw new Error("Config file root must be a mapping");
+  }
+
+  const warnings: string[] = [];
+  collectUnknownKeys(parsed, CONFIG_SCHEMA, [], warnings);
+
+  const fields: Record<string, unknown> = {};
+
+  const project = readString(parsed.project, "project");
+  if (project !== undefined) {
+    fields.legionId = project;
+  }
+
+  const workspace = readString(parsed.workspace, "workspace");
+  if (workspace !== undefined) {
+    fields.legionDir = normalizeConfigPath(workspace, configDir);
+  }
+
+  const port = readNumber(parsed.port, "port");
+  if (port !== undefined) {
+    fields.daemonPort = port;
+  }
+
+  const backend = validateBackend(readString(parsed.backend, "backend"), "backend");
+  if (backend !== undefined) {
+    fields.issueBackend = backend;
+  }
+
+  const runtime = validateRuntime(readString(parsed.runtime, "runtime"), "runtime");
+  if (runtime !== undefined) {
+    fields.runtime = runtime;
+  }
+
+  const controller = parsed.controller;
+  if (controller !== undefined && controller !== null) {
+    if (!isRecord(controller)) {
+      throw new Error("controller must be a mapping");
+    }
+    const sessionId = validateControllerSessionId(
+      readString(controller.session_id, "controller.session_id"),
+      "controller.session_id"
+    );
+    const prompt = readString(controller.prompt, "controller.prompt");
+    validateControllerPrompt(prompt);
+
+    if (sessionId !== undefined) {
+      fields.controllerSessionId = sessionId;
+    }
+    if (prompt !== undefined) {
+      fields.controllerPrompt = prompt;
+    }
+  }
+
+  const githubApps = loadGitHubAppsFromFile(parsed.github_apps, configDir);
+  if (githubApps !== undefined) {
+    fields.githubApps = githubApps;
+  }
+
+  const memory = parsed.memory;
+  if (memory !== undefined && memory !== null) {
+    if (!isRecord(memory)) {
+      throw new Error("memory must be a mapping");
+    }
+    const maxRssGb = readNumber(memory.max_rss_gb, "memory.max_rss_gb");
+    const rssCheckIntervalSeconds = readNumber(
+      memory.rss_check_interval_seconds,
+      "memory.rss_check_interval_seconds"
+    );
+    const maxRssBytes = parseMaxRssBytesFromGb(maxRssGb);
+    const rssCheckIntervalMs = parseRssCheckIntervalMsFromSeconds(rssCheckIntervalSeconds);
+
+    if (maxRssBytes !== undefined) {
+      fields.maxRssBytes = maxRssBytes;
+    }
+    if (rssCheckIntervalMs !== undefined) {
+      fields.rssCheckIntervalMs = rssCheckIntervalMs;
+    }
+  }
+
+  const envoyUrl = readString(parsed.envoy_url, "envoy_url");
+  if (envoyUrl !== undefined) {
+    fields.envoyUrl = envoyUrl;
+  }
+
+  const feedback = parsed.feedback;
+  if (feedback !== undefined && feedback !== null) {
+    if (!isRecord(feedback)) {
+      throw new Error("feedback must be a mapping");
+    }
+    const disabled = readBoolean(feedback.disabled, "feedback.disabled");
+    const maxBytes = readNumber(feedback.max_bytes, "feedback.max_bytes");
+    if (disabled !== undefined) {
+      fields.feedbackDisabled = disabled;
+    }
+    if (maxBytes !== undefined) {
+      fields.feedbackMaxBytes = maxBytes;
+    }
+  }
+
+  const extraProjects = parseExtraProjectsArray(parsed.extra_projects);
+  const effectiveBackend = (fields.issueBackend as "linear" | "github" | undefined) ?? "linear";
+  if (extraProjects !== undefined) {
+    if (effectiveBackend !== "github") {
+      throw new Error("extra_projects requires backend: github");
+    }
+    fields.extraProjects = extraProjects;
+  }
+
+  return { fields, warnings };
+}
+
+export function resolveDaemonConfig(
+  opts: ResolveDaemonConfigOptions = {}
+): ResolveDaemonConfigResult {
+  const env = opts.env ?? {};
+  const configFields = opts.configFile?.fields ?? {};
+  const warnings = [...(opts.configFile?.warnings ?? [])];
+
+  const envLegionId = env.LEGION_ID || undefined;
+  const envLegionDir = env.LEGION_DIR || undefined;
+  const envDaemonPort = parseOptionalNumber(env.LEGION_DAEMON_PORT);
+  const envControllerSessionId = validateControllerSessionId(
+    env.LEGION_CONTROLLER_SESSION_ID || undefined,
+    "LEGION_CONTROLLER_SESSION_ID"
+  );
+  const envControllerPrompt = env.LEGION_CONTROLLER_PROMPT || undefined;
+  validateControllerPrompt(envControllerPrompt);
+  const envIssueBackend = validateBackend(env.LEGION_ISSUE_BACKEND, "LEGION_ISSUE_BACKEND");
+  const envRuntime = validateRuntime(env.LEGION_RUNTIME, "LEGION_RUNTIME");
+  const envExtraProjects = parseExtraProjects(env.LEGION_EXTRA_PROJECTS);
+  const envGithubApps = loadGitHubApps(env);
+  const envMaxRssBytes = parseMaxRssBytesFromGb(parseOptionalNumber(env.OPENCODE_MAX_RSS_GB));
+  const envRssCheckIntervalMs = parseRssCheckIntervalMsFromSeconds(
+    parseOptionalNumber(env.OPENCODE_RSS_CHECK_INTERVAL)
+  );
+  const envEnvoyUrl = env.ENVOY_URL || undefined;
+  const envFeedbackDisabled = parseOptionalBoolean(env.LEGION_FEEDBACK_DISABLED);
+  const envFeedbackMaxBytes = parseOptionalNumber(env.LEGION_FEEDBACK_MAX_BYTES);
+
+  const legionId = resolveValue(
+    opts.cliOverrides?.legionId,
+    maybeReadStringField(configFields, "legionId"),
+    envLegionId,
+    undefined
+  );
+  const legionDir = resolveValue(
+    opts.cliOverrides?.legionDir,
+    maybeReadStringField(configFields, "legionDir"),
+    envLegionDir,
+    undefined
+  );
+  const daemonPort = resolveValue(
+    opts.cliOverrides?.daemonPort,
+    maybeReadNumberField(configFields, "daemonPort"),
+    envDaemonPort,
+    BASE_DAEMON_PORT
+  );
+  const controllerSessionId = resolveValue(
+    opts.cliOverrides?.controllerSessionId,
+    maybeReadStringField(configFields, "controllerSessionId"),
+    envControllerSessionId,
+    undefined
+  );
+  const controllerPrompt = resolveValue(
+    opts.cliOverrides?.controllerPrompt,
+    maybeReadStringField(configFields, "controllerPrompt"),
+    envControllerPrompt,
+    undefined
+  );
+  const issueBackend = resolveValue<DaemonConfig["issueBackend"]>(
+    opts.cliOverrides?.issueBackend,
+    maybeReadIssueBackend(configFields, "issueBackend"),
+    envIssueBackend,
+    "linear"
+  );
+  const extraProjects = resolveValue(
+    opts.cliOverrides?.extraProjects,
+    maybeReadStringArrayField(configFields, "extraProjects"),
+    envExtraProjects,
+    undefined
+  );
+  const runtime = resolveValue<DaemonConfig["runtime"]>(
+    opts.cliOverrides?.runtime,
+    maybeReadRuntime(configFields, "runtime"),
+    envRuntime,
+    "opencode"
+  );
+  const githubApps = resolveValue(
+    opts.cliOverrides?.githubApps,
+    maybeReadGitHubApps(configFields, "githubApps"),
+    envGithubApps,
+    undefined
+  );
+  const maxRssBytes = resolveValue(
+    opts.cliOverrides?.maxRssBytes,
+    maybeReadNumberField(configFields, "maxRssBytes"),
+    envMaxRssBytes,
+    DEFAULT_MAX_RSS_GB * 1024 * 1024 * 1024
+  );
+  const rssCheckIntervalMs = resolveValue(
+    opts.cliOverrides?.rssCheckIntervalMs,
+    maybeReadNumberField(configFields, "rssCheckIntervalMs"),
+    envRssCheckIntervalMs,
+    DEFAULT_RSS_CHECK_INTERVAL_S * 1000
+  );
+  const envoyUrl = resolveValue(
+    opts.cliOverrides?.envoyUrl,
+    maybeReadStringField(configFields, "envoyUrl"),
+    envEnvoyUrl,
+    DEFAULT_ENVOY_URL
+  );
+  const feedbackDisabled = resolveValue(
+    opts.cliOverrides?.feedbackDisabled,
+    maybeReadBooleanField(configFields, "feedbackDisabled"),
+    envFeedbackDisabled,
+    false
+  );
+  const feedbackMaxBytes = resolveValue(
+    opts.cliOverrides?.feedbackMaxBytes,
+    maybeReadNumberField(configFields, "feedbackMaxBytes"),
+    envFeedbackMaxBytes,
+    DEFAULT_FEEDBACK_MAX_BYTES
+  );
+
+  if (
+    extraProjects.value !== undefined &&
+    extraProjects.source !== "env" &&
+    issueBackend.value !== "github"
+  ) {
+    throw new Error("extra_projects requires backend: github");
+  }
+
+  const paths = resolveLegionPaths(env, os.homedir());
+  const stateFilePath = legionId.value
+    ? paths.forLegion(legionId.value).workersFile
+    : path.join(paths.stateDir, "daemon", "workers.json");
+  const logDir = legionId.value
+    ? paths.forLegion(legionId.value).logDir
+    : path.join(paths.stateDir, "daemon", "logs");
+
+  pushEnvDeprecationWarning(warnings, legionId.source, env, "LEGION_ID", "project");
+  pushEnvDeprecationWarning(
+    warnings,
+    extraProjects.source,
+    env,
+    "LEGION_EXTRA_PROJECTS",
+    "extra_projects"
+  );
+  pushEnvDeprecationWarning(warnings, issueBackend.source, env, "LEGION_ISSUE_BACKEND", "backend");
+  pushEnvDeprecationWarning(warnings, runtime.source, env, "LEGION_RUNTIME", "runtime");
+  pushEnvDeprecationWarning(warnings, legionDir.source, env, "LEGION_DIR", "workspace");
+  pushEnvDeprecationWarning(warnings, daemonPort.source, env, "LEGION_DAEMON_PORT", "port");
+  pushEnvDeprecationWarning(
+    warnings,
+    controllerSessionId.source,
+    env,
+    "LEGION_CONTROLLER_SESSION_ID",
+    "controller.session_id"
+  );
+  pushEnvDeprecationWarning(
+    warnings,
+    controllerPrompt.source,
+    env,
+    "LEGION_CONTROLLER_PROMPT",
+    "controller.prompt"
+  );
+  pushEnvDeprecationWarning(
+    warnings,
+    maxRssBytes.source,
+    env,
+    "OPENCODE_MAX_RSS_GB",
+    "memory.max_rss_gb"
+  );
+  pushEnvDeprecationWarning(
+    warnings,
+    rssCheckIntervalMs.source,
+    env,
+    "OPENCODE_RSS_CHECK_INTERVAL",
+    "memory.rss_check_interval_seconds"
+  );
+  pushEnvDeprecationWarning(warnings, envoyUrl.source, env, "ENVOY_URL", "envoy_url");
+  pushEnvDeprecationWarning(
+    warnings,
+    feedbackDisabled.source,
+    env,
+    "LEGION_FEEDBACK_DISABLED",
+    "feedback.disabled"
+  );
+  pushEnvDeprecationWarning(
+    warnings,
+    feedbackMaxBytes.source,
+    env,
+    "LEGION_FEEDBACK_MAX_BYTES",
+    "feedback.max_bytes"
+  );
+
+  if (githubApps.source === "env") {
+    for (const role of GITHUB_APP_ROLES) {
+      const prefix = `LEGION_GITHUB_APP_${role.toUpperCase()}`;
+      pushEnvDeprecationWarning(
+        warnings,
+        githubApps.source,
+        env,
+        `${prefix}_ID`,
+        `github_apps.${role}.app_id`
+      );
+      pushEnvDeprecationWarning(
+        warnings,
+        githubApps.source,
+        env,
+        `${prefix}_PRIVATE_KEY_PATH`,
+        `github_apps.${role}.private_key_path`
+      );
+      pushEnvDeprecationWarning(
+        warnings,
+        githubApps.source,
+        env,
+        `${prefix}_INSTALLATION_ID`,
+        `github_apps.${role}.installation_id`
+      );
+    }
+  }
+
+  return {
+    config: {
+      daemonPort: daemonPort.value,
+      daemonPortExplicit: daemonPort.source === "cli" || daemonPort.source === "config",
+      legionId: legionId.value,
+      legionDir: legionDir.value,
+      paths,
+      checkIntervalMs: DEFAULT_CHECK_INTERVAL_MS,
+      baseWorkerPort: DEFAULT_BASE_WORKER_PORT,
+      stateFilePath,
+      logDir,
+      controllerSessionId: controllerSessionId.value,
+      controllerPrompt: controllerPrompt.value,
+      issueBackend: issueBackend.value,
+      extraProjects: extraProjects.value,
+      runtime: runtime.value,
+      githubApps: githubApps.value,
+      envoyUrl: envoyUrl.value,
+      feedbackDisabled: feedbackDisabled.value,
+      feedbackMaxBytes: feedbackMaxBytes.value,
+      maxRssBytes: maxRssBytes.value,
+      rssCheckIntervalMs: rssCheckIntervalMs.value,
+    },
+    warnings,
+  };
+}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): DaemonConfig {
+  return resolveDaemonConfig({ env }).config;
 }

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -7,7 +7,7 @@ import {
   createEmptyCodebaseIndexResponse,
 } from "../index/types";
 import { computeControllerSessionId } from "../state/types";
-import { type DaemonConfig, loadConfig, validateControllerPrompt } from "./config";
+import { type DaemonConfig, resolveDaemonConfig, validateControllerPrompt } from "./config";
 import { FeedbackLogger, FileFeedbackWriter } from "./feedback";
 import { modeToRole, TokenManager } from "./github-apps";
 import {
@@ -46,12 +46,14 @@ interface DaemonDependencies {
   clearTimeout: typeof clearTimeout;
 }
 
-interface DaemonOverrides extends Partial<DaemonConfig> {
+interface DaemonStartOptions {
   readLegionsRegistry?: typeof readLegionsRegistry;
   cleanupStaleServes?: typeof cleanupStaleServes;
   allocatePort?: typeof allocatePort;
   writeLegionEntry?: typeof writeLegionEntry;
   removeLegionEntry?: typeof removeLegionEntry;
+  daemonPortExplicit?: boolean;
+  deps?: Partial<DaemonDependencies>;
 }
 
 export interface DaemonHandle {
@@ -137,8 +139,7 @@ async function sendPromptWithRetry(
   throw lastError;
 }
 
-async function subscribeControllerToEnvoy(sessionId: string) {
-  const envoyUrl = process.env.ENVOY_URL ?? "http://127.0.0.1:9020";
+async function subscribeControllerToEnvoy(sessionId: string, envoyUrl: string) {
   try {
     const roleRes = await fetch(`${envoyUrl}/v1/roles/set`, {
       method: "POST",
@@ -176,8 +177,7 @@ async function subscribeControllerToEnvoy(sessionId: string) {
     });
 }
 
-function unsubscribeFromEnvoy(sessionId: string) {
-  const envoyUrl = process.env.ENVOY_URL ?? "http://127.0.0.1:9020";
+function unsubscribeFromEnvoy(sessionId: string, envoyUrl: string) {
   fetch(`${envoyUrl}/v1/interests/unsubscribe`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -202,8 +202,8 @@ function buildControllerEnv(config: DaemonConfig): Record<string, string> {
 }
 
 export async function startDaemon(
-  overrides: DaemonOverrides = {},
-  deps?: Partial<DaemonDependencies>
+  inputConfig: DaemonConfig,
+  opts: DaemonStartOptions = {}
 ): Promise<DaemonHandle> {
   const {
     readLegionsRegistry: readLegionsRegistryOverride,
@@ -211,8 +211,9 @@ export async function startDaemon(
     allocatePort: allocatePortOverride,
     writeLegionEntry: writeLegionEntryOverride,
     removeLegionEntry: removeLegionEntryOverride,
-    ...configOverrides
-  } = overrides;
+    daemonPortExplicit,
+    deps,
+  } = opts;
 
   const readLegionsRegistryFn = readLegionsRegistryOverride ?? readLegionsRegistry;
   const cleanupStaleServesFn = cleanupStaleServesOverride ?? cleanupStaleServes;
@@ -220,7 +221,7 @@ export async function startDaemon(
   const writeLegionEntryFn = writeLegionEntryOverride ?? writeLegionEntry;
   const removeLegionEntryFn = removeLegionEntryOverride ?? removeLegionEntry;
 
-  let config = { ...loadConfig(), ...configOverrides };
+  let config = inputConfig;
   const legionId = config.legionId;
   if (!legionId) {
     throw new Error("Missing legionId for daemon");
@@ -234,11 +235,18 @@ export async function startDaemon(
   // This prevents orphaned serves from holding SQLite locks and occupying ports.
   await cleanupStaleServesFn(config.paths.legionsFile, legionId);
 
-  const { daemonPort, servePort } = allocatePortFn(registry);
+  const { daemonPort: allocatedDaemonPort, servePort } = allocatePortFn(registry);
 
-  let actualDaemonPort = daemonPort;
-  while (!(await isPortFree(actualDaemonPort))) {
-    actualDaemonPort++;
+  const daemonPortIsExplicit = daemonPortExplicit ?? config.daemonPortExplicit;
+  let actualDaemonPort = daemonPortIsExplicit ? config.daemonPort : allocatedDaemonPort;
+  if (daemonPortIsExplicit) {
+    if (!(await isPortFree(actualDaemonPort))) {
+      throw new Error(`Daemon port ${actualDaemonPort} is unavailable`);
+    }
+  } else {
+    while (!(await isPortFree(actualDaemonPort))) {
+      actualDaemonPort++;
+    }
   }
 
   let actualServePort = servePort;
@@ -255,11 +263,10 @@ export async function startDaemon(
   const resolvedDeps = resolveDependencies(config, deps);
 
   let feedbackLogger: FeedbackLogger | undefined;
-  if (!process.env.LEGION_FEEDBACK_DISABLED) {
+  if (!config.feedbackDisabled) {
     const feedbackPath = config.paths.forLegion(legionId).feedbackFile;
     mkdirSync(path.dirname(feedbackPath), { recursive: true });
-    const maxBytes = Number(process.env.LEGION_FEEDBACK_MAX_BYTES) || 50 * 1024 * 1024;
-    const writer = new FileFeedbackWriter(feedbackPath, maxBytes);
+    const writer = new FileFeedbackWriter(feedbackPath, config.feedbackMaxBytes);
     feedbackLogger = new FeedbackLogger(writer, legionId);
   }
 
@@ -485,6 +492,7 @@ export async function startDaemon(
         tokenManager,
         indexManager,
         feedbackLogger,
+        envoyUrl: config.envoyUrl,
         shutdownFn: async () => {
           resolvedDeps.setTimeout(async () => {
             await shutdown(true);
@@ -498,7 +506,7 @@ export async function startDaemon(
     } catch (error) {
       const err = error as NodeJS.ErrnoException;
       bindAttempts++;
-      if (err.code !== "EADDRINUSE" || bindAttempts >= 5) {
+      if (daemonPortIsExplicit || err.code !== "EADDRINUSE" || bindAttempts >= 5) {
         throw error;
       }
       config = { ...config, daemonPort: config.daemonPort + 1 };
@@ -531,11 +539,11 @@ export async function startDaemon(
     }
     // Unsubscribe old controller from Envoy if session ID changed
     if (existingController && existingController.sessionId !== config.controllerSessionId) {
-      unsubscribeFromEnvoy(existingController.sessionId);
+      unsubscribeFromEnvoy(existingController.sessionId, config.envoyUrl);
     }
     console.log(`External controller: session=${config.controllerSessionId}`);
     controllerState = { sessionId: config.controllerSessionId };
-    subscribeControllerToEnvoy(config.controllerSessionId);
+    subscribeControllerToEnvoy(config.controllerSessionId, config.envoyUrl);
   } else {
     const requestedSessionId = computeControllerSessionId(legionId);
     let actualSessionId: string | undefined;
@@ -561,7 +569,7 @@ export async function startDaemon(
           resolvedDeps
         );
         console.log(`Controller started: session=${actualSessionId} port=${sharedServePort}`);
-        subscribeControllerToEnvoy(actualSessionId);
+        subscribeControllerToEnvoy(actualSessionId, config.envoyUrl);
       } catch (error) {
         console.error(`Controller session created but prompt failed: ${error}`);
         console.error("Health loop will retry on next tick.");
@@ -664,7 +672,7 @@ export async function startDaemon(
             for (const entry of liveWorkers) {
               const actualSessionId = recreatedSessions.get(entry.id);
               if (actualSessionId && entry.envoyTopics?.length) {
-                subscribeWorkerToEnvoy(actualSessionId, entry.envoyTopics);
+                subscribeWorkerToEnvoy(actualSessionId, entry.envoyTopics, config.envoyUrl);
               }
             }
 
@@ -681,7 +689,7 @@ export async function startDaemon(
                 }
                 // Unsubscribe old session ID if it changed
                 if (actualControllerSessionId !== controllerState.sessionId) {
-                  unsubscribeFromEnvoy(controllerState.sessionId);
+                  unsubscribeFromEnvoy(controllerState.sessionId, config.envoyUrl);
                 }
                 controllerState = {
                   ...controllerState,
@@ -802,5 +810,6 @@ if (import.meta.main) {
   process.on("unhandledRejection", (reason) => {
     console.error("[daemon] unhandled rejection:", reason);
   });
-  void startDaemon();
+  const { config } = resolveDaemonConfig({ env: process.env });
+  void startDaemon(config);
 }

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -46,6 +46,7 @@ interface WorkerEntry extends BaseWorkerEntry {
 export interface ServerOptions {
   port?: number;
   hostname?: string;
+  envoyUrl?: string;
   legionId: string;
   projectId?: string;
   extraProjects?: string[];
@@ -192,9 +193,12 @@ export function buildPrTopics(owner: string, repo: string, prNumber: number): st
   return [`notifications.github.${owner}.${repo}.pr.${prNumber}.>`];
 }
 
-export function subscribeWorkerToEnvoy(sessionId: string, topics: string[]): void {
+export function subscribeWorkerToEnvoy(
+  sessionId: string,
+  topics: string[],
+  envoyUrl = "http://127.0.0.1:9020"
+): void {
   if (topics.length === 0) return;
-  const envoyUrl = process.env.ENVOY_URL ?? "http://127.0.0.1:9020";
   fetch(`${envoyUrl}/v1/interests/subscribe`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -215,11 +219,14 @@ export function subscribeWorkerToEnvoy(sessionId: string, topics: string[]): voi
     });
 }
 
-function detachWorkerFromEnvoy(entry: BaseWorkerEntry, reason: string): void {
+function detachWorkerFromEnvoy(
+  entry: BaseWorkerEntry,
+  reason: string,
+  envoyUrl = "http://127.0.0.1:9020"
+): void {
   const hadTopics = entry.envoyTopics;
   entry.envoyTopics = undefined;
   if (!hadTopics?.length) return;
-  const envoyUrl = process.env.ENVOY_URL ?? "http://127.0.0.1:9020";
   fetch(`${envoyUrl}/v1/interests/unsubscribe`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -239,8 +246,7 @@ function detachWorkerFromEnvoy(entry: BaseWorkerEntry, reason: string): void {
     });
 }
 
-function publishStateDelta(delta: StateDelta): void {
-  const envoyUrl = process.env.ENVOY_URL ?? "http://127.0.0.1:9020";
+function publishStateDelta(delta: StateDelta, envoyUrl = "http://127.0.0.1:9020"): void {
   fetch(`${envoyUrl}/v1/messages/publish`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -257,8 +263,7 @@ function publishStateDelta(delta: StateDelta): void {
     });
 }
 
-function unsubscribeAllWorkerTopics(sessionId: string): void {
-  const envoyUrl = process.env.ENVOY_URL ?? "http://127.0.0.1:9020";
+function unsubscribeAllWorkerTopics(sessionId: string, envoyUrl = "http://127.0.0.1:9020"): void {
   fetch(`${envoyUrl}/v1/interests/unsubscribe`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -283,6 +288,7 @@ export function startServer(opts: ServerOptions): {
 } {
   const hostname = opts.hostname ?? "127.0.0.1";
   const port = opts.port ?? 13370;
+  const envoyUrl = opts.envoyUrl ?? "http://127.0.0.1:9020";
   const startedAt = Date.now();
   const workers = new Map<string, WorkerEntry>();
   const crashHistory = new Map<string, CrashHistoryEntry>();
@@ -368,7 +374,7 @@ export function startServer(opts: ServerOptions): {
 
       if (recoveredTopics?.length) {
         loadedEntry.envoyTopics = recoveredTopics;
-        subscribeWorkerToEnvoy(loadedEntry.sessionId, recoveredTopics);
+        subscribeWorkerToEnvoy(loadedEntry.sessionId, recoveredTopics, envoyUrl);
       }
     }
   };
@@ -398,7 +404,7 @@ export function startServer(opts: ServerOptions): {
       if (previousIssueState !== null) {
         const delta = computeStateDelta(previousIssueState, currentDict);
         if (delta && opts.getControllerState?.()?.sessionId) {
-          publishStateDelta(delta);
+          publishStateDelta(delta, envoyUrl);
         }
       }
 
@@ -474,8 +480,8 @@ export function startServer(opts: ServerOptions): {
         );
       }
 
-      detachWorkerFromEnvoy(entry, "auto-cleanup-done");
-      unsubscribeAllWorkerTopics(entry.sessionId);
+      detachWorkerFromEnvoy(entry, "auto-cleanup-done", envoyUrl);
+      unsubscribeAllWorkerTopics(entry.sessionId, envoyUrl);
       workers.delete(entry.id);
       crashHistory.delete(entry.id);
       cleanedIssueIds.add(issueId);
@@ -962,7 +968,7 @@ export function startServer(opts: ServerOptions): {
                 if (existingEntry.envoyTopics?.length) {
                   workerEntriesChanged = true;
                 }
-                detachWorkerFromEnvoy(existingEntry, "cross-mode-cleanup");
+                detachWorkerFromEnvoy(existingEntry, "cross-mode-cleanup", envoyUrl);
               }
             }
 
@@ -971,7 +977,7 @@ export function startServer(opts: ServerOptions): {
             // Implement self-subscribes to PR topics after PR creation via envoy_subscribe.
             if (mode === WorkerMode.PLAN && repoRef && issueNumber !== undefined) {
               const topics = buildIssueTopics(repoRef.owner, repoRef.repo, issueNumber);
-              subscribeWorkerToEnvoy(actualSessionId, topics);
+              subscribeWorkerToEnvoy(actualSessionId, topics, envoyUrl);
               entry.envoyTopics = topics;
               workerEntriesChanged = true;
             }
@@ -1102,7 +1108,7 @@ export function startServer(opts: ServerOptions): {
           workers.delete(workerId);
           crashHistory.delete(workerId);
           await persistState();
-          unsubscribeAllWorkerTopics(entry.sessionId);
+          unsubscribeAllWorkerTopics(entry.sessionId, envoyUrl);
 
           return jsonResponse({ status: "cleaned", workerRemoved: true });
         }
@@ -1159,7 +1165,7 @@ export function startServer(opts: ServerOptions): {
               prunedWorkers.push(workerId);
               prunedSessionIds.push(entry.sessionId);
               // Clear daemon-managed topic tracking before deletion
-              detachWorkerFromEnvoy(entry, "prune-done");
+              detachWorkerFromEnvoy(entry, "prune-done", envoyUrl);
             }
           }
           for (const id of prunedWorkers) {
@@ -1193,7 +1199,7 @@ export function startServer(opts: ServerOptions): {
           // may also have self-managed subscriptions (e.g. implementer PR topics)
           // that aren't tracked in entry.envoyTopics.
           for (const sessionId of prunedSessionIds) {
-            unsubscribeAllWorkerTopics(sessionId);
+            unsubscribeAllWorkerTopics(sessionId, envoyUrl);
           }
 
           return jsonResponse({
@@ -1254,7 +1260,7 @@ export function startServer(opts: ServerOptions): {
               });
               // Clean up Envoy subscriptions on transition to dead (fire-and-forget)
               if (entry.status !== "dead") {
-                detachWorkerFromEnvoy(updated, "worker-dead");
+                detachWorkerFromEnvoy(updated, "worker-dead", envoyUrl);
               }
             }
             await persistState();
@@ -1298,7 +1304,7 @@ export function startServer(opts: ServerOptions): {
             entry.envoyTopics = undefined;
             workers.delete(id);
             await persistState();
-            unsubscribeAllWorkerTopics(entry.sessionId);
+            unsubscribeAllWorkerTopics(entry.sessionId, envoyUrl);
             return jsonResponse({ status: "stopped" });
           }
         }
@@ -1358,7 +1364,7 @@ export function startServer(opts: ServerOptions): {
             await promptAdapter.sendPrompt(entry.sessionId, text);
 
             if (entry.envoyTopics?.length) {
-              subscribeWorkerToEnvoy(entry.sessionId, entry.envoyTopics);
+              subscribeWorkerToEnvoy(entry.sessionId, entry.envoyTopics, envoyUrl);
             }
 
             return jsonResponse({ ok: true });


### PR DESCRIPTION
Closes #436

## Summary

Adds YAML config file as primary configuration interface for the Legion daemon, replacing scattered env vars.

### What changed

- **`config.ts`**: Added `loadConfigFromFile()` (YAML parsing, validation, path normalization, unknown-key detection) and `resolveDaemonConfig()` (field-by-field precedence: CLI > config file > env vars > defaults, with deprecation warnings). New `DaemonConfig` fields: `envoyUrl`, `feedbackDisabled`, `feedbackMaxBytes`, `daemonPortExplicit`.

- **`cli/index.ts`**: Added `--config/-c` flag to `legion start`. `team` positional is now optional when config provides `project`. `cmdStart()` rewired to use `resolveDaemonConfig()` — no more `process.env` mutation.

- **`daemon/index.ts`**: `startDaemon()` now accepts a fully resolved `DaemonConfig`. Explicit daemon port is authoritative (fails if unavailable instead of auto-incrementing). Direct `process.env.ENVOY_URL` and `LEGION_FEEDBACK_*` reads replaced with config fields.

- **`daemon/server.ts`**: `envoyUrl` threaded via `ServerOptions`. All 4 envoy helper functions now use the config value instead of `process.env.ENVOY_URL`.

### Usage

```bash
# Config file is the primary interface
legion start --config ./legion.yaml

# CLI flags override config values
legion start --config ./legion.yaml --backend github

# Legacy env var path still works (deprecated with warnings)
legion start my-team
```

### Verification

- 861 tests pass (73 new config tests, 3 CLI tests, 3 port authority tests)
- `bunx tsc --noEmit` clean
- `bunx biome check src/` clean
- Cross-family review: 0 P1, 2 P2 (both fixed), 2 P3 (informational)