### PR TITLE
sjawhar-legion-272: add repetitive tool use circuit breaker

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,28 +1,21 @@
 {
-  "summary": "Implemented tracked issue notifications for targeted controller delta filtering",
   "filesChanged": [
-    "packages/daemon/src/daemon/state-delta.ts",
-    "packages/daemon/src/daemon/server.ts",
-    "packages/daemon/src/cli/index.ts",
-    "packages/daemon/src/daemon/__tests__/state-delta.test.ts",
-    "packages/daemon/src/daemon/__tests__/server.test.ts"
+    "packages/opencode-plugin/src/config/index.ts",
+    "packages/opencode-plugin/src/hooks/circuit-breaker.ts",
+    "packages/opencode-plugin/src/hooks/__tests__/circuit-breaker.test.ts",
+    "packages/opencode-plugin/src/index.ts"
   ],
-  "concerns": [],
-  "testResults": {
-    "stateDelta": "26 pass (8 new trackedIssueIds tests)",
-    "server": "165 pass (16 new tracking/materialized tests)",
-    "fullSuite": "1313 pass, 2 pre-existing failures in ledger.test.ts and serve-manager.test.ts (unrelated)"
-  },
-  "designDecisions": [
-    "trackedIssueIds undefined = full delta (backward compat)",
-    "new issues always flow regardless of tracked set",
-    "changed/removed filtered to tracked set when provided",
-    "auto-track on POST /workers dispatch",
-    "auto-untrack on cleanupDoneIssueWorkers for all Done issues",
-    "newIssuesSinceLastPoll accumulator drains on GET /state/materialized read",
-    "legion poll now calls GET /state/materialized instead of POST /state/fetch-and-collect"
+  "trickyParts": [
+    "output.args is the source of parsed tool input in tool.execute.before — not input.args. Using input.args would cause the hook to always see the raw args, not the parsed ones.",
+    "JSON.stringify key order is not guaranteed — needed sortedStringify with recursive key sorting for stable arg hashing across different key insertion orders.",
+    "Duplicate CircuitBreakerConfig interface existed in both config/index.ts and circuit-breaker.ts initially — consolidated to import from config (single source of truth)."
   ],
+  "deviations": [
+    "Plan had duplicate CircuitBreakerConfig interface in circuit-breaker.ts — cross-family review caught this, consolidated to import from config/index.ts instead."
+  ],
+  "openQuestions": [],
+  "subPlanningNeeded": false,
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-13T01:05:11.122Z"
+  "completed": "2026-04-13T05:33:10.900Z"
 }

--- a/.legion/retro.json
+++ b/.legion/retro.json
@@ -1,11 +1,9 @@
 {
   "skipped": false,
   "docs": [
-    "docs/solutions/infra/pulumi-aws-identity-center-patterns.md",
-    "docs/solutions/infra/mixed-runtime-type-boundaries.md"
+    "docs/solutions/architecture-patterns/opencode-plugin-hook-authoring-patterns.md"
   ],
-  "summary": "Documented Pulumi AWS Identity Center resource patterns (async data source wrapping, Output unwrapping, stable GroupMembership naming, SCIM vs Pulumi groups, optional config). Updated mixed-runtime-type-boundaries.md with Bun workspace exclusion pattern (explicit list vs packages/*).",
   "schemaVersion": 1,
   "phase": "retro",
-  "completed": "2026-04-13T01:20:01.519Z"
+  "completed": "2026-04-13T05:52:32.529Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,33 +1,23 @@
 {
-  "critical": 1,
-  "important": 1,
+  "critical": 0,
+  "important": 0,
   "minor": 2,
-  "verdict": "changes_requested",
+  "verdict": "approved",
   "keyFindings": [
     {
-      "severity": "P1",
-      "file": ".legion/implement.json",
-      "description": "PR has merge conflicts with main — both this branch and a parallel PR added .legion/implement.json and .legion/retro.json independently. Code changes in packages/opencode-plugin/ do not conflict. Implementer must rebase."
-    },
-    {
-      "severity": "P2",
-      "file": "packages/opencode-plugin/src/delegation/background-manager.ts",
-      "description": "No test verifying spawn limits are enforced after rehydrate() — rehydration code appears correct but is untested for limit enforcement"
+      "severity": "P3",
+      "file": "packages/opencode-plugin/src/hooks/__tests__/circuit-breaker.test.ts",
+      "description": "Console.warn leaks to test runner output in the 'does not throw on trigger when action is warn' test — cosmetic only"
     },
     {
       "severity": "P3",
-      "file": "packages/opencode-plugin/src/delegation/background-manager.ts",
-      "description": "Misleading rootDescendantCounts.delete(task.sessionID) in error handler — no-op for non-root tasks, only applies to root tasks"
-    },
-    {
-      "severity": "P3",
-      "file": "packages/opencode-plugin/src/delegation/background-manager.ts",
-      "description": "taskDepths and rootDescendantCounts maps never pruned — pre-existing pattern, not a regression"
+      "file": "packages/opencode-plugin/src/hooks/circuit-breaker.ts",
+      "description": "No reset/cooldown mechanism after threshold — intentional behavior, verified by test, but worth noting for future feature needs"
     }
   ],
-  "learningsInjected": ["docs/solutions/delegation/hardening-patterns.md"],
-  "learningsHelpful": ["docs/solutions/delegation/hardening-patterns.md"],
+  "learningsInjected": [],
+  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-13T01:23:31.429Z"
+  "completed": "2026-04-13T05:46:45.782Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,43 +1,54 @@
 {
   "result": "pass",
-  "summary": "All acceptance criteria verified. 22/22 new spawn-limits tests pass. 1311/1313 total tests pass (2 pre-existing @pulumi/docker failures). TypeScript clean. Biome clean. Implementation note: 3 TDD test cases had off-by-one errors in maxDepth values — corrected to match spec semantics (depth >= maxDepth rejects).",
+  "summary": "All 6 acceptance criteria verified. 26 circuit-breaker tests pass. 384 total tests pass in opencode-plugin. TypeScript clean. Biome clean.",
+  "passed": 6,
+  "failed": 0,
+  "failures": [],
+  "documentationFeedback": "No user-facing docs updated (appropriate for internal plugin hook). Code has good JSDoc comments. PR body is adequate.",
+  "observations": [
+    "No config merge tests for mergeCircuitBreaker specifically (minor gap, trivial function)",
+    "No integration test for wiring in index.ts (mitigated by TypeScript type checking)",
+    "Hook runs first in tool.execute.before chain, before subagentQuestionBlockerHook (correct ordering)"
+  ],
   "criteriaResults": [
     {
-      "criterion": "TDD: failing test written first, then implementation",
+      "criterion": "TDD: failing test first, then implementation",
       "result": "pass",
-      "evidence": "Verified by git log: commit nrnluuzt (test(delegation): add failing spawn limits tests (TDD)) precedes implementation commit sywzynoo."
+      "evidence": "Implementer attestation in retro comment. Branch squash-merged so individual TDD commits not visible."
     },
     {
-      "criterion": "Spawning at depth=4 (default max=5) succeeds; spawning at depth=5 returns clear rejection error",
+      "criterion": "5 identical tool calls triggers the breaker",
       "result": "pass",
-      "evidence": "Tests pass: spawning at depth=4 succeeds; spawning at depth=5 throws Spawn rejected: max depth 5 reached (current depth: 5)"
+      "evidence": "bun test --grep 'triggers on the 5th' — 1 pass"
     },
     {
-      "criterion": "20th descendant of a root succeeds; 21st returns clear rejection error",
+      "criterion": "Warning/abort behavior configurable via plugin config",
       "result": "pass",
-      "evidence": "Tests pass: 20th descendant succeeds; 21st throws Spawn rejected: max descendants 20 reached for root session ..."
+      "evidence": "abort throws, warn does not throw + console.warn called. Config wired at index.ts:94."
     },
     {
-      "criterion": "Config overrides work (custom depth/descendant limits via plugin config)",
+      "criterion": "Per-session tracking — independent counters",
       "result": "pass",
-      "evidence": "Tests pass: custom maxDepth=4 rejects at depth=4; custom maxDescendants=10 rejects at 11th descendant. Config wired in index.ts line 78."
+      "evidence": "5 calls across 2 sessions does not trigger either. Sessions trigger independently."
     },
     {
-      "criterion": "Existing delegation tests still pass",
+      "criterion": "Tracking cleaned up on session.deleted event",
       "result": "pass",
-      "evidence": "1311/1313 total tests pass. 2 failures are pre-existing @pulumi/docker module errors — confirmed pre-existing by running tests on parent commit."
+      "evidence": "Counter resets after session.deleted. Other sessions unaffected."
     },
     {
-      "criterion": "Resource accounting state is asserted after every rejection path",
+      "criterion": "4 identical calls does NOT trigger",
       "result": "pass",
-      "evidence": "Tests verify counter state after rejection: depth counters unchanged after rejection; descendant counter not corrupted by first rejection."
+      "evidence": "bun test --grep 'does not trigger on 4' — 1 pass, 4 expect() calls"
     }
   ],
-  "testCritique": "22 new tests covering depth tracking, depth boundary, descendant boundary, concurrent spawns, error message format, rootSessionID tracking. 3 TDD tests had off-by-one errors in maxDepth values corrected to match spec semantics.",
+  "testCritique": "Tests are meaningful — exercise real hook with real inputs, no excessive mocking. Good edge case coverage (null, nested, key order). Minor gap: no config merge test for mergeCircuitBreaker.",
   "ciStatus": "pending",
-  "prNumber": 490,
-  "prUrl": "https://github.com/sjawhar/legion/pull/490",
+  "prNumber": 499,
+  "prUrl": "https://github.com/sjawhar/legion/pull/499",
+  "learningsInjected": [],
+  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-13T00:59:17.029Z"
+  "completed": "2026-04-13T05:42:10.895Z"
 }

--- a/docs/solutions/architecture-patterns/opencode-plugin-hook-authoring-patterns.md
+++ b/docs/solutions/architecture-patterns/opencode-plugin-hook-authoring-patterns.md
@@ -1,0 +1,173 @@
+---
+title: "OpenCode Plugin Hook Authoring Patterns"
+category: architecture-patterns
+tags:
+  - opencode-plugin
+  - hooks
+  - tool-execute-before
+  - config
+  - factory-pattern
+  - session-cleanup
+date: 2026-04-13
+status: active
+module: opencode-plugin
+related_issues:
+  - "272"
+symptoms:
+  - "hook sees empty args"
+  - "output.args vs input.args"
+  - "how to add a new hook"
+  - "config not taking effect"
+  - "session cleanup memory leak"
+---
+
+# OpenCode Plugin Hook Authoring Patterns
+
+Patterns for adding new hooks and configurable features to `packages/opencode-plugin`.
+Extracted from implementing the circuit breaker hook (#272).
+
+## 1. `tool.execute.before` Arg Source
+
+**Critical: `output.args` contains the parsed tool arguments, not `input.args`.**
+
+```typescript
+"tool.execute.before": (input, output) => {
+  // input = { tool: string, sessionID: string, callID: string, args?: unknown }
+  // output = { args: Record<string, unknown> }  ← PARSED tool args live here
+
+  const args = output.args;  // ✅ correct — parsed/validated args
+  // NOT input.args           // ❌ wrong — raw/unprocessed args
+}
+```
+
+`input` carries metadata (tool name, session ID, call ID) plus raw args.
+`output.args` carries the parsed tool input that the tool will actually receive.
+Using `input.args` causes the hook to see different (possibly empty) values from
+what the tool processes. This is the single most common mistake in hook authoring.
+
+## 2. The 5+3 Touch Point Pattern for New Configurable Hooks
+
+Adding a new configurable hook requires exactly 8 touch points:
+
+### Config (5 in `config/index.ts`)
+
+| # | What | Example |
+|---|------|---------|
+| 1 | Zod schema | `const CircuitBreakerConfigSchema = z.object({...}).strict()` |
+| 2 | TypeScript interface | `export interface CircuitBreakerConfig { ... }` |
+| 3 | PluginConfig field | `circuitBreaker?: CircuitBreakerConfig` in `interface PluginConfig` |
+| 4 | PluginConfigSchema field | `circuitBreaker: CircuitBreakerConfigSchema.optional()` in `PluginConfigSchema` |
+| 5 | mergeConfig entry | `mergeCircuitBreaker` function + call in `mergeConfig()` |
+
+**Merge function pattern for flat configs:**
+
+```typescript
+function mergeCircuitBreaker(
+  base?: CircuitBreakerConfig,
+  override?: CircuitBreakerConfig
+): CircuitBreakerConfig | undefined {
+  if (!base) return override;
+  if (!override) return base;
+  return { ...base, ...override };
+}
+```
+
+Only configs with special merge semantics (e.g., `outputCompression.excludeTools`
+which unions arrays) need custom logic beyond spread.
+
+**Single source of truth:** Define the TypeScript interface in `config/index.ts`
+and import it in the hook file. Do not duplicate the interface.
+
+### Wiring (3 in `index.ts`)
+
+| # | What | Example |
+|---|------|---------|
+| 6 | Import | `import { createCircuitBreakerHook } from "./hooks/circuit-breaker"` |
+| 7 | Instantiation | `const hook = createCircuitBreakerHook(pluginConfig.circuitBreaker ?? {})` |
+| 8 | Hook point registration | Add call in the appropriate handler body |
+
+The `?? {}` fallback ensures the factory always receives a valid config even when
+the user didn't configure the feature.
+
+## 3. Factory Function vs Plain Function
+
+**Factory function** — for hooks that need state, config, or cleanup:
+
+```typescript
+export function createCircuitBreakerHook(config: CircuitBreakerConfig = {}) {
+  const state = new Map<string, Map<string, number>>();
+
+  return {
+    "tool.execute.before": (input, output) => { /* uses state */ },
+    event: async ({ event }) => { /* cleanup state */ },
+  };
+}
+```
+
+**Plain function** — for stateless, deterministic hooks:
+
+```typescript
+export function subagentQuestionBlockerHook(input, output) { /* no state */ }
+```
+
+Use a factory when:
+- Hook tracks per-session state
+- Hook reads from config at instantiation time
+- Hook needs cleanup on `session.deleted`
+
+Return an object with keys matching hook point names (`tool.execute.before`, `event`, etc.).
+
+## 4. Session Cleanup via `session.deleted`
+
+Stateful hooks must clean up when sessions are deleted. Wire in `index.ts`:
+
+```typescript
+if (event.type === "session.deleted") {
+  // ... existing cleanup ...
+  await circuitBreakerHook.event({ event });
+}
+```
+
+Inside the hook, use `resolveSessionID` from `hooks/utils.ts`:
+
+```typescript
+import { isRecord, resolveSessionID } from "./utils";
+
+const event = async ({ event }) => {
+  if (event.type === "session.deleted") {
+    const props = isRecord(event.properties) ? event.properties : undefined;
+    const sessionID = resolveSessionID(props);
+    if (sessionID) {
+      sessionCounts.delete(sessionID);
+    }
+  }
+};
+```
+
+`resolveSessionID` handles two property shapes from the SDK:
+- `{ sessionID: "s-1" }` — direct
+- `{ info: { id: "s-1" } }` — nested alternative
+
+**Always test both shapes** in your test suite.
+
+## 5. Stable JSON Hashing for Arg Comparison
+
+When comparing tool arguments for equality, use key-sorted JSON stringification:
+
+```typescript
+function sortedStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, v: unknown) => {
+    if (v !== null && typeof v === "object" && !Array.isArray(v)) {
+      const r = v as Record<string, unknown>;
+      const s: Record<string, unknown> = {};
+      for (const k of Object.keys(r).sort()) s[k] = r[k];
+      return s;
+    }
+    return v;
+  });
+}
+```
+
+This ensures `{b:1, a:2}` and `{a:2, b:1}` produce identical strings.
+The replacer recursively sorts nested objects too. No external hash
+library needed — the string itself is the comparison key.

--- a/docs/solutions/index.json
+++ b/docs/solutions/index.json
@@ -52,124 +52,66 @@
       "daemon/controller-observability.md",
       "controller/skill-vs-state-machine-policy-boundary.md"
     ],
-    ".opencode/skills/linear": [
-      "integration-issues/linear-mcp-label-resolution.md"
-    ],
+    ".opencode/skills/linear": ["integration-issues/linear-mcp-label-resolution.md"],
     ".opencode/skills": [
       "skill-patterns/parallel-subagent-background-execution.md",
       "delegation/delegation-hardening-retro.md",
       "delegation/hardening-patterns.md",
       "delegation/subagent-timeout-stall-prevention.md"
     ],
-    "tests": [
-      "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"
-    ],
-    "tag:SIGTERM": [
-      "daemon/opencode-serve-lifecycle.md"
-    ],
-    "tag:active-index": [
-      "task-index-patterns.md"
-    ],
-    "tag:agent-restrictions": [
-      "delegation/hardening-patterns.md"
-    ],
-    "tag:aiofiles": [
-      "architecture-patterns/sync-to-async-modular-refactoring.md"
-    ],
-    "tag:alru-cache": [
-      "architecture-patterns/sync-to-async-modular-refactoring.md"
-    ],
-    "tag:anyio": [
-      "architecture-patterns/sync-to-async-modular-refactoring.md"
-    ],
+    "tests": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
+    "tag:SIGTERM": ["daemon/opencode-serve-lifecycle.md"],
+    "tag:active-index": ["task-index-patterns.md"],
+    "tag:agent-restrictions": ["delegation/hardening-patterns.md"],
+    "tag:aiofiles": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
+    "tag:alru-cache": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
+    "tag:anyio": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
     "tag:architecture": [
       "daemon/controller-lifecycle-separation.md",
       "daemon/shared-serve-refactor.md"
     ],
-    "tag:askuserquestion": [
-      "integration-patterns/tmux-askuserquestion-navigation.md"
-    ],
-    "tag:async": [
-      "architecture-patterns/sync-to-async-modular-refactoring.md"
-    ],
-    "tag:asyncmock": [
-      "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"
-    ],
-    "tag:atomic-writes": [
-      "delegation/hardening-patterns.md"
-    ],
-    "tag:auto-transition": [
-      "integration-issues/external-repo-pr-auto-transition-gap.md"
-    ],
-    "tag:automation": [
-      "integration-patterns/tmux-askuserquestion-navigation.md"
-    ],
-    "tag:autospec": [
-      "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"
-    ],
-    "tag:background-tasks": [
-      "skill-patterns/parallel-subagent-background-execution.md"
-    ],
-    "tag:batch-queries": [
-      "architecture-patterns/sync-to-async-modular-refactoring.md"
-    ],
-    "tag:batching": [
-      "integration-issues/github-graphql-pr-draft-status.md"
-    ],
-    "tag:bootstrap-bug": [
-      "architecture-patterns/task-index-retro.md"
-    ],
+    "tag:askuserquestion": ["integration-patterns/tmux-askuserquestion-navigation.md"],
+    "tag:async": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
+    "tag:asyncmock": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
+    "tag:atomic-writes": ["delegation/hardening-patterns.md"],
+    "tag:auto-transition": ["integration-issues/external-repo-pr-auto-transition-gap.md"],
+    "tag:automation": ["integration-patterns/tmux-askuserquestion-navigation.md"],
+    "tag:autospec": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
+    "tag:background-tasks": ["skill-patterns/parallel-subagent-background-execution.md"],
+    "tag:batch-queries": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
+    "tag:batching": ["integration-issues/github-graphql-pr-draft-status.md"],
+    "tag:bootstrap-bug": ["architecture-patterns/task-index-retro.md"],
     "tag:caching": [
       "architecture-patterns/sync-to-async-modular-refactoring.md",
       "architecture-patterns/task-index-retro.md",
       "integration-issues/linear-mcp-label-resolution.md",
       "task-index-patterns.md"
     ],
-    "tag:callback-pattern": [
-      "architecture-patterns/shared-state-file-ownership.md"
-    ],
-    "tag:claude-code": [
-      "integration-patterns/tmux-askuserquestion-navigation.md"
-    ],
+    "tag:callback-pattern": ["architecture-patterns/shared-state-file-ownership.md"],
+    "tag:claude-code": ["integration-patterns/tmux-askuserquestion-navigation.md"],
     "tag:cleanup": [
       "daemon/deferred-review-comments-pattern.md",
       "daemon/graceful-worker-shutdown.md",
       "daemon/optional-dep-fallback-and-early-return-guard.md"
     ],
-    "tag:cli-interaction": [
-      "integration-patterns/tmux-askuserquestion-navigation.md"
-    ],
-    "tag:code-review": [
-      "daemon/deferred-review-comments-pattern.md"
-    ],
-    "tag:concurrency": [
-      "delegation/delegation-hardening-retro.md"
-    ],
+    "tag:cli-interaction": ["integration-patterns/tmux-askuserquestion-navigation.md"],
+    "tag:code-review": ["daemon/deferred-review-comments-pattern.md"],
+    "tag:concurrency": ["delegation/delegation-hardening-retro.md"],
     "tag:config-schema": [
-      "delegation/hardening-patterns.md"
+      "delegation/hardening-patterns.md",
+      "architecture-patterns/opencode-plugin-hook-authoring-patterns.md"
     ],
+    "tag:config": ["architecture-patterns/opencode-plugin-hook-authoring-patterns.md"],
     "tag:controller": [
       "daemon/controller-observability.md",
       "integration-patterns/controller-worker-protocol.md"
     ],
-    "tag:controller-dispatch": [
-      "integration-issues/external-repo-pr-auto-transition-gap.md"
-    ],
-    "tag:crash-recovery": [
-      "daemon/shared-serve-retro.md"
-    ],
-    "tag:daemon": [
-      "architecture-patterns/shared-state-file-ownership.md"
-    ],
-    "tag:debugging": [
-      "daemon/controller-observability.md"
-    ],
-    "tag:defense-in-depth": [
-      "daemon/graceful-worker-shutdown.md"
-    ],
-    "tag:deferred-review-comments": [
-      "daemon/workspace-validation-retro.md"
-    ],
+    "tag:controller-dispatch": ["integration-issues/external-repo-pr-auto-transition-gap.md"],
+    "tag:crash-recovery": ["daemon/shared-serve-retro.md"],
+    "tag:daemon": ["architecture-patterns/shared-state-file-ownership.md"],
+    "tag:debugging": ["daemon/controller-observability.md"],
+    "tag:defense-in-depth": ["daemon/graceful-worker-shutdown.md"],
+    "tag:deferred-review-comments": ["daemon/workspace-validation-retro.md"],
     "tag:delegation": [
       "delegation/delegation-hardening-retro.md",
       "delegation/hardening-patterns.md",
@@ -182,41 +124,20 @@
       "daemon/session-liveness-detection-pattern.md",
       "daemon/optional-dep-fallback-and-early-return-guard.md"
     ],
-    "tag:directory-resolution": [
-      "daemon/worker-directory-fix.md"
-    ],
-    "tag:dispatch": [
-      "integration-patterns/controller-worker-protocol.md"
-    ],
-    "tag:dispose": [
-      "daemon/opencode-serve-lifecycle.md"
-    ],
-    "tag:draft-status": [
-      "integration-issues/github-graphql-pr-draft-status.md"
-    ],
-    "tag:error-handling": [
-      "integration-issues/linear-mcp-label-resolution.md"
-    ],
-    "tag:external-repos": [
-      "integration-issues/external-repo-pr-auto-transition-gap.md"
-    ],
-    "tag:failure-modes": [
-      "skill-patterns/worker-skill-failure-modes.md"
-    ],
+    "tag:directory-resolution": ["daemon/worker-directory-fix.md"],
+    "tag:dispatch": ["integration-patterns/controller-worker-protocol.md"],
+    "tag:dispose": ["daemon/opencode-serve-lifecycle.md"],
+    "tag:draft-status": ["integration-issues/github-graphql-pr-draft-status.md"],
+    "tag:error-handling": ["integration-issues/linear-mcp-label-resolution.md"],
+    "tag:external-repos": ["integration-issues/external-repo-pr-auto-transition-gap.md"],
+    "tag:failure-modes": ["skill-patterns/worker-skill-failure-modes.md"],
     "tag:fallback-pattern": [
       "task-index-patterns.md",
       "daemon/optional-dep-fallback-and-early-return-guard.md"
     ],
-    "tag:file-based-index": [
-      "architecture-patterns/task-index-retro.md",
-      "task-index-patterns.md"
-    ],
-    "tag:file-based-storage": [
-      "delegation/hardening-patterns.md"
-    ],
-    "tag:finalize-pattern": [
-      "delegation/delegation-hardening-retro.md"
-    ],
+    "tag:file-based-index": ["architecture-patterns/task-index-retro.md", "task-index-patterns.md"],
+    "tag:file-based-storage": ["delegation/hardening-patterns.md"],
+    "tag:finalize-pattern": ["delegation/delegation-hardening-retro.md"],
     "tag:github": [
       "integration-issues/external-repo-pr-auto-transition-gap.md",
       "integration-issues/github-graphql-pr-draft-status.md"
@@ -226,94 +147,51 @@
       "integration-issues/github-graphql-pr-draft-status.md",
       "integration-issues/linear-mcp-label-resolution.md"
     ],
-    "tag:implement": [
-      "skill-patterns/worker-skill-failure-modes.md"
-    ],
+    "tag:implement": ["skill-patterns/worker-skill-failure-modes.md"],
     "tag:jj-workspaces": [
       "daemon/worker-directory-fix.md",
       "daemon/worker-directory-resolution.md",
       "best-practices/git-stash-jj-working-copy-interference.md"
     ],
-    "tag:keyboard-navigation": [
-      "integration-patterns/tmux-askuserquestion-navigation.md"
-    ],
-    "tag:labels": [
-      "integration-issues/linear-mcp-label-resolution.md"
-    ],
-    "tag:lifecycle": [
-      "daemon/controller-lifecycle-separation.md"
-    ],
-    "tag:lifecycle-separation": [
-      "architecture-patterns/shared-state-file-ownership.md"
-    ],
+    "tag:keyboard-navigation": ["integration-patterns/tmux-askuserquestion-navigation.md"],
+    "tag:labels": ["integration-issues/linear-mcp-label-resolution.md"],
+    "tag:lifecycle": ["daemon/controller-lifecycle-separation.md"],
+    "tag:lifecycle-separation": ["architecture-patterns/shared-state-file-ownership.md"],
     "tag:linear": [
       "integration-issues/external-repo-pr-auto-transition-gap.md",
       "integration-issues/linear-mcp-label-resolution.md"
     ],
-    "tag:mcp": [
-      "integration-issues/linear-mcp-label-resolution.md"
-    ],
-    "tag:merge": [
-      "skill-patterns/worker-skill-failure-modes.md"
-    ],
-    "tag:migration": [
-      "architecture-patterns/plugin-migration-assessment.md"
-    ],
-    "tag:mocking": [
-      "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"
-    ],
-    "tag:modular-architecture": [
-      "architecture-patterns/sync-to-async-modular-refactoring.md"
-    ],
-    "tag:n-plus-one": [
-      "architecture-patterns/sync-to-async-modular-refactoring.md"
-    ],
-    "tag:name-resolution": [
-      "integration-issues/linear-mcp-label-resolution.md"
-    ],
-    "tag:observability": [
-      "daemon/controller-observability.md"
-    ],
-    "tag:oh-my-opencode": [
-      "architecture-patterns/plugin-migration-assessment.md"
-    ],
+    "tag:mcp": ["integration-issues/linear-mcp-label-resolution.md"],
+    "tag:merge": ["skill-patterns/worker-skill-failure-modes.md"],
+    "tag:migration": ["architecture-patterns/plugin-migration-assessment.md"],
+    "tag:mocking": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
+    "tag:modular-architecture": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
+    "tag:n-plus-one": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
+    "tag:name-resolution": ["integration-issues/linear-mcp-label-resolution.md"],
+    "tag:observability": ["daemon/controller-observability.md"],
+    "tag:oh-my-opencode": ["architecture-patterns/plugin-migration-assessment.md"],
     "tag:opencode": [
       "daemon/opencode-serve-lifecycle.md",
       "skill-patterns/parallel-subagent-background-execution.md"
     ],
-    "tag:opencode-legion": [
-      "architecture-patterns/plugin-migration-assessment.md"
-    ],
-    "tag:opencode-sdk": [
-      "daemon/worker-directory-fix.md",
-      "daemon/worker-directory-resolution.md"
-    ],
-    "tag:opencode-serve": [
-      "daemon/shared-serve-refactor.md",
-      "daemon/shared-serve-retro.md"
-    ],
-    "tag:parallel-execution": [
-      "skill-patterns/parallel-subagent-background-execution.md"
-    ],
-    "tag:parallel-subagents": [
-      "architecture-patterns/task-index-retro.md"
-    ],
-    "tag:performance": [
-      "architecture-patterns/task-index-retro.md",
-      "task-index-patterns.md"
-    ],
-    "tag:persistence": [
-      "architecture-patterns/shared-state-file-ownership.md"
-    ],
+    "tag:opencode-legion": ["architecture-patterns/plugin-migration-assessment.md"],
+    "tag:opencode-sdk": ["daemon/worker-directory-fix.md", "daemon/worker-directory-resolution.md"],
+    "tag:opencode-serve": ["daemon/shared-serve-refactor.md", "daemon/shared-serve-retro.md"],
+    "tag:parallel-execution": ["skill-patterns/parallel-subagent-background-execution.md"],
+    "tag:parallel-subagents": ["architecture-patterns/task-index-retro.md"],
+    "tag:performance": ["architecture-patterns/task-index-retro.md", "task-index-patterns.md"],
+    "tag:persistence": ["architecture-patterns/shared-state-file-ownership.md"],
+    "tag:opencode-plugin": ["architecture-patterns/opencode-plugin-hook-authoring-patterns.md"],
+    "tag:hooks": ["architecture-patterns/opencode-plugin-hook-authoring-patterns.md"],
+    "tag:tool-execute-before": ["architecture-patterns/opencode-plugin-hook-authoring-patterns.md"],
+    "tag:factory-pattern": ["architecture-patterns/opencode-plugin-hook-authoring-patterns.md"],
+    "tag:session-cleanup": ["architecture-patterns/opencode-plugin-hook-authoring-patterns.md"],
     "tag:plugin": [
-      "architecture-patterns/plugin-migration-assessment.md"
+      "architecture-patterns/plugin-migration-assessment.md",
+      "architecture-patterns/opencode-plugin-hook-authoring-patterns.md"
     ],
-    "tag:pr-review": [
-      "integration-issues/github-graphql-pr-draft-status.md"
-    ],
-    "tag:pr-workflow": [
-      "daemon/workspace-validation-retro.md"
-    ],
+    "tag:pr-review": ["integration-issues/github-graphql-pr-draft-status.md"],
+    "tag:pr-workflow": ["daemon/workspace-validation-retro.md"],
     "tag:process-management": [
       "daemon/graceful-worker-shutdown.md",
       "daemon/opencode-serve-lifecycle.md",
@@ -327,86 +205,48 @@
       "integration-issues/external-repo-pr-auto-transition-gap.md",
       "integration-issues/github-graphql-pr-draft-status.md"
     ],
-    "tag:pytest-mock": [
-      "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"
-    ],
-    "tag:python": [
-      "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"
-    ],
-    "tag:race-condition": [
-      "architecture-patterns/shared-state-file-ownership.md"
-    ],
-    "tag:refactoring": [
-      "architecture-patterns/sync-to-async-modular-refactoring.md"
-    ],
-    "tag:remote-control": [
-      "integration-patterns/tmux-askuserquestion-navigation.md"
-    ],
-    "tag:resource-accounting": [
-      "delegation/delegation-hardening-retro.md"
-    ],
-    "tag:resume": [
-      "integration-patterns/controller-worker-protocol.md"
-    ],
-    "tag:retro": [
-      "skill-patterns/worker-skill-failure-modes.md"
-    ],
-    "tag:review": [
-      "skill-patterns/worker-skill-failure-modes.md"
-    ],
-    "tag:serve": [
-      "daemon/opencode-serve-lifecycle.md"
-    ],
+    "tag:pytest-mock": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
+    "tag:python": ["best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md"],
+    "tag:race-condition": ["architecture-patterns/shared-state-file-ownership.md"],
+    "tag:refactoring": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
+    "tag:remote-control": ["integration-patterns/tmux-askuserquestion-navigation.md"],
+    "tag:resource-accounting": ["delegation/delegation-hardening-retro.md"],
+    "tag:resume": ["integration-patterns/controller-worker-protocol.md"],
+    "tag:retro": ["skill-patterns/worker-skill-failure-modes.md"],
+    "tag:review": ["skill-patterns/worker-skill-failure-modes.md"],
+    "tag:serve": ["daemon/opencode-serve-lifecycle.md"],
     "tag:session-management": [
       "daemon/worker-directory-resolution.md",
       "daemon/session-liveness-detection-pattern.md"
     ],
-    "tag:sessions": [
-      "daemon/shared-serve-refactor.md",
-      "daemon/shared-serve-retro.md"
-    ],
-    "tag:shared-serve": [
-      "daemon/shared-serve-refactor.md",
-      "daemon/shared-serve-retro.md"
-    ],
+    "tag:sessions": ["daemon/shared-serve-refactor.md", "daemon/shared-serve-retro.md"],
+    "tag:shared-serve": ["daemon/shared-serve-refactor.md", "daemon/shared-serve-retro.md"],
     "tag:skill-authoring": [
       "skill-patterns/parallel-subagent-background-execution.md",
       "delegation/subagent-timeout-stall-prevention.md",
       "controller/skill-vs-state-machine-policy-boundary.md",
       "best-practices/git-stash-jj-working-copy-interference.md"
     ],
-    "tag:skills": [
-      "skill-patterns/worker-skill-failure-modes.md"
-    ],
-    "tag:stale-detection": [
-      "delegation/delegation-hardening-retro.md"
-    ],
-    "tag:state-file": [
-      "architecture-patterns/shared-state-file-ownership.md"
-    ],
+    "tag:skills": ["skill-patterns/worker-skill-failure-modes.md"],
+    "tag:stale-detection": ["delegation/delegation-hardening-retro.md"],
+    "tag:state-file": ["architecture-patterns/shared-state-file-ownership.md"],
     "tag:state-machine": [
       "daemon/controller-observability.md",
       "integration-issues/github-graphql-pr-draft-status.md",
       "controller/skill-vs-state-machine-policy-boundary.md"
     ],
-    "tag:state-management": [
-      "daemon/controller-lifecycle-separation.md"
-    ],
+    "tag:state-management": ["daemon/controller-lifecycle-separation.md"],
     "tag:subagents": [
       "skill-patterns/parallel-subagent-background-execution.md",
       "delegation/subagent-timeout-stall-prevention.md"
     ],
-    "tag:task-index": [
-      "architecture-patterns/task-index-retro.md"
-    ],
+    "tag:task-index": ["architecture-patterns/task-index-retro.md"],
     "tag:task-persistence": [
       "delegation/delegation-hardening-retro.md",
       "delegation/hardening-patterns.md",
       "task-index-patterns.md"
     ],
-    "tag:testability": [
-      "architecture-patterns/sync-to-async-modular-refactoring.md"
-    ],
+    "tag:testability": ["architecture-patterns/sync-to-async-modular-refactoring.md"],
     "tag:testing": [
       "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md",
       "daemon/controller-lifecycle-separation.md",
@@ -416,47 +256,31 @@
       "daemon/session-liveness-detection-pattern.md",
       "daemon/optional-dep-fallback-and-early-return-guard.md"
     ],
-    "tag:tmux": [
-      "integration-patterns/tmux-askuserquestion-navigation.md"
-    ],
-    "tag:validation": [
-      "daemon/workspace-validation-retro.md"
-    ],
-    "tag:worker": [
-      "integration-patterns/controller-worker-protocol.md"
-    ],
-    "tag:worker-isolation": [
-      "daemon/worker-directory-resolution.md"
-    ],
+    "tag:tmux": ["integration-patterns/tmux-askuserquestion-navigation.md"],
+    "tag:validation": ["daemon/workspace-validation-retro.md"],
+    "tag:worker": ["integration-patterns/controller-worker-protocol.md"],
+    "tag:worker-isolation": ["daemon/worker-directory-resolution.md"],
     "tag:worker-lifecycle": [
       "integration-issues/external-repo-pr-auto-transition-gap.md",
       "daemon/session-liveness-detection-pattern.md"
     ],
-    "tag:worker-spawning": [
-      "daemon/worker-directory-fix.md"
+    "tag:worker-spawning": ["daemon/worker-directory-fix.md"],
+    "tag:workers": ["skill-patterns/worker-skill-failure-modes.md"],
+    "tag:workflow-design": ["skill-patterns/parallel-subagent-background-execution.md"],
+    "tag:workflow-pattern": ["daemon/deferred-review-comments-pattern.md"],
+    "tag:workspace-validation": ["daemon/workspace-validation-retro.md"],
+    "packages/opencode-plugin/src/hooks": [
+      "architecture-patterns/opencode-plugin-hook-authoring-patterns.md"
     ],
-    "tag:workers": [
-      "skill-patterns/worker-skill-failure-modes.md"
-    ],
-    "tag:workflow-design": [
-      "skill-patterns/parallel-subagent-background-execution.md"
-    ],
-    "tag:workflow-pattern": [
-      "daemon/deferred-review-comments-pattern.md"
-    ],
-    "tag:workspace-validation": [
-      "daemon/workspace-validation-retro.md"
+    "packages/opencode-plugin/src/config": [
+      "architecture-patterns/opencode-plugin-hook-authoring-patterns.md"
     ],
     "packages/opencode-plugin/src/delegation": [
       "delegation/subagent-timeout-stall-prevention.md",
       "delegation/bun-node-timer-type-portability.md"
     ],
-    ".opencode/skills/legion-retro": [
-      "delegation/subagent-timeout-stall-prevention.md"
-    ],
-    "tag:timeout": [
-      "delegation/subagent-timeout-stall-prevention.md"
-    ],
+    ".opencode/skills/legion-retro": ["delegation/subagent-timeout-stall-prevention.md"],
+    "tag:timeout": ["delegation/subagent-timeout-stall-prevention.md"],
     "tag:reliability": [
       "delegation/subagent-timeout-stall-prevention.md",
       "daemon/session-liveness-detection-pattern.md"
@@ -470,75 +294,31 @@
       "infra/mixed-runtime-type-boundaries.md",
       "daemon/targeted-delta-filtering-pattern.md"
     ],
-    "tag:timer": [
-      "delegation/bun-node-timer-type-portability.md"
-    ],
-    "tag:portability": [
-      "delegation/bun-node-timer-type-portability.md"
-    ],
-    "packages/daemon/src/daemon/runtime": [
-      "daemon/session-liveness-detection-pattern.md"
-    ],
-    "tag:health-tick": [
-      "daemon/session-liveness-detection-pattern.md"
-    ],
-    "tag:liveness": [
-      "daemon/session-liveness-detection-pattern.md"
-    ],
-    "tag:dead-worker": [
-      "daemon/session-liveness-detection-pattern.md"
-    ],
-    "tag:jj": [
-      "best-practices/git-stash-jj-working-copy-interference.md"
-    ],
-    "tag:footgun": [
-      "best-practices/git-stash-jj-working-copy-interference.md"
-    ],
-    "tag:version-control": [
-      "best-practices/git-stash-jj-working-copy-interference.md"
-    ],
-    "tag:policy": [
-      "controller/skill-vs-state-machine-policy-boundary.md"
-    ],
-    "tag:decision-engine": [
-      "controller/skill-vs-state-machine-policy-boundary.md"
-    ],
+    "tag:timer": ["delegation/bun-node-timer-type-portability.md"],
+    "tag:portability": ["delegation/bun-node-timer-type-portability.md"],
+    "packages/daemon/src/daemon/runtime": ["daemon/session-liveness-detection-pattern.md"],
+    "tag:health-tick": ["daemon/session-liveness-detection-pattern.md"],
+    "tag:liveness": ["daemon/session-liveness-detection-pattern.md"],
+    "tag:dead-worker": ["daemon/session-liveness-detection-pattern.md"],
+    "tag:jj": ["best-practices/git-stash-jj-working-copy-interference.md"],
+    "tag:footgun": ["best-practices/git-stash-jj-working-copy-interference.md"],
+    "tag:version-control": ["best-practices/git-stash-jj-working-copy-interference.md"],
+    "tag:policy": ["controller/skill-vs-state-machine-policy-boundary.md"],
+    "tag:decision-engine": ["controller/skill-vs-state-machine-policy-boundary.md"],
     "packages/aws-infra": [
       "infra/pulumi-aws-identity-center-patterns.md",
       "infra/mixed-runtime-type-boundaries.md"
     ],
-    "tag:pulumi": [
-      "infra/pulumi-aws-identity-center-patterns.md"
-    ],
-    "tag:aws": [
-      "infra/pulumi-aws-identity-center-patterns.md"
-    ],
-    "tag:identity-center": [
-      "infra/pulumi-aws-identity-center-patterns.md"
-    ],
-    "tag:sso": [
-      "infra/pulumi-aws-identity-center-patterns.md"
-    ],
-    "tag:scim": [
-      "infra/pulumi-aws-identity-center-patterns.md"
-    ],
-    "tag:mixed-runtime": [
-      "infra/mixed-runtime-type-boundaries.md"
-    ],
-    "packages/daemon/src/daemon/state-delta": [
-      "daemon/targeted-delta-filtering-pattern.md"
-    ],
-    "tag:state-delta": [
-      "daemon/targeted-delta-filtering-pattern.md"
-    ],
-    "tag:tracking": [
-      "daemon/targeted-delta-filtering-pattern.md"
-    ],
-    "tag:notifications": [
-      "daemon/targeted-delta-filtering-pattern.md"
-    ],
-    "tag:backward-compatibility": [
-      "daemon/targeted-delta-filtering-pattern.md"
-    ]
+    "tag:pulumi": ["infra/pulumi-aws-identity-center-patterns.md"],
+    "tag:aws": ["infra/pulumi-aws-identity-center-patterns.md"],
+    "tag:identity-center": ["infra/pulumi-aws-identity-center-patterns.md"],
+    "tag:sso": ["infra/pulumi-aws-identity-center-patterns.md"],
+    "tag:scim": ["infra/pulumi-aws-identity-center-patterns.md"],
+    "tag:mixed-runtime": ["infra/mixed-runtime-type-boundaries.md"],
+    "packages/daemon/src/daemon/state-delta": ["daemon/targeted-delta-filtering-pattern.md"],
+    "tag:state-delta": ["daemon/targeted-delta-filtering-pattern.md"],
+    "tag:tracking": ["daemon/targeted-delta-filtering-pattern.md"],
+    "tag:notifications": ["daemon/targeted-delta-filtering-pattern.md"],
+    "tag:backward-compatibility": ["daemon/targeted-delta-filtering-pattern.md"]
   }
 }

--- a/packages/opencode-plugin/src/config/index.ts
+++ b/packages/opencode-plugin/src/config/index.ts
@@ -65,6 +65,14 @@ const OutputCompressionConfigSchema = z
   })
   .strict();
 
+const CircuitBreakerConfigSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    threshold: z.number().optional(),
+    action: z.enum(["warn", "abort"]).optional(),
+  })
+  .strict();
+
 const SpawnLimitsConfigSchema = z
   .object({
     maxDepth: z.number().optional(),
@@ -85,6 +93,7 @@ const PluginConfigSchema = z
     taskRetentionMs: z.number().optional(),
     outputCompression: OutputCompressionConfigSchema.optional(),
     spawnLimits: SpawnLimitsConfigSchema.optional(),
+    circuitBreaker: CircuitBreakerConfigSchema.optional(),
   })
   .passthrough();
 
@@ -112,6 +121,12 @@ export interface OutputCompressionConfig {
   maxIndexSizeMB?: number;
 }
 
+export interface CircuitBreakerConfig {
+  enabled?: boolean;
+  threshold?: number;
+  action?: "warn" | "abort";
+}
+
 export interface SpawnLimitsConfig {
   maxDepth?: number;
   maxDescendants?: number;
@@ -130,6 +145,7 @@ export interface PluginConfig {
   taskRetentionMs?: number;
   outputCompression?: OutputCompressionConfig;
   spawnLimits?: SpawnLimitsConfig;
+  circuitBreaker?: CircuitBreakerConfig;
 }
 
 const DEFAULT_CONFIG: PluginConfig = {
@@ -245,6 +261,15 @@ function mergeSpawnLimits(
   return { ...base, ...override };
 }
 
+function mergeCircuitBreaker(
+  base?: CircuitBreakerConfig,
+  override?: CircuitBreakerConfig
+): CircuitBreakerConfig | undefined {
+  if (!base) return override;
+  if (!override) return base;
+  return { ...base, ...override };
+}
+
 function mergeConfig(base: PluginConfig, override: PluginConfig): PluginConfig {
   return {
     ...base,
@@ -256,6 +281,7 @@ function mergeConfig(base: PluginConfig, override: PluginConfig): PluginConfig {
     retry: mergeRetry(base.retry, override.retry),
     outputCompression: mergeOutputCompression(base.outputCompression, override.outputCompression),
     spawnLimits: mergeSpawnLimits(base.spawnLimits, override.spawnLimits),
+    circuitBreaker: mergeCircuitBreaker(base.circuitBreaker, override.circuitBreaker),
   };
 }
 

--- a/packages/opencode-plugin/src/hooks/__tests__/circuit-breaker.test.ts
+++ b/packages/opencode-plugin/src/hooks/__tests__/circuit-breaker.test.ts
@@ -1,0 +1,444 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import { createCircuitBreakerHook } from "../circuit-breaker";
+
+function makeInput(tool: string, sessionID: string, args: unknown = {}) {
+  return { tool, sessionID, callID: "c-1", args };
+}
+
+function makeOutput(args: unknown = {}) {
+  return { args };
+}
+
+describe("createCircuitBreakerHook", () => {
+  describe("threshold triggering", () => {
+    it("does not trigger on 4 identical calls (below default threshold of 5)", () => {
+      const hook = createCircuitBreakerHook({ threshold: 5 });
+      const args = { command: "ls" };
+
+      for (let i = 0; i < 4; i++) {
+        expect(() =>
+          hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args))
+        ).not.toThrow();
+      }
+    });
+
+    it("triggers on the 5th identical call (reaches threshold)", () => {
+      const hook = createCircuitBreakerHook({ threshold: 5 });
+      const args = { command: "ls" };
+
+      for (let i = 0; i < 4; i++) {
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args));
+      }
+
+      expect(() =>
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args))
+      ).toThrow(/repetitive tool use detected/i);
+    });
+
+    it("uses default threshold of 5 when not configured", () => {
+      const hook = createCircuitBreakerHook();
+      const args = { filePath: "/foo" };
+
+      for (let i = 0; i < 4; i++) {
+        hook["tool.execute.before"](makeInput("read", "s-1", args), makeOutput(args));
+      }
+
+      expect(() =>
+        hook["tool.execute.before"](makeInput("read", "s-1", args), makeOutput(args))
+      ).toThrow();
+    });
+
+    it("respects custom threshold", () => {
+      const hook = createCircuitBreakerHook({ threshold: 3 });
+      const args = { command: "pwd" };
+
+      for (let i = 0; i < 2; i++) {
+        expect(() =>
+          hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args))
+        ).not.toThrow();
+      }
+
+      expect(() =>
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args))
+      ).toThrow();
+    });
+
+    it("continues to trigger on subsequent calls after threshold", () => {
+      const hook = createCircuitBreakerHook({ threshold: 3 });
+      const args = { command: "ls" };
+
+      // Reach threshold
+      for (let i = 0; i < 2; i++) {
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args));
+      }
+
+      // 3rd, 4th, 5th calls all throw
+      for (let i = 0; i < 3; i++) {
+        expect(() =>
+          hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args))
+        ).toThrow(/repetitive tool use detected/i);
+      }
+    });
+  });
+
+  describe("per-session isolation", () => {
+    it("tracks sessions independently — 5 calls across 2 sessions does not trigger either", () => {
+      const hook = createCircuitBreakerHook({ threshold: 5 });
+      const args = { command: "ls" };
+
+      // 3 calls in s-1, 2 calls in s-2 — neither reaches threshold
+      for (let i = 0; i < 3; i++) {
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args));
+      }
+      for (let i = 0; i < 2; i++) {
+        hook["tool.execute.before"](makeInput("bash", "s-2", args), makeOutput(args));
+      }
+
+      // 4th call in s-1 — still below threshold
+      expect(() =>
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args))
+      ).not.toThrow();
+    });
+
+    it("triggers independently per session without affecting the other", () => {
+      const hook = createCircuitBreakerHook({ threshold: 5 });
+      const args = { command: "ls" };
+
+      // Fill s-1 to threshold
+      for (let i = 0; i < 4; i++) {
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args));
+      }
+      expect(() =>
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args))
+      ).toThrow();
+
+      // s-2 is unaffected — 4 calls should not trigger
+      for (let i = 0; i < 4; i++) {
+        expect(() =>
+          hook["tool.execute.before"](makeInput("bash", "s-2", args), makeOutput(args))
+        ).not.toThrow();
+      }
+    });
+  });
+
+  describe("args normalization", () => {
+    it("two calls with same args in different key order count as the same call", () => {
+      const hook = createCircuitBreakerHook({ threshold: 5 });
+
+      // 4 calls with one key order
+      for (let i = 0; i < 4; i++) {
+        hook["tool.execute.before"](
+          makeInput("read", "s-1", { path: "/foo", limit: 100 }),
+          makeOutput({ path: "/foo", limit: 100 })
+        );
+      }
+
+      // 5th call with different key order — should still trigger (same logical args)
+      expect(() =>
+        hook["tool.execute.before"](
+          makeInput("read", "s-1", { limit: 100, path: "/foo" }),
+          makeOutput({ limit: 100, path: "/foo" })
+        )
+      ).toThrow();
+    });
+
+    it("calls with different arg values are distinct and do not trigger", () => {
+      const hook = createCircuitBreakerHook({ threshold: 5 });
+
+      for (let i = 0; i < 10; i++) {
+        const args = { command: `cmd-${i}` };
+        expect(() =>
+          hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args))
+        ).not.toThrow();
+      }
+    });
+
+    it("different tools with same args are tracked independently", () => {
+      const hook = createCircuitBreakerHook({ threshold: 5 });
+      const args = { filePath: "/foo" };
+
+      // 4 calls each for read and write — neither reaches threshold alone
+      for (let i = 0; i < 4; i++) {
+        hook["tool.execute.before"](makeInput("read", "s-1", args), makeOutput(args));
+        hook["tool.execute.before"](makeInput("write", "s-1", args), makeOutput(args));
+      }
+
+      // 5th read call triggers
+      expect(() =>
+        hook["tool.execute.before"](makeInput("read", "s-1", args), makeOutput(args))
+      ).toThrow();
+
+      // 5th write call also triggers
+      expect(() =>
+        hook["tool.execute.before"](makeInput("write", "s-1", args), makeOutput(args))
+      ).toThrow();
+    });
+
+    it("handles nested object args with stable hashing", () => {
+      const hook = createCircuitBreakerHook({ threshold: 3 });
+
+      hook["tool.execute.before"](
+        makeInput("bash", "s-1", { nested: { b: 2, a: 1 } }),
+        makeOutput({ nested: { b: 2, a: 1 } })
+      );
+      hook["tool.execute.before"](
+        makeInput("bash", "s-1", { nested: { a: 1, b: 2 } }),
+        makeOutput({ nested: { a: 1, b: 2 } })
+      );
+
+      // 3rd call — same logical args — should trigger
+      expect(() =>
+        hook["tool.execute.before"](
+          makeInput("bash", "s-1", { nested: { a: 1, b: 2 } }),
+          makeOutput({ nested: { a: 1, b: 2 } })
+        )
+      ).toThrow();
+    });
+
+    it("handles null and undefined args gracefully", () => {
+      const hook = createCircuitBreakerHook({ threshold: 3 });
+
+      // null args
+      hook["tool.execute.before"](makeInput("bash", "s-1", null), makeOutput(null));
+      hook["tool.execute.before"](makeInput("bash", "s-1", null), makeOutput(null));
+
+      expect(() =>
+        hook["tool.execute.before"](makeInput("bash", "s-1", null), makeOutput(null))
+      ).toThrow();
+    });
+
+    it("handles empty args", () => {
+      const hook = createCircuitBreakerHook({ threshold: 3 });
+
+      hook["tool.execute.before"](makeInput("bash", "s-1"), makeOutput());
+      hook["tool.execute.before"](makeInput("bash", "s-1"), makeOutput());
+
+      expect(() => hook["tool.execute.before"](makeInput("bash", "s-1"), makeOutput())).toThrow();
+    });
+  });
+
+  describe("action configuration", () => {
+    it("throws on trigger when action is 'abort' (default)", () => {
+      const hook = createCircuitBreakerHook({ threshold: 5, action: "abort" });
+      const args = { command: "ls" };
+
+      for (let i = 0; i < 4; i++) {
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args));
+      }
+
+      expect(() =>
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args))
+      ).toThrow();
+    });
+
+    it("does not throw on trigger when action is 'warn'", () => {
+      const hook = createCircuitBreakerHook({ threshold: 5, action: "warn" });
+      const args = { command: "ls" };
+
+      for (let i = 0; i < 4; i++) {
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args));
+      }
+
+      expect(() =>
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args))
+      ).not.toThrow();
+    });
+
+    it("logs a warning when action is 'warn' and threshold reached", () => {
+      const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const hook = createCircuitBreakerHook({ threshold: 3, action: "warn" });
+        const args = { command: "ls" };
+
+        for (let i = 0; i < 2; i++) {
+          hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args));
+        }
+
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args));
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0][0]).toMatch(/repetitive tool use detected/i);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("includes tool name and session ID in error message", () => {
+      const hook = createCircuitBreakerHook({ threshold: 2 });
+      const args = { command: "ls" };
+
+      hook["tool.execute.before"](makeInput("bash", "my-session", args), makeOutput(args));
+
+      try {
+        hook["tool.execute.before"](makeInput("bash", "my-session", args), makeOutput(args));
+        // Should not reach here
+        expect(true).toBe(false);
+      } catch (e) {
+        const message = (e as Error).message;
+        expect(message).toContain("bash");
+        expect(message).toContain("my-session");
+        expect(message).toContain("2 times");
+      }
+    });
+  });
+
+  describe("session cleanup", () => {
+    it("clears tracking on session.deleted event", async () => {
+      const hook = createCircuitBreakerHook({ threshold: 5 });
+      const args = { command: "ls" };
+
+      // Fill to 4 calls
+      for (let i = 0; i < 4; i++) {
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args));
+      }
+
+      // Delete session
+      await hook.event({
+        event: { type: "session.deleted", properties: { sessionID: "s-1" } },
+      });
+
+      // Counter reset — 4 more calls should not trigger
+      for (let i = 0; i < 4; i++) {
+        expect(() =>
+          hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args))
+        ).not.toThrow();
+      }
+    });
+
+    it("ignores session.deleted for unknown session without error", async () => {
+      const hook = createCircuitBreakerHook({ threshold: 5 });
+
+      await expect(
+        hook.event({ event: { type: "session.deleted", properties: { sessionID: "unknown" } } })
+      ).resolves.toBeUndefined();
+    });
+
+    it("does not affect other sessions on session.deleted", async () => {
+      const hook = createCircuitBreakerHook({ threshold: 5 });
+      const args = { command: "ls" };
+
+      // Fill both sessions to 4 calls
+      for (let i = 0; i < 4; i++) {
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args));
+        hook["tool.execute.before"](makeInput("bash", "s-2", args), makeOutput(args));
+      }
+
+      // Delete s-1
+      await hook.event({
+        event: { type: "session.deleted", properties: { sessionID: "s-1" } },
+      });
+
+      // s-2 still at 4 calls — 5th should trigger
+      expect(() =>
+        hook["tool.execute.before"](makeInput("bash", "s-2", args), makeOutput(args))
+      ).toThrow();
+
+      // s-1 was reset — should not trigger
+      expect(() =>
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args))
+      ).not.toThrow();
+    });
+
+    it("ignores non-session.deleted events", async () => {
+      const hook = createCircuitBreakerHook({ threshold: 5 });
+      const args = { command: "ls" };
+
+      // Fill to 4 calls
+      for (let i = 0; i < 4; i++) {
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args));
+      }
+
+      // Non-session.deleted event should not clear tracking
+      await hook.event({
+        event: { type: "session.created", properties: { sessionID: "s-1" } },
+      });
+
+      // 5th call should still trigger
+      expect(() =>
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args))
+      ).toThrow();
+    });
+
+    it("handles session.deleted with info.id format", async () => {
+      const hook = createCircuitBreakerHook({ threshold: 5 });
+      const args = { command: "ls" };
+
+      for (let i = 0; i < 4; i++) {
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args));
+      }
+
+      // Use info.id format (alternative shape handled by resolveSessionID)
+      await hook.event({
+        event: { type: "session.deleted", properties: { info: { id: "s-1" } } },
+      });
+
+      // Counter should be reset
+      for (let i = 0; i < 4; i++) {
+        expect(() =>
+          hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args))
+        ).not.toThrow();
+      }
+    });
+  });
+
+  describe("disabled state", () => {
+    it("never triggers when enabled is false, even after many identical calls", () => {
+      const hook = createCircuitBreakerHook({ enabled: false, threshold: 5 });
+      const args = { command: "ls" };
+
+      for (let i = 0; i < 10; i++) {
+        expect(() =>
+          hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args))
+        ).not.toThrow();
+      }
+    });
+
+    it("is enabled by default when enabled is not specified", () => {
+      const hook = createCircuitBreakerHook({ threshold: 3 });
+      const args = { command: "ls" };
+
+      for (let i = 0; i < 2; i++) {
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args));
+      }
+
+      expect(() =>
+        hook["tool.execute.before"](makeInput("bash", "s-1", args), makeOutput(args))
+      ).toThrow();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles missing sessionID gracefully (no-op)", () => {
+      const hook = createCircuitBreakerHook({ threshold: 2 });
+      const args = { command: "ls" };
+
+      // Calls without sessionID should be silently ignored
+      for (let i = 0; i < 10; i++) {
+        expect(() =>
+          hook["tool.execute.before"]({ tool: "bash", callID: "c-1", args }, makeOutput(args))
+        ).not.toThrow();
+      }
+    });
+
+    it("uses output.args for hashing (consistent with tool.execute.before pattern)", () => {
+      const hook = createCircuitBreakerHook({ threshold: 3 });
+
+      // Input args differ but output.args are the same — should count as same
+      hook["tool.execute.before"](
+        makeInput("read", "s-1", { different: "input" }),
+        makeOutput({ path: "/foo" })
+      );
+      hook["tool.execute.before"](
+        makeInput("read", "s-1", { also: "different" }),
+        makeOutput({ path: "/foo" })
+      );
+
+      expect(() =>
+        hook["tool.execute.before"](
+          makeInput("read", "s-1", { yet: "another" }),
+          makeOutput({ path: "/foo" })
+        )
+      ).toThrow();
+    });
+  });
+});

--- a/packages/opencode-plugin/src/hooks/circuit-breaker.ts
+++ b/packages/opencode-plugin/src/hooks/circuit-breaker.ts
@@ -1,0 +1,100 @@
+import type { CircuitBreakerConfig } from "../config";
+import { isRecord, resolveSessionID } from "./utils";
+
+const DEFAULT_THRESHOLD = 5;
+const DEFAULT_ACTION = "abort" as const;
+
+/**
+ * Produce a stable JSON string regardless of key insertion order.
+ * Uses a JSON.stringify replacer to recursively sort object keys.
+ * e.g. {b:1,a:2} and {a:2,b:1} both produce '{"a":2,"b":1}'
+ */
+function sortedStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, v: unknown) => {
+    if (v !== null && typeof v === "object" && !Array.isArray(v)) {
+      const r = v as Record<string, unknown>;
+      const s: Record<string, unknown> = {};
+      for (const k of Object.keys(r).sort()) {
+        s[k] = r[k];
+      }
+      return s;
+    }
+    return v;
+  });
+}
+
+/**
+ * Circuit breaker hook that detects repetitive identical tool calls per session.
+ *
+ * Tracking structure: Map<sessionID, Map<"toolName:argsHash", callCount>>
+ *
+ * Triggers when count reaches threshold (default 5).
+ * action "abort": throws Error (rejects the tool call, does not abort session).
+ * action "warn": logs to console.warn only.
+ * Cleanup: clears session tracking on session.deleted event.
+ */
+export function createCircuitBreakerHook(config: CircuitBreakerConfig = {}) {
+  const enabled = config.enabled !== false;
+  const threshold = config.threshold ?? DEFAULT_THRESHOLD;
+  const action = config.action ?? DEFAULT_ACTION;
+
+  // Map<sessionID, Map<"toolName:argsHash", count>>
+  const sessionCounts = new Map<string, Map<string, number>>();
+
+  const toolExecuteBefore = (
+    input: { tool: string; sessionID?: string; callID?: string; args?: unknown },
+    output: { args?: unknown }
+  ): void => {
+    if (!enabled) return;
+
+    const sessionID = typeof input.sessionID === "string" ? input.sessionID : undefined;
+    if (!sessionID) return;
+
+    const toolName = typeof input.tool === "string" ? input.tool : "";
+    // Args live in output.args (parsed tool input) in tool.execute.before
+    const args = isRecord(output) && "args" in output ? output.args : input.args;
+    const argsHash = sortedStringify(args ?? {});
+    const key = `${toolName}:${argsHash}`;
+
+    let sessionMap = sessionCounts.get(sessionID);
+    if (!sessionMap) {
+      sessionMap = new Map<string, number>();
+      sessionCounts.set(sessionID, sessionMap);
+    }
+
+    const count = (sessionMap.get(key) ?? 0) + 1;
+    sessionMap.set(key, count);
+
+    if (count >= threshold) {
+      const message =
+        `[circuit-breaker] Repetitive tool use detected: "${toolName}" called ${count} times ` +
+        `with identical arguments in session "${sessionID}". ` +
+        "This may indicate a stuck loop. Vary your approach or use a different tool.";
+
+      if (action === "abort") {
+        throw new Error(message);
+      } else {
+        console.warn(message);
+      }
+    }
+  };
+
+  const event = async ({
+    event,
+  }: {
+    event: { type: string; properties?: unknown };
+  }): Promise<void> => {
+    if (event.type === "session.deleted") {
+      const props = isRecord(event.properties) ? event.properties : undefined;
+      const sessionID = resolveSessionID(props);
+      if (sessionID) {
+        sessionCounts.delete(sessionID);
+      }
+    }
+  };
+
+  return {
+    "tool.execute.before": toolExecuteBefore,
+    event,
+  };
+}

--- a/packages/opencode-plugin/src/index.ts
+++ b/packages/opencode-plugin/src/index.ts
@@ -7,6 +7,7 @@ import { loadPluginConfig, mergePermissionConfig } from "./config";
 import { BackgroundTaskManager, createDelegationTools } from "./delegation";
 import { anthropicEffortHook } from "./hooks/anthropic-effort";
 import { createBackgroundNotificationHook } from "./hooks/background-notification";
+import { createCircuitBreakerHook } from "./hooks/circuit-breaker";
 import { COMPACTION_CONTEXT_TEMPLATE } from "./hooks/compaction-context-injector";
 import { createCompactionTodoPreserverHook } from "./hooks/compaction-todo-preserver";
 import { createGitHubAppCredentialsHook } from "./hooks/github-app-credentials";
@@ -90,6 +91,7 @@ const OpenCodeLegion: Plugin = async (ctx) => {
   const githubAppCredentialsHook = createGitHubAppCredentialsHook();
   const contextSearchTool = createContextSearchTool(outputCompressionHook.getStore);
   const sessionRecoveryHook = createSessionRecoveryHook(ctx);
+  const circuitBreakerHook = createCircuitBreakerHook(pluginConfig.circuitBreaker ?? {});
   const stopContinuationGuardHook = createStopContinuationGuardHook();
   const compactionTodoPreserver = createCompactionTodoPreserverHook(ctx);
   const todoContinuationEnforcer = createTodoContinuationEnforcerHook(ctx, {
@@ -161,6 +163,7 @@ const OpenCodeLegion: Plugin = async (ctx) => {
         if (sessionID) {
           await manager.cleanup(sessionID);
         }
+        await circuitBreakerHook.event({ event });
       }
 
       if (event.type === "session.error") {
@@ -190,6 +193,7 @@ const OpenCodeLegion: Plugin = async (ctx) => {
       anthropicEffortHook(input, output);
     },
     "tool.execute.before": async (input, output) => {
+      circuitBreakerHook["tool.execute.before"](input, output);
       subagentQuestionBlockerHook(input, output);
       const toolInput = isRecord(input) ? (input as ToolExecuteInput) : undefined;
       const toolName = typeof toolInput?.tool === "string" ? toolInput.tool : undefined;


### PR DESCRIPTION
Closes #272

## Summary

Adds a `tool.execute.before` hook that detects when an agent calls the same tool with identical arguments repeatedly (indicating a stuck loop), and either warns or aborts the call when a configurable threshold is reached.

### Changes
- **Config** (`config/index.ts`): Added `CircuitBreakerConfig` interface, Zod schema, and merge function. Fields: `enabled` (boolean), `threshold` (number, default 5), `action` ("warn" | "abort", default "abort").
- **Hook** (`hooks/circuit-breaker.ts`): Factory function returning `tool.execute.before` handler and `event` handler. Tracks `Map<sessionID, Map<"toolName:argsHash", count>>`. Uses stable key-sorted JSON for arg comparison. Cleans up on `session.deleted`.
- **Wiring** (`index.ts`): Circuit breaker runs first in `tool.execute.before` chain. Session cleanup wired into `session.deleted` event block.
- **Tests** (`hooks/__tests__/circuit-breaker.test.ts`): 26 tests covering threshold triggering, per-session isolation, args normalization (key order, nested objects, null/empty), action configuration (abort/warn), session cleanup, disabled state, and edge cases.

### Acceptance Criteria
- [x] TDD: failing test first, then implementation
- [x] 5 identical tool calls (same tool + same args) triggers the breaker
- [x] Warning/abort behavior is configurable via plugin config
- [x] Per-session tracking — different sessions have independent counters
- [x] Tracking cleaned up on session.deleted event
- [x] 4 identical calls does NOT trigger (below threshold)