### PR TITLE
fix(daemon): liveness sweep uses session list instead of status endpoint

### DIFF
--- a/packages/daemon/src/daemon/runtime/__tests__/opencode.test.ts
+++ b/packages/daemon/src/daemon/runtime/__tests__/opencode.test.ts
@@ -334,4 +334,44 @@ describe("OpenCodeAdapter", () => {
       expect(data.tokensUsed).toBe(1500); // only from second message
     });
   });
+  describe("listActiveSessions", () => {
+    it("returns all sessions including idle ones (not just busy)", async () => {
+      const adapter = new OpenCodeAdapter(13381);
+      const originalFetch = globalThis.fetch;
+      try {
+        globalThis.fetch = (async (url: string | URL | Request) => {
+          const urlStr = String(url);
+          if (urlStr.includes("/session") && !urlStr.includes("/session/")) {
+            return new Response(
+              JSON.stringify([{ id: "ses_busy_1" }, { id: "ses_idle_2" }, { id: "ses_idle_3" }]),
+              { status: 200 }
+            );
+          }
+          return originalFetch(url);
+        }) as typeof fetch;
+
+        const sessions = await adapter.listActiveSessions();
+        expect(sessions.size).toBe(3);
+        expect(sessions.has("ses_busy_1")).toBe(true);
+        expect(sessions.has("ses_idle_2")).toBe(true);
+        expect(sessions.has("ses_idle_3")).toBe(true);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("throws on non-200 response", async () => {
+      const adapter = new OpenCodeAdapter(13381);
+      const originalFetch = globalThis.fetch;
+      try {
+        globalThis.fetch = Object.assign(async () => new Response("error", { status: 500 }), {
+          preconnect: originalFetch.preconnect,
+        }) as typeof fetch;
+
+        await expect(adapter.listActiveSessions()).rejects.toThrow("HTTP 500");
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  });
 });

--- a/packages/daemon/src/daemon/runtime/opencode.ts
+++ b/packages/daemon/src/daemon/runtime/opencode.ts
@@ -148,11 +148,14 @@ export class OpenCodeAdapter implements RuntimeAdapter {
   }
 
   async listActiveSessions(): Promise<Set<string>> {
-    const client = createWorkerClient(this.port, "");
-    const result = await client.session.status();
-    if (result.error || !result.data) {
-      throw new Error(`Failed to list sessions: ${JSON.stringify(result.error ?? "no data")}`);
+    // Use the session list endpoint (GET /session) which returns ALL sessions (busy + idle).
+    // The previous implementation used session.status() which only returns BUSY sessions,
+    // causing idle workers to be falsely marked as dead.
+    const res = await fetch(`http://127.0.0.1:${this.port}/session`);
+    if (!res.ok) {
+      throw new Error(`Failed to list sessions: HTTP ${res.status}`);
     }
-    return new Set(Object.keys(result.data as Record<string, unknown>));
+    const sessions = (await res.json()) as Array<{ id: string }>;
+    return new Set(sessions.map((s) => s.id));
   }
 }


### PR DESCRIPTION
Closes #497

## Summary

The `listActiveSessions()` method was calling `session.status()` which only returns **BUSY** sessions. Idle workers (between prompts, waiting for Envoy notifications) were not returned, causing the liveness sweep to falsely mark them as dead (`crash=1`).

## Root Cause

- `GET /session/status` returns only sessions currently processing a prompt (5 out of 100 sessions)
- `GET /session` returns ALL sessions including idle ones (100 sessions)
- The liveness sweep compared workers against the status endpoint, so any worker not actively processing was marked dead

## Fix

Changed `listActiveSessions()` in `runtime/opencode.ts` to use `GET /session` (session list) instead of `session.status()` (busy-only status).

## Tests

Added 2 tests to `opencode.test.ts`:
- Verifies all sessions (busy + idle) are returned
- Verifies error handling on non-200 response

All 17 OpenCode adapter tests pass. TypeScript clean.

## Impact

This was marking 14 of 15 workers as dead overnight, preventing the daemon from managing them. Every worker that finished a prompt and went idle was falsely reaped on the next health tick.