### PR TITLE
sjawhar-legion-423: fix(envoy): add source_session and payload preview to listener receive log

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,22 +1,12 @@
 {
-  "filesChanged": [
-    ".opencode/skills/legion-controller/SKILL.md",
-    ".opencode/skills/legion-worker/workflows/review.md"
+  "filesChanged": ["packages/envoy/cmd/listener/main.go"],
+  "trickyParts": [
+    "Rebase onto main caused .legion/plan.json conflicts from concurrent issue #240 merge — required resolving both ancestor commits (vuvz and wytu) separately"
   ],
-  "trickyParts": [],
   "deviations": [],
   "openQuestions": [],
   "subPlanningNeeded": false,
-  "learningsInjected": [
-    "skill-patterns/merge-retry-race-condition-pattern.md",
-    "skill-patterns/cross-cutting-workflow-concerns.md",
-    "integration-patterns/controller-worker-protocol.md"
-  ],
-  "learningsHelpful": [
-    "skill-patterns/merge-retry-race-condition-pattern.md",
-    "integration-patterns/controller-worker-protocol.md"
-  ],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-12T13:28:32.037Z"
+  "completed": "2026-04-12T13:16:13.683Z"
 }

--- a/.legion/plan.json
+++ b/.legion/plan.json
@@ -1,34 +1,15 @@
 {
   "taskCount": 2,
-  "independentTasks": 2,
+  "independentTasks": 1,
   "routingHints": {
     "complexity": "small",
     "estimatedImplementers": 1,
     "skipRetro": true,
     "skipArchitect": true
   },
-  "concerns": [
-    "Review worker lacks Contents write permission — must NOT rebase or push; detect-and-stop only",
-    "State machine keys off prIsDraft, not GitHub review API state — reviewer must use draft status for signaling conflicts",
-    "UNKNOWN mergeability must be treated as non-pass at controller (fail closed), but pass-through at worker",
-    "Retro-skip path bypasses Pre-Merge Gate — needs its own inline mergeability check before dispatching merge"
-  ],
-  "learningsInjected": [
-    "skill-patterns/merge-retry-race-condition-pattern.md",
-    "skill-patterns/cross-cutting-workflow-concerns.md",
-    "integration-patterns/controller-worker-protocol.md"
-  ],
-  "learningsHelpful": [
-    "skill-patterns/merge-retry-race-condition-pattern.md",
-    "integration-patterns/controller-worker-protocol.md"
-  ],
-  "workflowRecommendation": "Simple docs-only fix — skip retro, single implementer. Two independent tasks can run in parallel but both touch the same controller file, so sequential is safer.",
-  "requiredSkills": {
-    "implement": [],
-    "test": [],
-    "review": []
-  },
+  "concerns": [],
+  "workflowRecommendation": "Simple single-line fix — skip retro, single implementer",
   "schemaVersion": 1,
   "phase": "plan",
-  "completed": "2026-04-12T00:06:18.564Z"
+  "completed": "2026-04-11T19:00:06.801Z"
 }

--- a/.legion/retro.json
+++ b/.legion/retro.json
@@ -1,7 +1,7 @@
 {
-  "skipped": true,
-  "reason": "no significant learnings — mechanical skill file edits following exact plan",
+  "skipped": false,
+  "docsCreated": ["docs/solutions/legion/handoff-file-conflicts-during-rebases.md"],
   "schemaVersion": 1,
   "phase": "retro",
-  "completed": "2026-04-12T13:42:49.702Z"
+  "completed": "2026-04-12T13:34:36.609Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,26 +1,12 @@
 {
   "critical": 0,
   "important": 0,
-  "minor": 1,
+  "minor": 0,
   "verdict": "approved",
-  "keyFindings": [
-    {
-      "severity": "P3",
-      "file": ".opencode/skills/legion-controller/SKILL.md",
-      "description": "Two separate gh pr view API calls in retro-skip mergeability check could be combined into one"
-    }
-  ],
-  "learningsInjected": [
-    "skill-patterns/merge-retry-race-condition-pattern.md",
-    "integration-patterns/controller-worker-protocol.md",
-    "skill-patterns/cross-cutting-workflow-concerns.md"
-  ],
-  "learningsHelpful": [
-    "skill-patterns/merge-retry-race-condition-pattern.md",
-    "integration-patterns/controller-worker-protocol.md",
-    "skill-patterns/cross-cutting-workflow-concerns.md"
-  ],
+  "keyFindings": [],
+  "learningsInjected": [],
+  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-12T13:40:43.210Z"
+  "completed": "2026-04-12T13:26:47.926Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,18 +1,14 @@
 {
-  "passed": 5,
+  "passed": 3,
   "failed": 0,
   "failures": [],
-  "documentationFeedback": "PR body clearly describes the two-layer approach. No public docs needed — changes are internal agent skill files. Controller SKILL.md inline documentation is clear and actionable.",
-  "observations": [],
-  "learningsInjected": [
-    "skill-patterns/merge-retry-race-condition-pattern.md",
-    "integration-patterns/controller-worker-protocol.md",
-    "skill-patterns/cross-cutting-workflow-concerns.md"
+  "documentationFeedback": "PR body clearly describes change and purpose. No README updates needed — internal log format change. %.80s truncation documented.",
+  "observations": [
+    ".legion/plan.json and .legion/implement.json diffs are handoff data updates from re-implementation cycle, not part of feature change"
   ],
-  "learningsHelpful": [
-    "skill-patterns/merge-retry-race-condition-pattern.md"
-  ],
+  "learningsInjected": [],
+  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-12T13:33:54.605Z"
+  "completed": "2026-04-12T13:20:48.569Z"
 }

--- a/docs/solutions/index.json
+++ b/docs/solutions/index.json
@@ -523,6 +523,7 @@
     "tag:handoff": [
       "daemon/handoff-schema-migration-patterns.md",
       "skill-patterns/agent-workflow-enforcement-patterns.md"
+      "legion/handoff-file-conflicts-during-rebases.md"
     ],
     "tag:zod": [
       "daemon/handoff-schema-migration-patterns.md"
@@ -554,6 +555,7 @@
       "envoy/nats-bus-client-self-healing.md",
       "envoy/webhook-handler-extraction-and-testing.md",
       "envoy/multi-layer-service-consolidation.md"
+      "legion/handoff-file-conflicts-during-rebases.md"
     ],
     "packages/envoy/internal/webhook": [
       "envoy/webhook-handler-extraction-and-testing.md",
@@ -749,6 +751,7 @@
     ],
     "tag:conflict-resolution": [
       "skill-patterns/merge-retry-race-condition-pattern.md"
+      "legion/handoff-file-conflicts-during-rebases.md"
     ],
     "tag:github-api": [
       "skill-patterns/merge-retry-race-condition-pattern.md",
@@ -776,5 +779,11 @@
       "daemon/workspace-scanning-patterns.md",
       "delegation/subagent-plan-compliance.md"
     ]
+    ],
+    ".legion": [
+      "legion/handoff-file-conflicts-during-rebases.md"
+    ],
+    "tag:jj": [
+      "legion/handoff-file-conflicts-during-rebases.md"
   }
 }

--- a/docs/solutions/legion/handoff-file-conflicts-during-rebases.md
+++ b/docs/solutions/legion/handoff-file-conflicts-during-rebases.md
@@ -1,0 +1,62 @@
+---
+title: ".legion/ Handoff File Conflicts During Concurrent Rebases"
+category: legion
+tags:
+  - legion
+  - jj
+  - conflict-resolution
+  - handoff
+date: 2026-04-12
+status: active
+module: legion
+related_issues:
+  - "sjawhar-legion-423"
+symptoms:
+  - "Rebase onto main causes .legion/plan.json conflicts"
+  - "Resolving conflict in ancestor commit re-triggers conflict in descendant"
+  - "Multiple rounds of conflict resolution needed for same .legion/ file"
+---
+
+# .legion/ Handoff File Conflicts During Concurrent Rebases
+
+## The Pattern
+
+When rebasing a feature branch onto main after a concurrent issue merges, `.legion/plan.json` conflicts across **multiple ancestor commits**. Resolving the deepest ancestor causes descendants to re-conflict due to jj's automatic descendant rebasing.
+
+This happens because `.legion/plan.json` lives at a fixed path but contains per-issue data. Every issue branch writes different content to the same file, so any rebase after a concurrent merge creates a conflict.
+
+## Example (Issue #423)
+
+Issue #240 merges to main. Issue #423 rebases onto main. Two ancestor commits (plan phase and implement phase) both have `.legion/plan.json` conflicts:
+
+```
+@  (empty, working copy)
+×  wytu — conflict in .legion/plan.json
+×  vuvz — conflict in .legion/plan.json
+◆  main — includes #240's plan.json
+```
+
+Resolving `vuvz` (deepest) causes jj to auto-rebase `wytu`, which re-conflicts because `wytu` was based on the pre-resolution `vuvz`.
+
+## Resolution: Edit-and-Squash, Bottom-Up
+
+1. **Start at the deepest conflicted commit**: `jj new <deepest-conflict>`
+2. **Edit the conflicted file** to keep the current branch's version (overwrite conflict markers)
+3. **Squash into the conflicted commit**: `jj squash -u`
+4. **Move to the next conflict** (which re-appeared from the auto-rebase): `jj new <next-conflict>`
+5. **Repeat** edit → squash for each descendant
+6. **Verify**: `jj agent-log` — all commits should show `"conflict":false`
+
+The key insight: use `jj new <commit>` + edit file + `jj squash -u`, NOT `jj resolve`. The file contains per-issue data where one side is always correct — just overwrite with the right version.
+
+## Prevention
+
+- **Squash before rebasing**: If the branch has multiple commits touching `.legion/`, squash them into one first. One conflict to resolve instead of N.
+- **Rebase frequently**: Don't let branches diverge from main for long.
+- **Merge shorter-lived branches first**: Reduces the conflict window.
+
+## When This Isn't a Problem
+
+- Single-implementer workflows (only one branch at a time)
+- Sequential merges (no concurrent work)
+- Issue only has one commit touching `.legion/plan.json`

--- a/packages/envoy/cmd/listener/main.go
+++ b/packages/envoy/cmd/listener/main.go
@@ -540,7 +540,7 @@ func main() {
 			_ = msg.Ack()
 			return
 		}
-		log.Printf("listener received machine=%s source=%s topic=%s event_id=%s", cfg.MachineID, item.Source, item.Topic, item.EventID)
+		log.Printf("listener received machine=%s source=%s source_session=%s topic=%s event_id=%s payload=%.80s", cfg.MachineID, item.Source, item.SourceSession, item.Topic, item.EventID, item.PayloadSummary)
 		if strings.HasPrefix(item.Topic, contracts.AgentTopicPrefix) {
 			sessionID := strings.TrimPrefix(item.Topic, contracts.AgentTopicPrefix)
 			if dedupeCache.Seen(item.DedupeKey, sessionID) {


### PR DESCRIPTION
Closes #423

## Summary

Adds `source_session` and `payload_summary` (truncated to 80 chars via `%.80s`) to the listener's receive log line in `packages/envoy/cmd/listener/main.go`. This enables diagnosing duplicate delivery issues by showing which session sent an event and a preview of its payload.

Single line change — both fields already exist on `contracts.Envelope`.