### PR TITLE
sjawhar-legion-447: feat(daemon): session liveness detection in health tick

### DIFF
--- a/.legion/architect.json
+++ b/.legion/architect.json
@@ -1,10 +1,11 @@
 {
   "scope": "medium",
   "components": [
-    "packages/daemon/src/daemon/config.ts",
-    "packages/daemon/src/cli/index.ts",
     "packages/daemon/src/daemon/index.ts",
-    "packages/daemon/src/daemon/server.ts"
+    "packages/daemon/src/daemon/runtime/types.ts",
+    "packages/daemon/src/daemon/runtime/opencode.ts",
+    "packages/daemon/src/daemon/server.ts",
+    "packages/daemon/src/daemon/multi-serve.ts"
   ],
   "subIssues": [],
   "routingHints": {
@@ -13,16 +14,16 @@
     "skipRetro": false
   },
   "concerns": [
-    "startDaemon() currently overrides config.daemonPort via registry allocation — port from config must be authoritative",
-    "ENVOY_URL and LEGION_FEEDBACK_* are read directly from process.env outside loadConfig() — must migrate to config object",
-    "Relative paths in YAML (workspace, private_key_path) must resolve relative to config file directory, not cwd",
-    "extra_projects is GitHub-multi-board only — Linear backend with extra_projects should error",
-    "Deprecation warnings should only fire when env var is the effective value, not when overridden",
-    "Unknown key warnings must cover full key paths (nested), not just top-level keys"
+    "getSessionStatus() masks dead sessions by defaulting to { type: 'idle' } for non-existent sessions (opencode.ts:97) — liveness check must use session existence in the status map, not status type",
+    "Health tick must NOT run liveness checks on ticks that just restarted the serve — newly recreated sessions would be immediately reaped",
+    "Workers in 'starting' status should be excluded from liveness checks — they may not have sessions yet",
+    "Multi-serve: workers on role-specific serves must be checked against the correct serve instance via roleServeManager",
+    "RuntimeAdapter needs a new bulk method (listActiveSessions) — per-worker getSessionStatus calls are N+1 and mask missing sessions",
+    "Dead-marking logic in server.ts (crash history, Envoy detach) may need extraction for reuse by health tick in index.ts"
   ],
   "learningsInjected": [
-    "delegation/hardening-patterns.md",
-    "daemon/controller-lifecycle-separation.md",
+    "daemon/health-tick-baseline-isolation.md",
+    "daemon/opencode-serve-lifecycle.md",
     "daemon/shared-serve-refactor.md"
   ],
   "learningsHelpful": [
@@ -30,5 +31,5 @@
   ],
   "schemaVersion": 1,
   "phase": "architect",
-  "completed": "2026-04-11T21:45:53.294Z"
+  "completed": "2026-04-12T13:43:44.429Z"
 }

--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,12 +1,43 @@
 {
-  "filesChanged": ["packages/envoy/cmd/listener/main.go"],
-  "trickyParts": [
-    "Rebase onto main caused .legion/plan.json conflicts from concurrent issue #240 merge — required resolving both ancestor commits (vuvz and wytu) separately"
+  "filesChanged": [
+    "packages/daemon/src/daemon/runtime/types.ts",
+    "packages/daemon/src/daemon/runtime/opencode.ts",
+    "packages/daemon/src/daemon/runtime/claude-code.ts",
+    "packages/daemon/src/daemon/feedback.ts",
+    "packages/daemon/src/daemon/index.ts",
+    "packages/daemon/src/daemon/__tests__/index.test.ts",
+    "packages/daemon/src/daemon/__tests__/feedback.test.ts",
+    "packages/daemon/src/daemon/__tests__/multi-serve.test.ts",
+    "packages/daemon/src/daemon/__tests__/server.test.ts",
+    "packages/daemon/src/daemon/__tests__/session-id-contract.test.ts",
+    "packages/daemon/src/daemon/__tests__/feedback.integration.test.ts",
+    "packages/daemon/src/__tests__/integration.test.ts"
   ],
-  "deviations": [],
-  "openQuestions": [],
+  "trickyParts": [
+    "Brace nesting in the health tick is deep (10+ levels) — the liveness sweep adds another 3-4 levels of nesting on top",
+    "The union approach for multi-serve required tracking both restartedRoles AND failedRoles to avoid false positives",
+    "Cross-family review caught that the initial implementation was missing failedRoles tracking and PATCH response checking — both were in the plan but missed by the subagent"
+  ],
+  "deviations": [
+    "Added failedRoles tracking to skip workers on role serves that failed listActiveSessions — was in the plan but initially missed",
+    "Added PATCH response.ok check before emitting daemon.worker_reaped — Oracle review caught this gap",
+    "Resolved serveType dynamically from worker mode instead of hardcoding 'shared' — Oracle review improvement"
+  ],
+  "openQuestions": [
+    "No concurrency protection between state file read and PATCH — a newly replaced worker could theoretically be marked dead by a stale sweep. Low risk since health tick runs every 60s."
+  ],
   "subPlanningNeeded": false,
+  "learningsInjected": [
+    "daemon/health-tick-baseline-isolation.md",
+    "daemon/shared-serve-refactor.md",
+    "daemon/opencode-serve-lifecycle.md",
+    "testing/bun-fetch-mocking-patterns.md"
+  ],
+  "learningsHelpful": [
+    "daemon/shared-serve-refactor.md",
+    "daemon/opencode-serve-lifecycle.md"
+  ],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-12T13:16:13.683Z"
+  "completed": "2026-04-12T14:55:02.810Z"
 }

--- a/.legion/plan.json
+++ b/.legion/plan.json
@@ -1,15 +1,30 @@
 {
-  "taskCount": 2,
-  "independentTasks": 1,
+  "taskCount": 3,
+  "independentTasks": 2,
   "routingHints": {
     "complexity": "small",
     "estimatedImplementers": 1,
-    "skipRetro": true,
-    "skipArchitect": true
+    "skipRetro": false,
+    "skipArchitect": false
   },
-  "concerns": [],
-  "workflowRecommendation": "Simple single-line fix — skip retro, single implementer",
+  "concerns": [
+    "Startup session recreation uses shared adapter for ALL workers including role workers — union approach in liveness handles this routing ambiguity",
+    "Test harness must use startDaemonForTest + captured timeoutCallback pattern, not direct startDaemon",
+    "All 5 test files with RuntimeAdapter mocks need listActiveSessions added for type check",
+    "Session-ID-mismatch scenario acknowledged in existing code — liveness checks by ID presence in bulk status map, not status type",
+    "PATCH to daemon's own HTTP API requires mockable fetch in DaemonDependencies (already injectable)"
+  ],
+  "learningsInjected": [
+    "daemon/health-tick-baseline-isolation.md",
+    "daemon/shared-serve-refactor.md",
+    "daemon/opencode-serve-lifecycle.md"
+  ],
+  "learningsHelpful": [
+    "daemon/shared-serve-refactor.md",
+    "daemon/opencode-serve-lifecycle.md"
+  ],
+  "workflowRecommendation": "Standard pipeline — all phases needed. Medium complexity, single implementer.",
   "schemaVersion": 1,
   "phase": "plan",
-  "completed": "2026-04-11T19:00:06.801Z"
+  "completed": "2026-04-12T14:12:59.838Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,12 +1,23 @@
 {
   "critical": 0,
   "important": 0,
-  "minor": 0,
+  "minor": 2,
   "verdict": "approved",
-  "keyFindings": [],
+  "keyFindings": [
+    {
+      "severity": "P3",
+      "file": "packages/daemon/src/daemon/index.ts",
+      "description": "Deep nesting in health tick (10+ levels) with liveness sweep adding 3-4 more — consider extracting into helper function"
+    },
+    {
+      "severity": "P3",
+      "file": "packages/daemon/src/daemon/__tests__/index.test.ts",
+      "description": "Missing edge case tests for multi-worker selective reaping, PATCH non-ok response, and role serve failedRoles/restartedRoles integration"
+    }
+  ],
   "learningsInjected": [],
   "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-12T13:26:47.926Z"
+  "completed": "2026-04-12T16:34:53.967Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,14 +1,19 @@
 {
-  "passed": 3,
+  "passed": 8,
   "failed": 0,
   "failures": [],
-  "documentationFeedback": "PR body clearly describes change and purpose. No README updates needed — internal log format change. %.80s truncation documented.",
+  "documentationFeedback": "PR body is comprehensive — clearly describes the change, architecture (union approach), guards, and AC coverage table. No README updates needed for internal daemon feature.",
   "observations": [
-    ".legion/plan.json and .legion/implement.json diffs are handoff data updates from re-implementation cycle, not part of feature change"
+    "Deep nesting in health tick (10+ levels with liveness sweep) — may benefit from extraction in future refactor",
+    "workerMode = worker.id.split('-').pop() pattern is fragile if worker ID format changes, but matches existing codebase patterns",
+    "P2: Missing edge case test coverage (positive case, multi-worker, PATCH failure, role serve integration) — core paths well-tested"
   ],
-  "learningsInjected": [],
+  "learningsInjected": [
+    "daemon/health-tick-baseline-isolation.md",
+    "testing/bun-fetch-mocking-patterns.md"
+  ],
   "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-12T13:20:48.569Z"
+  "completed": "2026-04-12T16:29:34.552Z"
 }

--- a/docs/solutions/daemon/liveness-sweep-multi-serve-patterns.md
+++ b/docs/solutions/daemon/liveness-sweep-multi-serve-patterns.md
@@ -1,0 +1,122 @@
+---
+title: "Liveness Sweep: Multi-Serve Session Detection Patterns"
+category: daemon
+tags:
+  - health-tick
+  - liveness
+  - multi-serve
+  - session-management
+  - union-aggregation
+  - false-positive-prevention
+date: 2026-04-12
+status: active
+module: daemon
+related_issues:
+  - "447"
+symptoms:
+  - "workers show status running but serve sessions are dead"
+  - "daemon restart leaves workers silently stalling"
+  - "health tick does not detect dead serve sessions"
+---
+
+# Liveness Sweep: Multi-Serve Session Detection Patterns
+
+## Problem
+
+After a daemon restart, workers show status "running" but their serve sessions are gone. The health tick checked shared serve health but never verified individual sessions existed. Workers sat "running" indefinitely with no output.
+
+## Solution: Union-Based Session Liveness
+
+The health tick now collects active sessions from all serves (shared + role) into a union `Set<string>`, then checks each running worker's session ID against the union. Workers absent from the union are marked dead via the existing `PATCH /workers/:id` cleanup path.
+
+## Key Patterns
+
+### 1. Dual Failure-Tracking Sets
+
+Two distinct failure modes require separate tracking to avoid false positives:
+
+```typescript
+const restartedRoles = new Set<string>(); // populated during role health check
+const failedRoles = new Set<string>();    // populated during liveness query
+```
+
+- **`restartedRoles`**: A restarted serve has fresh sessions — old worker session IDs won't match, producing false positives.
+- **`failedRoles`**: A serve that threw on `listActiveSessions()` means incomplete data — workers on that serve must not be reaped.
+
+Both sets are checked before marking any worker dead:
+
+```typescript
+if (roleAdapter !== resolvedDeps.adapter &&
+    (failedRoles.has(role) || restartedRoles.has(role))) {
+  continue; // skip — can't determine liveness for this worker
+}
+```
+
+**Critical lesson**: The "obvious" guard (restart) is easy to implement; the "subtle" guard (query failure) is easy to miss. Both are required.
+
+### 2. Primary Source Gate (`sharedServeQueried`)
+
+The reap loop is gated on a boolean set only when the shared serve query succeeds:
+
+```typescript
+let sharedServeQueried = false;
+if (serveHealthy && !restartReason) {
+  try {
+    const sessions = await adapter.listActiveSessions();
+    for (const s of sessions) allActiveSessions.add(s);
+    sharedServeQueried = true;
+  } catch { /* non-fatal */ }
+}
+// ...role serve queries...
+if (sharedServeQueried) {
+  // reap loop runs only with a reliable baseline
+}
+```
+
+This is better than checking `allActiveSessions.size > 0` (wrong if the serve genuinely has zero sessions). The pattern: use a boolean gate for "primary source succeeded," not the aggregated data's emptiness.
+
+### 3. Feedback Events After Confirmed State Change
+
+Only emit `daemon.worker_reaped` after the PATCH confirms success:
+
+```typescript
+const patchRes = await fetch(url, { method: "PATCH", ... });
+if (patchRes.ok) {
+  feedbackLogger?.log({ event: "daemon.worker_reaped", ... });
+}
+```
+
+Any feedback event representing a state change should be emitted only after the operation confirms success. Otherwise, monitoring sees a "reaped" event but the worker is still running.
+
+### 4. Self-HTTP PATCH for Cleanup Reuse
+
+Rather than extracting the dead-marking logic (crash history, Envoy detach, state persistence), the sweep calls the daemon's own `PATCH /workers/:id` endpoint. This reuses all existing cleanup without code duplication. Tradeoff: requires injectable `fetch` in `DaemonDependencies` (already present).
+
+## Testing Pattern
+
+Health tick tests capture the `setTimeout` callback and invoke it manually:
+
+```typescript
+let timeoutCallback: TimeoutCallback | null = null;
+const mockSetTimeout = Object.assign(
+  ((callback, _delay, ..._args) => {
+    timeoutCallback = callback;
+    return {} as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout,
+  { __promisify__: setTimeout.__promisify__ }  // Required for TypeScript
+);
+```
+
+The `__promisify__` assignment is non-obvious but required to satisfy `typeof setTimeout`.
+
+## Known Limitation
+
+No concurrency protection between reading the state file and PATCHing the worker. A newly replaced worker could theoretically be marked dead by a stale sweep. Low risk: the health tick runs every 60s, and the PATCH endpoint validates the worker still exists.
+
+## Generalization
+
+When aggregating data from multiple independent sources where partial failure matters:
+1. Track failures per source, not globally
+2. Gate the consumer on the primary source's success
+3. Skip consumers that depend on failed sources
+4. Emit side effects (events, notifications) only after confirmed state changes

--- a/docs/solutions/delegation/cross-family-review-validates-subagent-output.md
+++ b/docs/solutions/delegation/cross-family-review-validates-subagent-output.md
@@ -1,0 +1,70 @@
+---
+title: "Cross-Family Review Validates Subagent Output Against Plans"
+category: delegation
+tags:
+  - cross-family-review
+  - subagent-fidelity
+  - plan-compliance
+  - oracle-review
+  - quality-gates
+date: 2026-04-12
+status: active
+module: daemon
+related_issues:
+  - "447"
+symptoms:
+  - "subagent implements plan partially — omits guards or error handling"
+  - "plan has correct code but subagent drops subtle requirements"
+  - "tests pass but production edge cases are unhandled"
+---
+
+# Cross-Family Review Validates Subagent Output Against Plans
+
+## Problem
+
+When delegating implementation to subagents with detailed plans, the subagent may implement the "happy path" correctly but omit guards, error handling, or subtle requirements that were explicitly in the plan. This produces code that passes tests but fails in production edge cases.
+
+## Observed Pattern
+
+In issue #447, the plan explicitly included:
+1. `failedRoles` tracking — skip workers on role serves that failed `listActiveSessions()`
+2. PATCH response checking — only emit `daemon.worker_reaped` after `patchRes.ok`
+3. Dynamic `serveType` resolution — don't hardcode `"shared"` for all workers
+
+The implementing subagent (GPT-5.4 via `deep` category) produced working code that passed 37 tests but:
+- Dropped `failedRoles` entirely (only had `restartedRoles`)
+- Emitted the feedback event regardless of PATCH success
+- Hardcoded `serveType: "shared"` for all workers
+
+All three were caught by the cross-family Oracle review (Claude Opus).
+
+## Why This Happens
+
+Subagents optimize for "get tests to pass" rather than "implement the full spec." When the plan has both obvious guards (restart check) and subtle guards (query failure check), the subagent tends to implement only the obvious ones. The subtle guards don't have corresponding test failures to drive their implementation.
+
+## Mitigation
+
+### 1. Cross-Family Review Is Non-Optional for Medium+ Complexity
+
+The implement workflow's step 5 (cross-family review) caught all three issues. This validates that the review step is not ceremonial — it provides genuine coverage that tests alone don't.
+
+### 2. Tests Should Cover Subtle Guards
+
+The plan's testing section included a test for `failedRoles` but the subagent didn't implement it. When delegating both implementation and tests to the same subagent, the subagent may omit tests for the same guards it omitted in production code. Consider delegating test writing separately, or including explicit "must test X" assertions in the delegation prompt.
+
+### 3. Delegation Prompts Should Flag Critical Guards
+
+In the delegation prompt's "MUST DO" section, explicitly call out guards that are easy to miss:
+
+```
+MUST DO:
+- Track failedRoles separately from restartedRoles
+- Check patchRes.ok before emitting feedback events
+- Resolve serveType dynamically, not hardcode "shared"
+```
+
+The plan had the right code but the delegation prompt didn't flag these as critical. Adding explicit "MUST DO" for subtle requirements improves fidelity.
+
+## Generalization
+
+When a plan is detailed enough to include code snippets, the delegation should verify the subagent used ALL snippets, not just the main implementation path. The cross-family review (Oracle or equivalent) is the verification mechanism. Skipping it for "simple" changes risks the exact class of bugs this caught.

--- a/docs/solutions/index.json
+++ b/docs/solutions/index.json
@@ -36,7 +36,8 @@
       "daemon/codebase-index-file-placement.md",
       "daemon/envoy-auto-subscription-patterns.md",
       "daemon/post-collection-processing-pattern.md",
-      "daemon/workspace-scanning-patterns.md"
+      "daemon/workspace-scanning-patterns.md",
+      "daemon/liveness-sweep-multi-serve-patterns.md"
     ],
     "packages/daemon/src/cli": [
       "daemon/controller-lifecycle-separation.md",
@@ -218,7 +219,8 @@
     "tag:delegation": [
       "delegation/delegation-hardening-retro.md",
       "delegation/hardening-patterns.md",
-      "delegation/subagent-plan-compliance.md"
+      "delegation/subagent-plan-compliance.md",
+      "delegation/cross-family-review-validates-subagent-output.md"
     ],
     "tag:dependency-injection": [
       "architecture-patterns/sync-to-async-modular-refactoring.md",
@@ -522,7 +524,7 @@
     ],
     "tag:handoff": [
       "daemon/handoff-schema-migration-patterns.md",
-      "skill-patterns/agent-workflow-enforcement-patterns.md"
+      "skill-patterns/agent-workflow-enforcement-patterns.md",
       "legion/handoff-file-conflicts-during-rebases.md"
     ],
     "tag:zod": [
@@ -554,7 +556,7 @@
       "envoy/contracts-and-handler-patterns.md",
       "envoy/nats-bus-client-self-healing.md",
       "envoy/webhook-handler-extraction-and-testing.md",
-      "envoy/multi-layer-service-consolidation.md"
+      "envoy/multi-layer-service-consolidation.md",
       "legion/handoff-file-conflicts-during-rebases.md"
     ],
     "packages/envoy/internal/webhook": [
@@ -750,7 +752,7 @@
       "skill-patterns/merge-retry-race-condition-pattern.md"
     ],
     "tag:conflict-resolution": [
-      "skill-patterns/merge-retry-race-condition-pattern.md"
+      "skill-patterns/merge-retry-race-condition-pattern.md",
       "legion/handoff-file-conflicts-during-rebases.md"
     ],
     "tag:github-api": [
@@ -758,7 +760,8 @@
       "github-api/graphql-org-user-fallback.md"
     ],
     "tag:health-tick": [
-      "daemon/health-tick-baseline-isolation.md"
+      "daemon/health-tick-baseline-isolation.md",
+      "daemon/liveness-sweep-multi-serve-patterns.md"
     ],
     "tag:state-delta": [
       "daemon/health-tick-baseline-isolation.md"
@@ -778,12 +781,29 @@
     "packages/daemon/src/knowledge": [
       "daemon/workspace-scanning-patterns.md",
       "delegation/subagent-plan-compliance.md"
-    ]
     ],
     ".legion": [
       "legion/handoff-file-conflicts-during-rebases.md"
     ],
     "tag:jj": [
       "legion/handoff-file-conflicts-during-rebases.md"
+    ],
+    "tag:liveness": [
+      "daemon/liveness-sweep-multi-serve-patterns.md"
+    ],
+    "tag:multi-serve": [
+      "daemon/liveness-sweep-multi-serve-patterns.md"
+    ],
+    "tag:cross-family-review": [
+      "delegation/cross-family-review-validates-subagent-output.md"
+    ],
+    "tag:subagent-fidelity": [
+      "delegation/cross-family-review-validates-subagent-output.md"
+    ],
+    "tag:session-management": [
+      "daemon/worker-directory-resolution.md",
+      "controller/controller-session-anti-patterns.md",
+      "daemon/liveness-sweep-multi-serve-patterns.md"
+    ]
   }
 }

--- a/packages/daemon/src/__tests__/integration.test.ts
+++ b/packages/daemon/src/__tests__/integration.test.ts
@@ -38,6 +38,7 @@ async function withTestServer(run: (ctx: TestServerContext) => Promise<void>): P
       data: undefined,
     }),
     deleteSession: async () => {},
+    listActiveSessions: async (): Promise<Set<string>> => new Set<string>(),
   };
   const { server, stop } = startServer({
     port: randomPort(),

--- a/packages/daemon/src/daemon/__tests__/feedback.integration.test.ts
+++ b/packages/daemon/src/daemon/__tests__/feedback.integration.test.ts
@@ -21,6 +21,7 @@ function makeAdapter(): RuntimeAdapter {
     sendPrompt: async () => {},
     getSessionStatus: async () => ({ data: undefined }),
     deleteSession: async () => {},
+    listActiveSessions: async () => new Set<string>(),
   };
 }
 

--- a/packages/daemon/src/daemon/__tests__/feedback.test.ts
+++ b/packages/daemon/src/daemon/__tests__/feedback.test.ts
@@ -226,8 +226,8 @@ describe("FeedbackLogger", () => {
     await logger.flush();
 
     expect(writer.lines).toHaveLength(2);
-    expect((JSON.parse(writer.lines[0]) as FeedbackEvent).issueId).toBe("ENG-21");
-    expect((JSON.parse(writer.lines[1]) as FeedbackEvent).issueId).toBe("ENG-22");
+    expect((JSON.parse(writer.lines[0]) as { issueId: string }).issueId).toBe("ENG-21");
+    expect((JSON.parse(writer.lines[1]) as { issueId: string }).issueId).toBe("ENG-22");
     expect(writer.flushCalls).toBe(1);
   });
 
@@ -276,6 +276,34 @@ describe("FeedbackLogger", () => {
     if (event.event === "daemon.health_tick") {
       expect(event.workerCount).toBe(3);
     }
+  });
+
+  it("validates daemon.worker_reaped event", () => {
+    const event = {
+      schemaVersion: 1,
+      timestamp: "2026-04-12T00:00:00.000Z",
+      legionId: "test-team",
+      event: "daemon.worker_reaped" as const,
+      workerId: "test-repo-42-implement",
+      sessionId: "ses_abc123def456ABCDEFGHIJKLMN",
+      mode: "implement",
+      serveType: "shared",
+      reason: "session_missing",
+    };
+    const result = FeedbackEventSchema.safeParse(event);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects daemon.worker_reaped with missing fields", () => {
+    const event = {
+      schemaVersion: 1,
+      timestamp: "2026-04-12T00:00:00.000Z",
+      legionId: "test-team",
+      event: "daemon.worker_reaped" as const,
+      workerId: "test-repo-42-implement",
+    };
+    const result = FeedbackEventSchema.safeParse(event);
+    expect(result.success).toBe(false);
   });
 });
 

--- a/packages/daemon/src/daemon/__tests__/index.test.ts
+++ b/packages/daemon/src/daemon/__tests__/index.test.ts
@@ -106,6 +106,7 @@ function makeAdapter(overrides?: {
   stopServeCalls?: number[];
   createSessionCalls?: Array<{ sessionId: string; workspace: string }>;
   getServePid?: () => number;
+  listActiveSessions?: () => Promise<Set<string>>;
 }): RuntimeAdapter {
   const createSessionCalls = overrides?.createSessionCalls ?? [];
   const stopServeCalls = overrides?.stopServeCalls ?? [];
@@ -130,6 +131,7 @@ function makeAdapter(overrides?: {
     },
     getSessionStatus: async () => ({ data: undefined }),
     deleteSession: async () => {},
+    listActiveSessions: overrides?.listActiveSessions ?? (async () => new Set<string>()),
   };
 }
 
@@ -1906,5 +1908,270 @@ describe("daemon entry", () => {
       // No restart should happen — getServePid returns 0
       expect(stopCalls).toHaveLength(0);
     });
+  });
+
+  it("marks running worker as dead when session is missing from serve", async () => {
+    let timeoutCallback: TimeoutCallback | null = null;
+    const mockSetTimeout: typeof setTimeout = Object.assign(
+      ((callback: TimeoutCallback, _delay?: number, ..._args: unknown[]) => {
+        timeoutCallback = callback as TimeoutCallback;
+        return {} as ReturnType<typeof setTimeout>;
+      }) as unknown as typeof setTimeout,
+      { __promisify__: setTimeout.__promisify__ }
+    );
+
+    const patchCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
+
+    await startDaemonForTest(
+      {
+        stateFilePath: "/tmp/daemon-workers.json",
+        checkIntervalMs: 1000,
+        legionId: TEAM_ID,
+        controllerSessionId: "ses_test",
+      },
+      {
+        readStateFile: async () => ({
+          workers: { [baseEntry.id]: baseEntry },
+          crashHistory: {},
+        }),
+        writeStateFile: async () => {},
+        adapter: makeAdapter({
+          listActiveSessions: async () => new Set<string>(),
+        }),
+        startServer: () => ({
+          server: { port: 15555 } as ReturnType<typeof Bun.serve>,
+          stop: () => {},
+          fetchAndProcessState: async () => {},
+        }),
+        setTimeout: mockSetTimeout,
+        clearTimeout: () => {},
+        fetch: Object.assign(
+          async (input: string | URL | Request, init?: RequestInit) => {
+            const url =
+              typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+            if (url.includes("/workers/") && init?.method === "PATCH") {
+              patchCalls.push({
+                url,
+                body: JSON.parse(String(init.body ?? "{}")) as Record<string, unknown>,
+              });
+              return new Response("{}", { status: 200 });
+            }
+            return originalFetch(input, init);
+          },
+          { preconnect: originalFetch.preconnect }
+        ) as typeof fetch,
+      }
+    );
+
+    if (!timeoutCallback) {
+      throw new Error("Expected health loop callback to be scheduled");
+    }
+    await (timeoutCallback as () => Promise<void>)();
+
+    expect(patchCalls).toHaveLength(1);
+    expect(patchCalls[0]?.url).toContain(`/workers/${baseEntry.id}`);
+    expect(patchCalls[0]?.body.status).toBe("dead");
+    expect(patchCalls[0]?.body.crashCount).toBe(1);
+  });
+
+  it("does not mark workers dead when listActiveSessions fails", async () => {
+    let timeoutCallback: TimeoutCallback | null = null;
+    const mockSetTimeout: typeof setTimeout = Object.assign(
+      ((callback: TimeoutCallback, _delay?: number, ..._args: unknown[]) => {
+        timeoutCallback = callback as TimeoutCallback;
+        return {} as ReturnType<typeof setTimeout>;
+      }) as unknown as typeof setTimeout,
+      { __promisify__: setTimeout.__promisify__ }
+    );
+
+    const patchCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
+
+    await startDaemonForTest(
+      {
+        stateFilePath: "/tmp/daemon-workers.json",
+        checkIntervalMs: 1000,
+        legionId: TEAM_ID,
+        controllerSessionId: "ses_test",
+      },
+      {
+        readStateFile: async () => ({
+          workers: { [baseEntry.id]: baseEntry },
+          crashHistory: {},
+        }),
+        writeStateFile: async () => {},
+        adapter: makeAdapter({
+          listActiveSessions: async () => {
+            throw new Error("connection refused");
+          },
+        }),
+        startServer: () => ({
+          server: { port: 15555 } as ReturnType<typeof Bun.serve>,
+          stop: () => {},
+          fetchAndProcessState: async () => {},
+        }),
+        setTimeout: mockSetTimeout,
+        clearTimeout: () => {},
+        fetch: Object.assign(
+          async (input: string | URL | Request, init?: RequestInit) => {
+            const url =
+              typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+            if (url.includes("/workers/") && init?.method === "PATCH") {
+              patchCalls.push({
+                url,
+                body: JSON.parse(String(init.body ?? "{}")) as Record<string, unknown>,
+              });
+              return new Response("{}", { status: 200 });
+            }
+            return originalFetch(input, init);
+          },
+          { preconnect: originalFetch.preconnect }
+        ) as typeof fetch,
+      }
+    );
+
+    if (!timeoutCallback) {
+      throw new Error("Expected health loop callback to be scheduled");
+    }
+    await (timeoutCallback as () => Promise<void>)();
+
+    expect(patchCalls).toHaveLength(0);
+  });
+
+  it("skips liveness check when serve was restarted this tick", async () => {
+    let timeoutCallback: TimeoutCallback | null = null;
+    const mockSetTimeout: typeof setTimeout = Object.assign(
+      ((callback: TimeoutCallback, _delay?: number, ..._args: unknown[]) => {
+        timeoutCallback = callback as TimeoutCallback;
+        return {} as ReturnType<typeof setTimeout>;
+      }) as unknown as typeof setTimeout,
+      { __promisify__: setTimeout.__promisify__ }
+    );
+
+    let healthCallCount = 0;
+    let listActiveSessionsCalls = 0;
+    const patchCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
+
+    await startDaemonForTest(
+      {
+        stateFilePath: "/tmp/daemon-workers.json",
+        checkIntervalMs: 1000,
+        legionId: TEAM_ID,
+        controllerSessionId: "ses_test",
+      },
+      {
+        readStateFile: async () => ({
+          workers: { [baseEntry.id]: baseEntry },
+          crashHistory: {},
+        }),
+        writeStateFile: async () => {},
+        adapter: makeAdapter({
+          healthy: async () => {
+            healthCallCount += 1;
+            if (healthCallCount === 1) return true;
+            if (healthCallCount === 2) return false;
+            return true;
+          },
+          listActiveSessions: async () => {
+            listActiveSessionsCalls += 1;
+            return new Set<string>();
+          },
+        }),
+        startServer: () => ({
+          server: { port: 15555 } as ReturnType<typeof Bun.serve>,
+          stop: () => {},
+          fetchAndProcessState: async () => {},
+        }),
+        setTimeout: mockSetTimeout,
+        clearTimeout: () => {},
+        fetch: Object.assign(
+          async (input: string | URL | Request, init?: RequestInit) => {
+            const url =
+              typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+            if (url.includes("/workers/") && init?.method === "PATCH") {
+              patchCalls.push({
+                url,
+                body: JSON.parse(String(init.body ?? "{}")) as Record<string, unknown>,
+              });
+              return new Response("{}", { status: 200 });
+            }
+            return originalFetch(input, init);
+          },
+          { preconnect: originalFetch.preconnect }
+        ) as typeof fetch,
+      }
+    );
+
+    if (!timeoutCallback) {
+      throw new Error("Expected health loop callback to be scheduled");
+    }
+    await (timeoutCallback as () => Promise<void>)();
+
+    expect(listActiveSessionsCalls).toBe(0);
+    expect(patchCalls).toHaveLength(0);
+  });
+
+  it("does not check liveness of workers in starting status", async () => {
+    let timeoutCallback: TimeoutCallback | null = null;
+    const mockSetTimeout: typeof setTimeout = Object.assign(
+      ((callback: TimeoutCallback, _delay?: number, ..._args: unknown[]) => {
+        timeoutCallback = callback as TimeoutCallback;
+        return {} as ReturnType<typeof setTimeout>;
+      }) as unknown as typeof setTimeout,
+      { __promisify__: setTimeout.__promisify__ }
+    );
+
+    const startingEntry: WorkerEntry = {
+      ...baseEntry,
+      status: "starting",
+    };
+    const patchCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
+
+    await startDaemonForTest(
+      {
+        stateFilePath: "/tmp/daemon-workers.json",
+        checkIntervalMs: 1000,
+        legionId: TEAM_ID,
+        controllerSessionId: "ses_test",
+      },
+      {
+        readStateFile: async () => ({
+          workers: { [startingEntry.id]: startingEntry },
+          crashHistory: {},
+        }),
+        writeStateFile: async () => {},
+        adapter: makeAdapter({
+          listActiveSessions: async () => new Set<string>(),
+        }),
+        startServer: () => ({
+          server: { port: 15555 } as ReturnType<typeof Bun.serve>,
+          stop: () => {},
+          fetchAndProcessState: async () => {},
+        }),
+        setTimeout: mockSetTimeout,
+        clearTimeout: () => {},
+        fetch: Object.assign(
+          async (input: string | URL | Request, init?: RequestInit) => {
+            const url =
+              typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+            if (url.includes("/workers/") && init?.method === "PATCH") {
+              patchCalls.push({
+                url,
+                body: JSON.parse(String(init.body ?? "{}")) as Record<string, unknown>,
+              });
+              return new Response("{}", { status: 200 });
+            }
+            return originalFetch(input, init);
+          },
+          { preconnect: originalFetch.preconnect }
+        ) as typeof fetch,
+      }
+    );
+
+    if (!timeoutCallback) {
+      throw new Error("Expected health loop callback to be scheduled");
+    }
+    await (timeoutCallback as () => Promise<void>)();
+
+    expect(patchCalls).toHaveLength(0);
   });
 });

--- a/packages/daemon/src/daemon/__tests__/multi-serve.test.ts
+++ b/packages/daemon/src/daemon/__tests__/multi-serve.test.ts
@@ -39,6 +39,9 @@ function createMockAdapter(port: number): RuntimeAdapter & {
       return { data: { type: "idle" } };
     },
     async deleteSession() {},
+    async listActiveSessions() {
+      return new Set(sessions.keys());
+    },
   };
 }
 

--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -63,6 +63,7 @@ describe("daemon server", () => {
       deleteSession: async (sessionId: string) => {
         deleteSessionCalls.push(sessionId);
       },
+      listActiveSessions: async () => new Set<string>(),
     };
   }
 

--- a/packages/daemon/src/daemon/__tests__/session-id-contract.test.ts
+++ b/packages/daemon/src/daemon/__tests__/session-id-contract.test.ts
@@ -41,6 +41,7 @@ describe("sessionId contract (daemon vs state)", () => {
       sendPrompt: async () => {},
       getSessionStatus: async () => ({ data: undefined }),
       deleteSession: async () => {},
+      listActiveSessions: async () => new Set<string>(),
     };
 
     tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-session-contract-"));
@@ -88,6 +89,7 @@ describe("sessionId contract (daemon vs state)", () => {
       sendPrompt: async () => {},
       getSessionStatus: async () => ({ data: undefined }),
       deleteSession: async () => {},
+      listActiveSessions: async () => new Set<string>(),
     };
 
     tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-session-contract-"));
@@ -141,6 +143,7 @@ describe("sessionId contract (daemon vs state)", () => {
       },
       getSessionStatus: async () => ({ data: undefined }),
       deleteSession: async () => {},
+      listActiveSessions: async () => new Set<string>(),
     };
 
     tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-session-contract-"));

--- a/packages/daemon/src/daemon/feedback.ts
+++ b/packages/daemon/src/daemon/feedback.ts
@@ -59,11 +59,21 @@ export const HealthTickEventSchema = FeedbackEventBase.extend({
   rssRestarts: z.number().int().nonnegative(),
 });
 
+export const WorkerReapedEventSchema = FeedbackEventBase.extend({
+  event: z.literal("daemon.worker_reaped"),
+  workerId: z.string(),
+  sessionId: z.string(),
+  mode: z.string(),
+  serveType: z.string(),
+  reason: z.string(),
+});
+
 export const FeedbackEventSchema = z.discriminatedUnion("event", [
   WorkerDispatchedEventSchema,
   WorkerStatusChangedEventSchema,
   StateCollectedEventSchema,
   HealthTickEventSchema,
+  WorkerReapedEventSchema,
 ]);
 
 type WorkerDispatchedEvent = z.infer<typeof WorkerDispatchedEventSchema>;
@@ -72,12 +82,14 @@ type StateCollectedEvent = z.infer<typeof StateCollectedEventSchema>;
 type HealthTickEvent = z.infer<typeof HealthTickEventSchema> & {
   issueId?: undefined;
 };
+type WorkerReapedEvent = z.infer<typeof WorkerReapedEventSchema>;
 
 export type FeedbackEvent =
   | WorkerDispatchedEvent
   | WorkerStatusChangedEvent
   | StateCollectedEvent
-  | HealthTickEvent;
+  | HealthTickEvent
+  | WorkerReapedEvent;
 
 type OmitFeedbackBase<TEvent> = TEvent extends unknown
   ? Omit<TEvent, "schemaVersion" | "timestamp" | "legionId">

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -732,6 +732,8 @@ export async function startDaemon(
           console.error(`Failed to update codebase index incrementally: ${error}`);
         }
 
+        const restartedRoles = new Set<string>();
+
         // Check role serves health
         if (roleServeManager?.hasRoleServes()) {
           const unhealthyRoles = await roleServeManager.checkHealth();
@@ -745,6 +747,7 @@ export async function startDaemon(
                 config.logDir
               );
               roleServeRestarts += 1;
+              restartedRoles.add(role);
               console.log(`Role serve '${role}' restarted`);
               // Re-create sessions for workers on this role
               const roleAdapter = roleServeManager.getAdapterForRole(role);
@@ -762,6 +765,118 @@ export async function startDaemon(
             } catch (restartError) {
               console.error(`Failed to restart role serve '${role}': ${restartError}`);
             }
+          }
+        }
+
+        // Session liveness sweep — detect dead serve sessions (AC1-AC8)
+        const allActiveSessions = new Set<string>();
+        let sharedServeQueried = false;
+        const failedRoles = new Set<string>();
+
+        if (serveHealthy && !restartReason) {
+          try {
+            const sessions = await resolvedDeps.adapter.listActiveSessions();
+            for (const s of sessions) allActiveSessions.add(s);
+            sharedServeQueried = true;
+          } catch (err) {
+            console.warn(`[liveness] Shared serve session list failed (non-fatal): ${err}`);
+          }
+        }
+
+        if (roleServeManager?.hasRoleServes()) {
+          for (const roleEntry of roleServeManager.getEntries()) {
+            if (restartedRoles.has(roleEntry.role)) continue;
+            try {
+              const sessions = await roleEntry.adapter.listActiveSessions();
+              for (const s of sessions) allActiveSessions.add(s);
+            } catch (err) {
+              failedRoles.add(roleEntry.role);
+              console.warn(
+                `[liveness] Role serve '${roleEntry.role}' session list failed (non-fatal): ${err}`
+              );
+            }
+          }
+        }
+
+        if (sharedServeQueried) {
+          try {
+            const livenessState = await resolvedDeps.readStateFile(config.stateFilePath);
+
+            for (const worker of Object.values(livenessState.workers)) {
+              if (worker.status !== "running") continue;
+              if (allActiveSessions.has(worker.sessionId)) continue;
+
+              const workerMode = worker.id.split("-").pop();
+
+              // Skip workers whose role serve was restarted or failed listing this tick
+              if (roleServeManager?.hasRoleServes() && workerMode) {
+                try {
+                  const role = modeToRole(workerMode);
+                  const roleAdapter = roleServeManager.getAdapterForRole(role);
+                  if (
+                    roleAdapter !== resolvedDeps.adapter &&
+                    (failedRoles.has(role) || restartedRoles.has(role))
+                  ) {
+                    continue;
+                  }
+                } catch {
+                  // Unknown mode — only shared serve matters
+                }
+              }
+
+              const now = new Date().toISOString();
+              try {
+                const patchRes = await resolvedDeps.fetch(
+                  `http://127.0.0.1:${config.daemonPort}/workers/${worker.id}`,
+                  {
+                    method: "PATCH",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                      status: "dead",
+                      crashCount: worker.crashCount + 1,
+                      lastCrashAt: now,
+                    }),
+                  }
+                );
+
+                if (patchRes.ok) {
+                  // Determine serve type for feedback event
+                  let serveType = "shared";
+                  if (roleServeManager?.hasRoleServes() && workerMode) {
+                    try {
+                      const role = modeToRole(workerMode);
+                      const roleAdapter = roleServeManager.getAdapterForRole(role);
+                      if (roleAdapter !== resolvedDeps.adapter) {
+                        serveType = `role:${role}`;
+                      }
+                    } catch {
+                      // Unknown mode — shared serve
+                    }
+                  }
+
+                  feedbackLogger?.log({
+                    event: "daemon.worker_reaped",
+                    workerId: worker.id,
+                    sessionId: worker.sessionId,
+                    mode: workerMode ?? "unknown",
+                    serveType,
+                    reason: "session_missing",
+                  });
+
+                  console.warn(
+                    `[liveness] Reaped worker ${worker.id}: session ${worker.sessionId} not found`
+                  );
+                } else {
+                  console.warn(
+                    `[liveness] PATCH to mark worker ${worker.id} as dead returned ${patchRes.status}`
+                  );
+                }
+              } catch (patchErr) {
+                console.warn(`[liveness] Failed to mark worker ${worker.id} as dead: ${patchErr}`);
+              }
+            }
+          } catch (livenessErr) {
+            console.warn(`[liveness] Session liveness check failed (non-fatal): ${livenessErr}`);
           }
         }
 

--- a/packages/daemon/src/daemon/runtime/claude-code.ts
+++ b/packages/daemon/src/daemon/runtime/claude-code.ts
@@ -153,4 +153,20 @@ export class ClaudeCodeAdapter implements RuntimeAdapter {
     }
     return "none";
   }
+
+  async listActiveSessions(): Promise<Set<string>> {
+    const result = this.spawn([
+      "tmux",
+      "list-windows",
+      "-t",
+      this.sessionName,
+      "-F",
+      "#{window_name}",
+    ]);
+    if (result.exitCode !== 0) {
+      throw new Error(`Failed to list tmux windows for session ${this.sessionName}`);
+    }
+    const windowNames = (result.stdout ?? "").split("\n").filter(Boolean);
+    return new Set(windowNames);
+  }
 }

--- a/packages/daemon/src/daemon/runtime/opencode.ts
+++ b/packages/daemon/src/daemon/runtime/opencode.ts
@@ -146,4 +146,13 @@ export class OpenCodeAdapter implements RuntimeAdapter {
       return { data: sessionStatus };
     }
   }
+
+  async listActiveSessions(): Promise<Set<string>> {
+    const client = createWorkerClient(this.port, "");
+    const result = await client.session.status();
+    if (result.error || !result.data) {
+      throw new Error(`Failed to list sessions: ${JSON.stringify(result.error ?? "no data")}`);
+    }
+    return new Set(Object.keys(result.data as Record<string, unknown>));
+  }
 }

--- a/packages/daemon/src/daemon/runtime/types.ts
+++ b/packages/daemon/src/daemon/runtime/types.ts
@@ -33,4 +33,6 @@ export interface RuntimeAdapter {
 
   /** Get the PID of the serve process (0 if not applicable or not started). */
   getServePid(): number;
+  /** Return the set of session IDs currently known to the serve. */
+  listActiveSessions(): Promise<Set<string>>;
 }


### PR DESCRIPTION
Closes #447

## Summary

Adds session liveness detection to the daemon health tick so dead serve sessions are detected and workers are transitioned to `dead` instead of silently stalling after a daemon restart.

### Changes

- **RuntimeAdapter extension**: New `listActiveSessions(): Promise<Set<string>>` method. OpenCodeAdapter uses the existing `client.session.status()` bulk endpoint. ClaudeCodeAdapter lists tmux windows.
- **Feedback schema**: New `daemon.worker_reaped` event with workerId, sessionId, mode, serveType, reason.
- **Liveness sweep in health tick**: After all restart handling, collects active sessions from all serves (shared + role) into a union set. Running workers whose session ID is missing are marked dead via `PATCH /workers/:id`, reusing existing cleanup path (crash history, Envoy detach, state persistence).
- **Guards**: Skip when serve restarted this tick, skip `starting`/`dead`/`stopped` workers, skip role workers when their role serve query failed or was restarted.
- **Correctness**: Only emits `daemon.worker_reaped` after PATCH confirms `ok`. Resolves `serveType` dynamically from worker mode.

### Testing

- 4 new liveness sweep tests (happy path, transient error, restart guard, starting worker exclusion)
- 2 new feedback schema tests
- All 902 daemon tests pass
- `tsc --noEmit` clean, `biome check` clean

### AC Coverage

| AC | Description | Implementation |
|----|-------------|----------------|
| AC1 | Session liveness detection | Health tick checks running workers against session list |
| AC2 | Batch efficiency | One `listActiveSessions()` call per serve per tick |
| AC3 | Healthy-serve prerequisite | Liveness only runs when serve healthy AND not restarted |
| AC4 | Transient error resilience | Failed serve queries skip those workers |
| AC5 | Dead worker cleanup | Reuses existing PATCH path (crash history, Envoy, persist) |
| AC6 | Controller notification | `daemon.worker_reaped` feedback event after successful PATCH |
| AC7 | Role serve coverage | Union from all serves, failed/restarted role serves skip |
| AC8 | RuntimeAdapter extension | `listActiveSessions()` on all adapters |