### PR TITLE
fix(daemon): state delta notifications published to wrong Envoy topic

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,12 +1,20 @@
 {
-  "filesChanged": ["packages/envoy/cmd/listener/main.go"],
-  "trickyParts": [
-    "Rebase onto main caused .legion/plan.json conflicts from concurrent issue #240 merge — required resolving both ancestor commits (vuvz and wytu) separately"
-  ],
-  "deviations": [],
-  "openQuestions": [],
-  "subPlanningNeeded": false,
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-12T13:16:13.683Z"
+  "completed": "2026-04-12T14:07:17.088Z",
+  "filesChanged": [
+    "packages/daemon/src/daemon/server.ts",
+    "packages/daemon/src/daemon/index.ts",
+    "packages/daemon/src/daemon/__tests__/server.test.ts"
+  ],
+  "trickyParts": [
+    "Issue described a one-line fix but the publish topic change also required adding the new topic to the controller's explicit subscription list in index.ts to ensure delivery"
+  ],
+  "deviations": [
+    "Added subscription registration in index.ts (not mentioned in issue) — required because changing the publish topic without subscribing would break delivery"
+  ],
+  "openQuestions": [
+    "CI did not trigger on the PR branch — may need manual re-trigger or token permissions check"
+  ],
+  "subPlanningNeeded": false
 }

--- a/.legion/plan.json
+++ b/.legion/plan.json
@@ -1,15 +1,34 @@
 {
-  "taskCount": 2,
-  "independentTasks": 1,
-  "routingHints": {
-    "complexity": "small",
-    "estimatedImplementers": 1,
-    "skipRetro": true,
-    "skipArchitect": true
-  },
-  "concerns": [],
-  "workflowRecommendation": "Simple single-line fix — skip retro, single implementer",
   "schemaVersion": 1,
   "phase": "plan",
-  "completed": "2026-04-11T19:00:06.801Z"
+  "completed": "2026-04-12T00:06:18.564Z",
+  "learningsInjected": [
+    "skill-patterns/merge-retry-race-condition-pattern.md",
+    "skill-patterns/cross-cutting-workflow-concerns.md",
+    "integration-patterns/controller-worker-protocol.md"
+  ],
+  "learningsHelpful": [
+    "skill-patterns/merge-retry-race-condition-pattern.md",
+    "integration-patterns/controller-worker-protocol.md"
+  ],
+  "taskCount": 2,
+  "independentTasks": 2,
+  "routingHints": {
+    "skipRetro": true,
+    "skipArchitect": true,
+    "complexity": "small",
+    "estimatedImplementers": 1
+  },
+  "concerns": [
+    "Review worker lacks Contents write permission — must NOT rebase or push; detect-and-stop only",
+    "State machine keys off prIsDraft, not GitHub review API state — reviewer must use draft status for signaling conflicts",
+    "UNKNOWN mergeability must be treated as non-pass at controller (fail closed), but pass-through at worker",
+    "Retro-skip path bypasses Pre-Merge Gate — needs its own inline mergeability check before dispatching merge"
+  ],
+  "workflowRecommendation": "Simple docs-only fix — skip retro, single implementer. Two independent tasks can run in parallel but both touch the same controller file, so sequential is safer.",
+  "requiredSkills": {
+    "implement": [],
+    "test": [],
+    "review": []
+  }
 }

--- a/.legion/retro.json
+++ b/.legion/retro.json
@@ -1,7 +1,7 @@
 {
-  "skipped": false,
-  "docsCreated": ["docs/solutions/legion/handoff-file-conflicts-during-rebases.md"],
   "schemaVersion": 1,
   "phase": "retro",
-  "completed": "2026-04-12T13:34:36.609Z"
+  "completed": "2026-04-12T13:42:49.702Z",
+  "skipped": true,
+  "reason": "no significant learnings — mechanical skill file edits following exact plan"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,26 +1,12 @@
 {
-  "schemaVersion": 1,
-  "phase": "review",
-  "completed": "2026-04-12T13:40:43.210Z",
-  "learningsInjected": [
-    "skill-patterns/merge-retry-race-condition-pattern.md",
-    "integration-patterns/controller-worker-protocol.md",
-    "skill-patterns/cross-cutting-workflow-concerns.md"
-  ],
-  "learningsHelpful": [
-    "skill-patterns/merge-retry-race-condition-pattern.md",
-    "integration-patterns/controller-worker-protocol.md",
-    "skill-patterns/cross-cutting-workflow-concerns.md"
-  ],
   "critical": 0,
   "important": 0,
-  "minor": 1,
+  "minor": 0,
   "verdict": "approved",
-  "keyFindings": [
-    {
-      "severity": "P3",
-      "file": ".opencode/skills/legion-controller/SKILL.md",
-      "description": "Two separate gh pr view API calls in retro-skip mergeability check could be combined into one"
-    }
-  ]
+  "keyFindings": [],
+  "learningsInjected": [],
+  "learningsHelpful": [],
+  "schemaVersion": 1,
+  "phase": "review",
+  "completed": "2026-04-12T14:37:28.721Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,12 +1,26 @@
 {
-  "critical": 0,
-  "important": 0,
-  "minor": 0,
-  "verdict": "approved",
-  "keyFindings": [],
-  "learningsInjected": [],
-  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-12T13:26:47.926Z"
+  "completed": "2026-04-12T13:40:43.210Z",
+  "learningsInjected": [
+    "skill-patterns/merge-retry-race-condition-pattern.md",
+    "integration-patterns/controller-worker-protocol.md",
+    "skill-patterns/cross-cutting-workflow-concerns.md"
+  ],
+  "learningsHelpful": [
+    "skill-patterns/merge-retry-race-condition-pattern.md",
+    "integration-patterns/controller-worker-protocol.md",
+    "skill-patterns/cross-cutting-workflow-concerns.md"
+  ],
+  "critical": 0,
+  "important": 0,
+  "minor": 1,
+  "verdict": "approved",
+  "keyFindings": [
+    {
+      "severity": "P3",
+      "file": ".opencode/skills/legion-controller/SKILL.md",
+      "description": "Two separate gh pr view API calls in retro-skip mergeability check could be combined into one"
+    }
+  ]
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,14 +1,18 @@
 {
-  "passed": 3,
-  "failed": 0,
-  "failures": [],
-  "documentationFeedback": "PR body clearly describes change and purpose. No README updates needed — internal log format change. %.80s truncation documented.",
-  "observations": [
-    ".legion/plan.json and .legion/implement.json diffs are handoff data updates from re-implementation cycle, not part of feature change"
-  ],
-  "learningsInjected": [],
-  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-12T13:20:48.569Z"
+  "completed": "2026-04-12T13:33:54.605Z",
+  "learningsInjected": [
+    "skill-patterns/merge-retry-race-condition-pattern.md",
+    "integration-patterns/controller-worker-protocol.md",
+    "skill-patterns/cross-cutting-workflow-concerns.md"
+  ],
+  "learningsHelpful": [
+    "skill-patterns/merge-retry-race-condition-pattern.md"
+  ],
+  "passed": 5,
+  "failed": 0,
+  "failures": [],
+  "documentationFeedback": "PR body clearly describes the two-layer approach. No public docs needed — changes are internal agent skill files. Controller SKILL.md inline documentation is clear and actionable.",
+  "observations": []
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,18 +1,20 @@
 {
-  "schemaVersion": 1,
-  "phase": "test",
-  "completed": "2026-04-12T13:33:54.605Z",
   "learningsInjected": [
     "skill-patterns/merge-retry-race-condition-pattern.md",
     "integration-patterns/controller-worker-protocol.md",
     "skill-patterns/cross-cutting-workflow-concerns.md"
   ],
   "learningsHelpful": [
-    "skill-patterns/merge-retry-race-condition-pattern.md"
+    "integration-patterns/controller-worker-protocol.md"
   ],
-  "passed": 5,
+  "passed": 4,
   "failed": 0,
   "failures": [],
-  "documentationFeedback": "PR body clearly describes the two-layer approach. No public docs needed — changes are internal agent skill files. Controller SKILL.md inline documentation is clear and actionable.",
-  "observations": []
+  "documentationFeedback": "PR body clearly describes the two-layer fix (publish topic + subscription registration). Root cause, impact, and deviation necessity are well-documented. No public docs needed — internal daemon plumbing.",
+  "observations": [
+    "Pre-existing tsc deprecation warning for baseUrl in tsconfig.json — unrelated to PR"
+  ],
+  "schemaVersion": 1,
+  "phase": "test",
+  "completed": "2026-04-12T14:14:06.700Z"
 }

--- a/docs/solutions/daemon/envoy-topic-pubsub-symmetry.md
+++ b/docs/solutions/daemon/envoy-topic-pubsub-symmetry.md
@@ -1,0 +1,74 @@
+---
+title: "Envoy Topic Publish/Subscribe Symmetry"
+category: daemon
+tags:
+  - envoy
+  - topic-routing
+  - subscription
+  - silent-failure
+  - state-delta
+date: 2026-04-12
+status: active
+module: daemon
+related_issues:
+  - "#454"
+symptoms:
+  - "controller not receiving state deltas"
+  - "CI status changes not reaching controller"
+  - "state delta notifications silently dropped"
+  - "role-based topic delivery failing"
+  - "publishStateDelta messages lost"
+---
+
+# Envoy Topic Publish/Subscribe Symmetry
+
+Changing an Envoy publish topic without updating the corresponding subscription silently
+breaks delivery. There is no compile-time enforcement — topic strings are inline in both
+the publisher (`server.ts`) and subscriber (`index.ts`), and a mismatch produces zero errors.
+
+## The Pattern
+
+Envoy message delivery requires a **two-sided contract**:
+
+1. **Publisher** calls `/v1/messages/publish` with a topic string
+2. **Subscriber** registers interest in that topic via `/v1/interests/subscribe` or `/v1/roles/set`
+3. Envoy's `registry.Match()` connects the two at delivery time
+
+If either side changes independently, messages are published to a topic nobody listens on,
+or a session listens to a topic nobody publishes to. Both cases are silent.
+
+## Role Topics vs Explicit Subscriptions
+
+| Mechanism | Registration | Failure mode |
+|-----------|-------------|--------------|
+| `notifications.role.<role>` | `/v1/roles/set` (claim) | Role claim is non-fatal (`console.warn`). If it fails, the topic vanishes from interests. |
+| `notifications.<namespace>.<name>` | `/v1/interests/subscribe` (explicit) | Subscription is also non-fatal, but is a separate call that can be independently verified. |
+
+**Use role topics** when the recipient is dynamic (multiple sessions might hold the role
+at different times) and the publisher doesn't know the session ID.
+
+**Use explicit named topics** when the recipient is a known, stable component. For
+daemon→controller communication, the daemon already knows the controller's session ID and
+sets up its subscriptions — explicit topics are more reliable because they don't depend on
+the role claim succeeding.
+
+## Verification Checklist
+
+When changing any Envoy topic string:
+
+1. **Grep both sides**: Search the repo for the topic string in both publish and subscribe contexts
+2. **Check the subscription setup**: In `subscribeControllerToEnvoy()` (`index.ts`) for controller topics, or `subscribeWorkerToEnvoy()` for worker topics
+3. **Check the publisher**: In `publishStateDelta()` (`server.ts`) or wherever the message originates
+4. **Update tests**: Topic strings in test assertions are regression guards — update them to match
+
+## Example: Issue #454
+
+The daemon published state deltas to `notifications.role.legion-controller`. The controller's
+role claim registered this topic in its interests. But the role claim is fire-and-forget with
+`console.warn` on failure — if it fails silently, state deltas are dropped with no error.
+
+Worker completion notifications (sent via `envoy_send` to the session ID directly) still
+worked, masking the daemon-side delivery problem.
+
+The fix changed the publish topic to `notifications.legion.controller` (explicit, non-role)
+AND added it to the controller's subscription list. Both sides of the contract had to change.

--- a/docs/solutions/index.json
+++ b/docs/solutions/index.json
@@ -36,7 +36,8 @@
       "daemon/codebase-index-file-placement.md",
       "daemon/envoy-auto-subscription-patterns.md",
       "daemon/post-collection-processing-pattern.md",
-      "daemon/workspace-scanning-patterns.md"
+      "daemon/workspace-scanning-patterns.md",
+      "daemon/envoy-topic-pubsub-symmetry.md"
     ],
     "packages/daemon/src/cli": [
       "daemon/controller-lifecycle-separation.md",
@@ -522,7 +523,7 @@
     ],
     "tag:handoff": [
       "daemon/handoff-schema-migration-patterns.md",
-      "skill-patterns/agent-workflow-enforcement-patterns.md"
+      "skill-patterns/agent-workflow-enforcement-patterns.md",
       "legion/handoff-file-conflicts-during-rebases.md"
     ],
     "tag:zod": [
@@ -554,7 +555,7 @@
       "envoy/contracts-and-handler-patterns.md",
       "envoy/nats-bus-client-self-healing.md",
       "envoy/webhook-handler-extraction-and-testing.md",
-      "envoy/multi-layer-service-consolidation.md"
+      "envoy/multi-layer-service-consolidation.md",
       "legion/handoff-file-conflicts-during-rebases.md"
     ],
     "packages/envoy/internal/webhook": [
@@ -590,7 +591,8 @@
       "testing/bun-fetch-mocking-patterns.md",
       "envoy/listener-routing-by-topic-prefix.md",
       "envoy/nats-bus-client-self-healing.md",
-      "envoy/publish-payload-source-validation.md"
+      "envoy/publish-payload-source-validation.md",
+      "daemon/envoy-topic-pubsub-symmetry.md"
     ],
     "packages/envoy/internal/contracts": [
       "envoy/structured-json-summary-patterns.md",
@@ -738,7 +740,8 @@
     ],
     "tag:notifications": [
       "skill-patterns/worker-notification-conventions.md",
-      "daemon/envoy-auto-subscription-patterns.md"
+      "daemon/envoy-auto-subscription-patterns.md",
+      "daemon/envoy-topic-pubsub-symmetry.md"
     ],
     "tag:escalation": [
       "skill-patterns/worker-notification-conventions.md"
@@ -750,7 +753,7 @@
       "skill-patterns/merge-retry-race-condition-pattern.md"
     ],
     "tag:conflict-resolution": [
-      "skill-patterns/merge-retry-race-condition-pattern.md"
+      "skill-patterns/merge-retry-race-condition-pattern.md",
       "legion/handoff-file-conflicts-during-rebases.md"
     ],
     "tag:github-api": [
@@ -761,7 +764,8 @@
       "daemon/health-tick-baseline-isolation.md"
     ],
     "tag:state-delta": [
-      "daemon/health-tick-baseline-isolation.md"
+      "daemon/health-tick-baseline-isolation.md",
+      "daemon/envoy-topic-pubsub-symmetry.md"
     ],
     "tag:baseline-oscillation": [
       "daemon/health-tick-baseline-isolation.md"
@@ -778,12 +782,19 @@
     "packages/daemon/src/knowledge": [
       "daemon/workspace-scanning-patterns.md",
       "delegation/subagent-plan-compliance.md"
-    ]
     ],
     ".legion": [
       "legion/handoff-file-conflicts-during-rebases.md"
     ],
     "tag:jj": [
       "legion/handoff-file-conflicts-during-rebases.md"
+    ],
+    "tag:topic-routing": [
+      "daemon/envoy-topic-pubsub-symmetry.md",
+      "envoy/listener-routing-by-topic-prefix.md"
+    ],
+    "tag:silent-failure": [
+      "daemon/envoy-topic-pubsub-symmetry.md"
+    ]
   }
 }

--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -1289,7 +1289,7 @@ describe("daemon server", () => {
 
       expect(publishCalls.length).toBe(1);
       const payload = publishCalls[0]?.body as { topic: string; message: string };
-      expect(payload.topic).toBe("notifications.role.legion-controller");
+      expect(payload.topic).toBe("notifications.legion.controller");
       const delta = JSON.parse(payload.message) as {
         type: string;
         changes: {

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -162,7 +162,11 @@ async function subscribeControllerToEnvoy(sessionId: string, envoyUrl: string) {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       session_id: sessionId,
-      topics: ["notifications.slack.*.*.mention", "notifications.github.*.*.mention"],
+      topics: [
+        "notifications.legion.controller",
+        "notifications.slack.*.*.mention",
+        "notifications.github.*.*.mention",
+      ],
     }),
   })
     .then((res) => {

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -251,7 +251,7 @@ function publishStateDelta(delta: StateDelta, envoyUrl = "http://127.0.0.1:9020"
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      topic: "notifications.role.legion-controller",
+      topic: "notifications.legion.controller",
       message: JSON.stringify(delta),
     }),
   })


### PR DESCRIPTION
Closes #454

## Summary

State delta notifications from the daemon were published to the role-based topic
`notifications.role.legion-controller`, which depends on the controller's Envoy role
claim succeeding. The role claim is non-fatal and can fail silently, causing state
deltas (CI status changes, PR state updates, issue status transitions) to go
undelivered while worker completion notifications (sent via `envoy_send`) still work.

## Changes

- **server.ts**: Changed `publishStateDelta` topic from `notifications.role.legion-controller`
  to `notifications.legion.controller`
- **index.ts**: Added `notifications.legion.controller` to the controller's explicit Envoy
  subscription list so the new topic is actively subscribed
- **server.test.ts**: Updated assertion to match the new topic