### PR TITLE
sjawhar-legion-443: add pre-approval merge conflict check

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,35 +1,22 @@
 {
   "filesChanged": [
-    "packages/daemon/src/knowledge/types.ts",
-    "packages/daemon/src/knowledge/feedback-logger.ts",
-    "packages/daemon/src/knowledge/collector.ts",
-    "packages/daemon/src/knowledge/aggregator.ts",
-    "packages/daemon/src/knowledge/rules.ts",
-    "packages/daemon/src/knowledge/front-matter.ts",
-    "packages/daemon/src/knowledge/promoter.ts",
-    "packages/daemon/src/knowledge/reporter.ts",
-    "packages/daemon/src/knowledge/consolidate.ts",
-    "packages/daemon/src/cli/index.ts",
-    ".opencode/skills/legion-retro/SKILL.md"
+    ".opencode/skills/legion-controller/SKILL.md",
+    ".opencode/skills/legion-worker/workflows/review.md"
   ],
-  "trickyParts": [
-    "Retro SKILL.md snippet needed env/homeDir params added post-review",
-    "scanForWorkspaceDirs was recursive causing timeout on real workspaces - fixed to shallow scan",
-    "collectWorkspaceIssue used legionId split instead of path.basename for issueId - fixed",
-    "Status values needed to be needs-review not review/stale - fixed"
-  ],
-  "deviations": [
-    "Subagents used different disposition names than plan (accepted/needs_review/archived/rejected vs promote/review/stale/keep) - functionally equivalent",
-    "Aggregator uses different field names (path/issues/touchedPaths) than plan"
-  ],
+  "trickyParts": [],
+  "deviations": [],
   "openQuestions": [],
+  "subPlanningNeeded": false,
   "learningsInjected": [
-    "daemon/handoff-schema-migration-patterns.md",
-    "task-index-patterns.md",
-    "skill-patterns/cross-cutting-workflow-concerns.md"
+    "skill-patterns/merge-retry-race-condition-pattern.md",
+    "skill-patterns/cross-cutting-workflow-concerns.md",
+    "integration-patterns/controller-worker-protocol.md"
   ],
-  "learningsHelpful": ["daemon/handoff-schema-migration-patterns.md", "task-index-patterns.md"],
+  "learningsHelpful": [
+    "skill-patterns/merge-retry-race-condition-pattern.md",
+    "integration-patterns/controller-worker-protocol.md"
+  ],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-11T22:47:00.374Z"
+  "completed": "2026-04-12T13:28:32.037Z"
 }

--- a/.legion/plan.json
+++ b/.legion/plan.json
@@ -1,35 +1,34 @@
 {
-  "taskCount": 3,
-  "independentTasks": 1,
+  "taskCount": 2,
+  "independentTasks": 2,
   "routingHints": {
-    "complexity": "medium",
+    "complexity": "small",
     "estimatedImplementers": 1,
-    "skipRetro": false,
-    "skipArchitect": false
+    "skipRetro": true,
+    "skipArchitect": true
   },
   "concerns": [
-    "Oracle simplicity review suggests collapsing 9 knowledge/ modules to 3-4 files (feedback-log.ts, consolidate.ts, apply.ts, types.ts) — implementer should evaluate",
-    "FileLearningFeedbackWriter log rotation is YAGNI — plain append-only JSONL is sufficient for acceptance criteria",
-    "trimToSoftCap may be scope expansion if not explicitly required by issue spec — verify before implementing",
-    "Path resolution helpers need traversal validation (reject .. paths) to prevent misclassification",
-    "Recursive .legion workspace scanning may be overkill — shallow scan of direct children is simpler and sufficient",
-    "Architect concern: index.json has pre-existing JSON syntax errors — consolidation must be resilient to malformed JSON",
-    "Architect concern: path canonicalization must strip docs/solutions/ prefix variants consistently",
-    "Architect concern: promotion key derivation must reuse exact retro directory-prefix rule"
+    "Review worker lacks Contents write permission — must NOT rebase or push; detect-and-stop only",
+    "State machine keys off prIsDraft, not GitHub review API state — reviewer must use draft status for signaling conflicts",
+    "UNKNOWN mergeability must be treated as non-pass at controller (fail closed), but pass-through at worker",
+    "Retro-skip path bypasses Pre-Merge Gate — needs its own inline mergeability check before dispatching merge"
   ],
   "learningsInjected": [
-    "daemon/handoff-schema-migration-patterns.md",
-    "task-index-patterns.md",
-    "skill-patterns/cross-cutting-workflow-concerns.md"
+    "skill-patterns/merge-retry-race-condition-pattern.md",
+    "skill-patterns/cross-cutting-workflow-concerns.md",
+    "integration-patterns/controller-worker-protocol.md"
   ],
-  "learningsHelpful": ["daemon/handoff-schema-migration-patterns.md", "task-index-patterns.md"],
-  "workflowRecommendation": "Standard pipeline — all phases needed. Medium complexity, single implementer. Retro workflow modification requires legion-retro skill.",
+  "learningsHelpful": [
+    "skill-patterns/merge-retry-race-condition-pattern.md",
+    "integration-patterns/controller-worker-protocol.md"
+  ],
+  "workflowRecommendation": "Simple docs-only fix — skip retro, single implementer. Two independent tasks can run in parallel but both touch the same controller file, so sequential is safer.",
   "requiredSkills": {
-    "implement": ["legion-retro"],
+    "implement": [],
     "test": [],
     "review": []
   },
   "schemaVersion": 1,
   "phase": "plan",
-  "completed": "2026-04-11T21:46:58.290Z"
+  "completed": "2026-04-12T00:06:18.564Z"
 }

--- a/.legion/retro.json
+++ b/.legion/retro.json
@@ -1,10 +1,7 @@
 {
-  "skipped": false,
-  "docsCreated": [
-    "docs/solutions/daemon/workspace-scanning-patterns.md",
-    "docs/solutions/delegation/subagent-plan-compliance.md"
-  ],
+  "skipped": true,
+  "reason": "no significant learnings — mechanical skill file edits following exact plan",
   "schemaVersion": 1,
   "phase": "retro",
-  "completed": "2026-04-11T23:13:43.152Z"
+  "completed": "2026-04-12T13:42:49.702Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,44 +1,26 @@
 {
   "critical": 0,
   "important": 0,
-  "minor": 5,
+  "minor": 1,
   "verdict": "approved",
   "keyFindings": [
     {
       "severity": "P3",
-      "file": "packages/daemon/src/knowledge/types.ts",
-      "description": "Dead type definitions (ConsolidationReport, IndexMutation, StatusMutation) have zero external references — superseded by implementation-specific types in consolidate.ts and promoter.ts"
-    },
-    {
-      "severity": "P3",
-      "file": "packages/daemon/src/knowledge/consolidate.ts",
-      "description": "Unused side-effect call on line 63: resolveLegionPaths return value discarded (appears to be validation)"
-    },
-    {
-      "severity": "P3",
-      "file": "packages/daemon/src/knowledge/collector.ts",
-      "description": "canonicalizeLearningPath doesn't strip ./docs/solutions/ prefix variant (minor edge case)"
-    },
-    {
-      "severity": "P3",
-      "file": "packages/daemon/src/knowledge/reporter.ts",
-      "description": "Disposition naming drift: JSON output uses internal names (accepted/needs_review/archived/rejected) vs spec (promote/review/stale/keep). Human report maps correctly."
-    },
-    {
-      "severity": "P3",
-      "file": "packages/daemon/src/knowledge/consolidate.ts",
-      "description": "generatedAt changes between idempotent runs (cosmetic, expected behavior)"
+      "file": ".opencode/skills/legion-controller/SKILL.md",
+      "description": "Two separate gh pr view API calls in retro-skip mergeability check could be combined into one"
     }
   ],
   "learningsInjected": [
-    "daemon/handoff-schema-migration-patterns.md",
-    "task-index-patterns.md",
+    "skill-patterns/merge-retry-race-condition-pattern.md",
+    "integration-patterns/controller-worker-protocol.md",
     "skill-patterns/cross-cutting-workflow-concerns.md"
   ],
   "learningsHelpful": [
-    "daemon/handoff-schema-migration-patterns.md"
+    "skill-patterns/merge-retry-race-condition-pattern.md",
+    "integration-patterns/controller-worker-protocol.md",
+    "skill-patterns/cross-cutting-workflow-concerns.md"
   ],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-11T23:01:45.681Z"
+  "completed": "2026-04-12T13:40:43.210Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,24 +1,18 @@
 {
-  "passed": 8,
+  "passed": 5,
   "failed": 0,
   "failures": [],
-  "documentationFeedback": "No README updates. CLI --help adequate. PR body clear. No docs on JSONL format or schema versioning.",
-  "observations": [
-    "P3: Human report omits per-learning injected/helpful/ratio stats (data only in --json)",
-    "P3: JSON disposition names use internal form (accepted/needs_review/archived/rejected) not spec form (promote/review/stale/keep)",
-    "P3: Malformed handoff JSON in workspace .legion/ dirs prints stack trace to stderr, not captured in report warnings",
-    "P3: canonicalizeLearningPath does not handle ./docs/solutions/ or absolute path variants",
-    "P3: generatedAt changes between idempotent runs (cosmetic)"
-  ],
+  "documentationFeedback": "PR body clearly describes the two-layer approach. No public docs needed — changes are internal agent skill files. Controller SKILL.md inline documentation is clear and actionable.",
+  "observations": [],
   "learningsInjected": [
-    "daemon/handoff-schema-migration-patterns.md",
-    "task-index-patterns.md",
+    "skill-patterns/merge-retry-race-condition-pattern.md",
+    "integration-patterns/controller-worker-protocol.md",
     "skill-patterns/cross-cutting-workflow-concerns.md"
   ],
   "learningsHelpful": [
-    "daemon/handoff-schema-migration-patterns.md"
+    "skill-patterns/merge-retry-race-condition-pattern.md"
   ],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-11T22:54:15.691Z"
+  "completed": "2026-04-12T13:33:54.605Z"
 }

--- a/.opencode/skills/legion-controller/SKILL.md
+++ b/.opencode/skills/legion-controller/SKILL.md
@@ -515,6 +515,17 @@ Before requesting merge approval, verify ALL conditions:
 | 4 | `test-passed` label present | `gh issue view $ISSUE_NUMBER --json labels -q '.labels[].name' -R $ISSUE_REPO \| grep test-passed` |
 | 5 | Issue has been through retro (or skipped via routing hints) | Check retro handoff: `legion handoff read --phase retro --workspace "$WORKSPACE_PATH" 2>/dev/null` or verify issue transitioned through Retro status |
 | 6 | No `user-input-needed` label present | `gh issue view $ISSUE_NUMBER --json labels -q '.labels[].name' -R $ISSUE_REPO \| grep -v user-input-needed` — must NOT match |
+| 7 | PR is mergeable (not CONFLICTING or UNKNOWN) | `gh pr view "$LEGION_ISSUE_ID" --json mergeable --jq '.mergeable' -R $ISSUE_REPO` returns `MERGEABLE` |
+
+**Mergeability gate (condition 7) — handling by state:**
+
+| `mergeable` value | Action |
+|-------------------|--------|
+| `MERGEABLE` | Proceed with approval flow |
+| `CONFLICTING` | Auto-rebase via existing pattern: `gh api repos/$ISSUE_REPO/pulls/$PR_NUMBER/update-branch -X PUT`. If successful, defer to next loop (CI re-runs). If failed, `resume_implementer_for_changes`. |
+| `UNKNOWN` / null / API failure | Defer to next loop. Do NOT add `needs-approval`. |
+
+**Resolving PR number:** `PR_NUMBER=$(gh pr view "$LEGION_ISSUE_ID" --json number --jq '.number' -R $ISSUE_REPO)`
 
 If ANY condition fails, do NOT request merge approval. Fix the failing condition first.
 
@@ -756,15 +767,33 @@ SKIP_RETRO=$(echo "$HANDOFF" | jq -r '.plan.routingHints.skipRetro // false')
 TRICKY_PARTS_COUNT=$(echo "$HANDOFF" | jq -r '(.implement.trickyParts // []) | length')
 DEVIATIONS_COUNT=$(echo "$HANDOFF" | jq -r '(.implement.deviations // []) | length')
 
+# Check mergeability before dispatching merge (retro-skip bypasses Pre-Merge Gate)
+LEGION_ISSUE_ID="$ISSUE_IDENTIFIER"
+PR_NUMBER=$(gh pr view "$LEGION_ISSUE_ID" --json number --jq '.number' -R $ISSUE_REPO 2>/dev/null)
+MERGEABLE=$(gh pr view "$LEGION_ISSUE_ID" --json mergeable --jq '.mergeable' -R $ISSUE_REPO 2>/dev/null)
+
 if [ "$SKIP_RETRO" = "true" ] && [ "$TRICKY_PARTS_COUNT" = "0" ] && [ "$DEVIATIONS_COUNT" = "0" ]; then
-  echo "Skipping retro: skipRetro=true with no implementer trickyParts/deviations; dispatching merger directly"
-  if [ "$LEGION_ISSUE_BACKEND" = "github" ]; then
-    legion dispatch "$ISSUE_IDENTIFIER" merge \
-      --repo "$ISSUE_REPO" \
-      --prompt "Invoke the /legion-worker skill for merge mode for $ISSUE_IDENTIFIER (github backend, repo: $ISSUE_REPO)"
+  if [ "$MERGEABLE" = "MERGEABLE" ]; then
+    echo "Skipping retro: skipRetro=true with no implementer trickyParts/deviations; dispatching merger directly"
+    if [ "$LEGION_ISSUE_BACKEND" = "github" ]; then
+      legion dispatch "$ISSUE_IDENTIFIER" merge \
+        --repo "$ISSUE_REPO" \
+        --prompt "Invoke the /legion-worker skill for merge mode for $ISSUE_IDENTIFIER (github backend, repo: $ISSUE_REPO)"
+    else
+      legion dispatch "$ISSUE_IDENTIFIER" merge \
+        --prompt "Invoke the /legion-worker skill for merge mode for $ISSUE_IDENTIFIER (linear backend)"
+    fi
+  elif [ "$MERGEABLE" = "CONFLICTING" ]; then
+    echo "Retro-skip: PR has merge conflicts — auto-rebasing before merge"
+    if ! gh api repos/$ISSUE_REPO/pulls/$PR_NUMBER/update-branch -X PUT 2>/dev/null; then
+      echo "Auto-rebase failed — resuming implementer to rebase manually"
+      legion prompt "$ISSUE_IDENTIFIER" --mode implement \
+        "Invoke the /legion-worker skill for implement mode. PR has merge conflicts that could not be auto-resolved. Rebase onto main and push. (${LEGION_ISSUE_BACKEND} backend, repo: $ISSUE_REPO)"
+    else
+      echo "Auto-rebase succeeded — deferring to next loop for CI"
+    fi
   else
-    legion dispatch "$ISSUE_IDENTIFIER" merge \
-      --prompt "Invoke the /legion-worker skill for merge mode for $ISSUE_IDENTIFIER (linear backend)"
+    echo "Retro-skip: mergeability unknown ($MERGEABLE) — deferring to next loop"
   fi
 else
   echo "Running full pipeline: retro required (missing/corrupt hints or skip conditions unmet)"

--- a/.opencode/skills/legion-worker/workflows/review.md
+++ b/.opencode/skills/legion-worker/workflows/review.md
@@ -160,6 +160,18 @@ Include the CI status in your review summary (step 3). If CI is failing, note wh
 checks are failing and treat it as a P1 issue — the implementer should have fixed this
 before opening the PR.
 
+### 2.7. Check PR Mergeability
+
+```bash
+MERGEABLE=$(gh pr view "$LEGION_ISSUE_ID" --json mergeable --jq '.mergeable' -R $OWNER/$REPO)
+```
+
+- **MERGEABLE:** Proceed to step 3.
+- **CONFLICTING:** P1 issue. Increment CRITICAL_COUNT. Include in review summary: "PR has merge conflicts with main. Implementer must rebase." Elevated CRITICAL_COUNT triggers changes-requested in step 5.
+- **UNKNOWN:** Proceed. Controller's Pre-Merge Gate is the primary gate.
+
+Do NOT rebase or push — review identity lacks Contents write permission.
+
 ### 3. Post Summary Comment
 
 Post a top-level PR comment with the review summary:


### PR DESCRIPTION
Closes #443

## Summary

Adds mergeability checks before requesting merge approval. Two layers of defense:

**Controller (primary):** Condition 7 in Pre-Merge Gate table checks `gh pr view --json mergeable` before adding `needs-approval`. CONFLICTING triggers auto-rebase via update-branch API with implementer fallback. UNKNOWN/null defers to next loop (fail closed). Retro-skip path gets the same gate — no more dispatching merge on stale PRs.

**Review workflow (defense-in-depth):** Step 2.7 between CI check and summary. Read-only — reviewer flags CONFLICTING as P1 (increments CRITICAL_COUNT → changes-requested via draft status). Does NOT rebase or push (lacks Contents write permission). UNKNOWN passes through since controller is the primary gate.

**Not changed:** test.md — existing `rebase_pr` action already catches conflicts at Needs Review transition.