### PR TITLE
chore: publish opencode-legion plugin to npm with OIDC

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   version:
@@ -123,7 +124,7 @@ jobs:
           path: legion-${{ matrix.target }}.tar.gz
 
   plugin:
-    name: Build Plugin
+    name: Build and Publish Plugin
     needs: version
     if: needs.version.outputs.should_release == 'true'
     runs-on: ubuntu-24.04
@@ -132,6 +133,11 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -145,6 +151,24 @@ jobs:
 
       - name: Build plugin
         run: bun run build
+        working-directory: packages/opencode-plugin
+
+      - name: Check if already published
+        id: check
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/@sjawhar%2Fopencode-legion/${VERSION}")
+          if [ "$STATUS" = "200" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "✓ @sjawhar/opencode-legion@${VERSION} already published"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        if: steps.check.outputs.skip != 'true'
+        run: npm publish --access public --provenance
         working-directory: packages/opencode-plugin
 
       - name: Pack plugin

--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,4 +1,13 @@
 {
+  "pr": "https://github.com/sjawhar/legion/pull/462",
+  "filesChanged": [
+    "packages/opencode-plugin/package.json",
+    ".github/workflows/release.yaml"
+  ],
+  "summary": "Published opencode-legion plugin to npm as @sjawhar/opencode-legion using OIDC. Updated package.json name/publishConfig, added id-token:write permission and npm publish step to release.yaml.",
+  "concerns": [],
+  "testStatus": "pre-existing failures only (58 fail, unrelated to changes)",
   "schemaVersion": 1,
-  "phase": "unknown"
+  "phase": "implement",
+  "completed": "2026-04-12T17:22:54.181Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,4 +1,10 @@
 {
+  "verdict": "approved",
+  "pr": "https://github.com/sjawhar/legion/pull/462",
+  "summary": "PR approved. All 4 requirements met. OIDC pattern matches reference (release-envoy-and-plugin.yaml). CI green. No blocking issues.",
+  "findings": [],
+  "concerns": [],
   "schemaVersion": 1,
-  "phase": "unknown"
+  "phase": "review",
+  "completed": "2026-04-12T20:37:58.033Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,4 +1,31 @@
 {
+  "verdict": "pass",
+  "summary": "All 4 acceptance criteria verified. CI green (lint, typecheck, test). Workflow structure correct. Shell.env hook confirmed in built bundle.",
+  "findings": [],
+  "criteriaResults": [
+    {
+      "criterion": "Add npm publish to release workflow using OIDC pattern",
+      "result": "pass",
+      "evidence": "plugin job in release.yaml uses setup-node with registry-url + npm publish --provenance + id-token:write permission"
+    },
+    {
+      "criterion": "Package name @sjawhar/opencode-legion",
+      "result": "pass",
+      "evidence": "packages/opencode-plugin/package.json name field is @sjawhar/opencode-legion"
+    },
+    {
+      "criterion": "Include shell.env hook in published bundle",
+      "result": "pass",
+      "evidence": "github-app-credentials.ts imported in src/index.ts, shell.env handler at line 216, confirmed present in dist/index.js after build"
+    },
+    {
+      "criterion": "Update daemon file:// to npm package reference",
+      "result": "pass",
+      "evidence": "packages/daemon/src/daemon/index.ts line 199 already uses @sjawhar/opencode-legion@latest (pre-existing, no change needed)"
+    }
+  ],
+  "notes": "Package not yet on npm (404) — will publish on next release trigger. bin field points to src/cli/index.ts (pre-existing, requires Bun runtime, intentional). No files/.npmignore means src/ will be included in published package (pre-existing, not introduced by this PR).",
   "schemaVersion": 1,
-  "phase": "unknown"
+  "phase": "test",
+  "completed": "2026-04-12T20:34:39.348Z"
 }

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "packages/daemon": {
       "name": "legion",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "bin": {
         "legion": "src/cli/index.ts",
       },
@@ -49,8 +49,8 @@
       },
     },
     "packages/opencode-plugin": {
-      "name": "opencode-legion",
-      "version": "0.16.0",
+      "name": "@sjawhar/opencode-legion",
+      "version": "0.16.1",
       "bin": {
         "opencode-legion": "./src/cli/index.ts",
       },
@@ -92,7 +92,9 @@
 
     "@opencode-ai/plugin": ["@opencode-ai/plugin@1.2.27", "", { "dependencies": { "@opencode-ai/sdk": "1.2.27", "zod": "4.1.8" } }, "sha512-h+8Bw9v9nghMg7T+SUCTzxlIhOrsTqXW7U0HVLGQST5DjbN7uyCUM51roZWZ8LRjGxzbzFhvPnY1bj8i+ioZyw=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@https://github.com/sjawhar/opencode/releases/download/v1.2.4-post.2/opencode-ai-sdk-1.2.4-post.1.tgz", {}, "sha512-ZRTvyD3GnUpUJ8kMLdeBH9rbtb3oC3hVvMSMdxW8B4ohLfTgUh/5vdDd6nG4vaUG+KqtN56KDltu6s6/TpN3yQ=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.2.27", "", {}, "sha512-Wk0o/I+Fo+wE3zgvlJDs8Fb67KlKqX0PrV8dK5adSDkANq6r4Z25zXJg2iOir+a8ntg3rAcpel1OY4FV/TwRUA=="],
+
+    "@sjawhar/opencode-legion": ["@sjawhar/opencode-legion@workspace:packages/opencode-plugin"],
 
     "@sjawhar/opencode-legion-envoy": ["@sjawhar/opencode-legion-envoy@workspace:packages/envoy-plugin"],
 
@@ -105,8 +107,6 @@
     "citty": ["citty@0.2.1", "", {}, "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg=="],
 
     "legion": ["legion@workspace:packages/daemon"],
-
-    "opencode-legion": ["opencode-legion@workspace:packages/opencode-plugin"],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -124,22 +124,20 @@
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "@opencode-ai/plugin/@opencode-ai/sdk": ["@opencode-ai/sdk@1.2.27", "", {}, "sha512-Wk0o/I+Fo+wE3zgvlJDs8Fb67KlKqX0PrV8dK5adSDkANq6r4Z25zXJg2iOir+a8ntg3rAcpel1OY4FV/TwRUA=="],
-
     "@opencode-ai/plugin/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
+
+    "@sjawhar/opencode-legion/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
+    "legion/@opencode-ai/sdk": ["@opencode-ai/sdk@https://github.com/sjawhar/opencode/releases/download/v1.2.4-post.2/opencode-ai-sdk-1.2.4-post.1.tgz", {}, "sha512-ZRTvyD3GnUpUJ8kMLdeBH9rbtb3oC3hVvMSMdxW8B4ohLfTgUh/5vdDd6nG4vaUG+KqtN56KDltu6s6/TpN3yQ=="],
 
     "legion/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "legion/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "opencode-legion/@opencode-ai/sdk": ["@opencode-ai/sdk@1.2.27", "", {}, "sha512-Wk0o/I+Fo+wE3zgvlJDs8Fb67KlKqX0PrV8dK5adSDkANq6r4Z25zXJg2iOir+a8ntg3rAcpel1OY4FV/TwRUA=="],
-
-    "opencode-legion/@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
-
     "vscode-languageserver-protocol/vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
 
-    "legion/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "@sjawhar/opencode-legion/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
-    "opencode-legion/@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+    "legion/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
   }
 }

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,9 +1,16 @@
 {
-  "name": "opencode-legion",
+  "name": "@sjawhar/opencode-legion",
   "version": "0.16.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sjawhar/legion"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "opencode-legion": "./src/cli/index.ts"
   },


### PR DESCRIPTION
## Summary

Publishes `packages/opencode-plugin/` to npm as `@sjawhar/opencode-legion` using the same OIDC pattern as `@sjawhar/opencode-legion-envoy`.

## Changes

- **`packages/opencode-plugin/package.json`**: Rename package from `opencode-legion` to `@sjawhar/opencode-legion`, add `repository` and `publishConfig` fields
- **`.github/workflows/release.yaml`**: Add `id-token: write` permission, `setup-node` with npm registry, idempotency check, and `npm publish --access public --provenance` step to the plugin job

## Notes

- The daemon already references `@sjawhar/opencode-legion@latest` in `packages/daemon/src/daemon/index.ts` (no change needed there)
- The `bin` command name `opencode-legion` and internal plugin name strings are unchanged — only the npm package name changes
- Idempotency check prevents re-publishing if the version already exists on npm

Closes #461