### PR TITLE
sjawhar-legion-452: infra: Configure SSM Session Manager access for dev box

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,21 +1,26 @@
 {
   "filesChanged": [
-    "packages/daemon/src/state/backends/issue-tracker.ts",
-    "packages/daemon/src/state/backends/github.ts",
-    "packages/daemon/src/state/backends/linear.ts",
-    "packages/daemon/src/daemon/server.ts",
-    "packages/daemon/src/state/backends/__tests__/mutations.test.ts"
+    "packages/aws-infra/index.ts",
+    "packages/aws-infra/docs/ssm-setup-runbook.md"
   ],
   "trickyParts": [
-    "Threading IssueSource through the IssueTracker interface required updating the interface, both implementations (GitHub + Linear), all callers in server.ts, and the mutation tests — a wider surface area than the other fixes",
-    "The remove_worker_active_and_redispatch fix needed to be non-blocking (try/catch) to avoid label removal failures preventing the redispatch"
+    "Extracted devAccountProvider from the security group if-block to a shared top-level provider so both IAM resources and security group can use it. Region now derived from aws.config.region instead of hardcoded us-west-1, following the brownfield adoption learning from #453."
   ],
   "deviations": [
-    "Envoy fast-path for auto-progression (P2 #6) not implemented — this was already a documented deliberate deferral from the original implementation. The daemon has no established Envoy consumer pattern; the 60s health tick fallback provides the same functionality with higher latency."
+    "Previous PR #480 was a standalone implementation. This PR reuses the existing devAccountProvider pattern from #453/PR#500 and refactors it to be shared. The IAM resources are always created (not config-gated) since they are new resources, unlike the security group which is an existing brownfield import."
   ],
-  "openQuestions": [],
+  "openQuestions": [
+    "Instance profile attachment is a manual CLI operation documented in the runbook — the EC2 instance itself is not Pulumi-managed. Operator must run the attachment after pulumi up."
+  ],
   "subPlanningNeeded": false,
+  "learningsInjected": [
+    "docs/solutions/infra/pulumi-cross-account-brownfield-adoption.md",
+    "docs/solutions/infra/pulumi-aws-identity-center-patterns.md"
+  ],
+  "learningsHelpful": [
+    "docs/solutions/infra/pulumi-cross-account-brownfield-adoption.md"
+  ],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-13T06:43:08.023Z"
+  "completed": "2026-04-13T13:20:52.349Z"
 }

--- a/packages/aws-infra/docs/ssm-setup-runbook.md
+++ b/packages/aws-infra/docs/ssm-setup-runbook.md
@@ -1,0 +1,188 @@
+# SSM Session Manager Setup Runbook
+
+This runbook covers deploying the SSM IAM resources via Pulumi and attaching the instance
+profile to the dev box. The IAM resources (role + instance profile) are Pulumi-managed;
+the instance profile attachment is a one-time CLI operation since the EC2 instance itself
+is not Pulumi-managed.
+
+**Prerequisites:**
+- Pulumi stack `prod` is configured with `devAccountRoleArn` (or running with dev-account credentials)
+- AWS CLI v2 with access to the dev account
+- Dev box instance ID: `i-0d1244b687e204a01` (us-west-1)
+
+---
+
+## 1. Deploy IAM Resources via Pulumi
+
+```bash
+cd packages/aws-infra
+pulumi up -s prod
+```
+
+This creates:
+- **EC2SSMRole** — IAM role with `ec2.amazonaws.com` trust policy
+- **EC2SSMInstanceProfile** — Instance profile wrapping EC2SSMRole
+- **AmazonSSMManagedInstanceCore** policy attachment on the role
+
+Verify the outputs:
+
+```bash
+pulumi stack output ec2SsmRoleArn -s prod
+pulumi stack output ec2SsmInstanceProfileArn -s prod
+pulumi stack output ec2SsmInstanceProfileName -s prod
+```
+
+---
+
+## 2. Check Existing Instance Profile
+
+Before attaching, check if the instance already has an instance profile:
+
+```bash
+aws ec2 describe-instances \
+  --instance-ids i-0d1244b687e204a01 \
+  --query 'Reservations[].Instances[].IamInstanceProfile' \
+  --output json \
+  --profile dev
+```
+
+- If the result is `null` or `[]` — proceed to step 3.
+- If a different profile is attached — you must disassociate it first:
+  ```bash
+  # Get the association ID
+  aws ec2 describe-iam-instance-profile-associations \
+    --filters Name=instance-id,Values=i-0d1244b687e204a01 \
+    --query 'IamInstanceProfileAssociations[0].AssociationId' \
+    --output text \
+    --profile dev
+
+  # Replace the profile (no instance stop required)
+  aws ec2 replace-iam-instance-profile-association \
+    --iam-instance-profile Name=EC2SSMInstanceProfile \
+    --association-id <association-id> \
+    --profile dev
+  ```
+
+---
+
+## 3. Attach Instance Profile
+
+Attaching a new instance profile to a running instance does **not** require stopping it
+(only replacing an existing one may, in some older API versions — but `associate` always works
+on instances with no profile).
+
+```bash
+aws ec2 associate-iam-instance-profile \
+  --iam-instance-profile Name=EC2SSMInstanceProfile \
+  --instance-id i-0d1244b687e204a01 \
+  --profile dev
+```
+
+Verify:
+
+```bash
+aws ec2 describe-instances \
+  --instance-ids i-0d1244b687e204a01 \
+  --query 'Reservations[].Instances[].IamInstanceProfile.Arn' \
+  --output text \
+  --profile dev
+```
+
+The output should contain `EC2SSMInstanceProfile`.
+
+---
+
+## 4. Verify SSM Agent
+
+SSH into the dev box (via Tailscale) and check the SSM agent:
+
+```bash
+ssh sami@sami
+sudo systemctl status amazon-ssm-agent
+```
+
+- If **active (running)** — proceed to step 5.
+- If **not found** — install it:
+  ```bash
+  # Ubuntu
+  sudo snap install amazon-ssm-agent --classic
+  sudo systemctl enable --now snap.amazon-ssm-agent.amazon-ssm-agent.service
+
+  # Amazon Linux 2
+  sudo yum install -y amazon-ssm-agent
+  sudo systemctl enable --now amazon-ssm-agent
+  ```
+- If **inactive** — start it:
+  ```bash
+  sudo systemctl start amazon-ssm-agent
+  ```
+
+---
+
+## 5. Verify SSM Connectivity
+
+The SSM agent needs outbound HTTPS (port 443) to reach these endpoints:
+- `ssm.us-west-1.amazonaws.com`
+- `ssmmessages.us-west-1.amazonaws.com`
+- `ec2messages.us-west-1.amazonaws.com`
+
+Check from the dev box:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" https://ssm.us-west-1.amazonaws.com
+# Should return 200 or 403 (reachable — 403 just means no valid auth header)
+```
+
+Check that the instance appears in SSM:
+
+```bash
+aws ssm describe-instance-information \
+  --filters "Key=InstanceIds,Values=i-0d1244b687e204a01" \
+  --profile dev
+```
+
+The instance should appear with `PingStatus: Online`. If it doesn't appear, wait 2-3
+minutes for the agent to register after the instance profile was attached.
+
+---
+
+## 6. Test a Session
+
+```bash
+aws ssm start-session --target i-0d1244b687e204a01 --profile dev
+```
+
+This should open an interactive shell. Type `whoami` to confirm you're on the instance,
+then `exit` to close the session.
+
+### With IAM Identity Center (SSO) credentials:
+
+```bash
+aws sso login --profile dev
+aws ssm start-session --target i-0d1244b687e204a01 --profile dev
+```
+
+---
+
+## Troubleshooting
+
+### Instance not appearing in SSM
+
+1. Verify instance profile is attached (step 3 verification command)
+2. Verify SSM agent is running (step 4)
+3. Verify outbound HTTPS connectivity (step 5)
+4. Check agent logs: `sudo journalctl -u amazon-ssm-agent -n 50` (or snap equivalent)
+5. Wait 2-5 minutes after attaching the profile — the agent re-registers on a timer
+
+### "TargetNotConnected" error
+
+Same as above — the instance isn't registered with SSM. Most common causes:
+- Instance profile not attached
+- SSM agent not running
+- No outbound HTTPS to SSM endpoints (check security group egress rules)
+
+### "AccessDeniedException" on start-session
+
+The IAM user/role doesn't have `ssm:StartSession` permission. For IAM Identity Center
+users, verify they have the `Developer` permission set assigned (which includes the
+SSM inline policy).

--- a/packages/aws-infra/index.ts
+++ b/packages/aws-infra/index.ts
@@ -204,6 +204,78 @@ new aws.ssoadmin.AccountAssignment("engineers-prod-readOnly", {
 });
 
 // ---------------------------------------------------------------------------
+// Cross-Account Provider (dev account)
+// ---------------------------------------------------------------------------
+// Explicit provider for dev account resources — assumes a role in the dev
+// account so this management-account stack can manage cross-account resources.
+// If devAccountRoleArn is not set, falls back to ambient credentials (useful
+// when running with dev-account credentials directly).
+// ---------------------------------------------------------------------------
+
+const devAccountRoleArn = cfg.get("devAccountRoleArn");
+
+const devAccountProvider = new aws.Provider("dev-account", {
+  region: aws.config.region ?? "us-west-1",
+  ...(devAccountRoleArn ? { assumeRole: { roleArn: devAccountRoleArn } } : {}),
+});
+
+// ---------------------------------------------------------------------------
+// Dev Box SSM Instance Profile (cross-account — lives in dev account)
+// ---------------------------------------------------------------------------
+// IAM role + instance profile for SSM Session Manager access to the dev box.
+// The role has the AmazonSSMManagedInstanceCore managed policy which covers
+// SSM agent communication (ssmmessages, ssm:UpdateInstanceInformation, etc.).
+//
+// After `pulumi up`, the operator must attach the instance profile to the
+// dev box instance. See docs/ssm-setup-runbook.md for the full procedure.
+// ---------------------------------------------------------------------------
+
+const ec2SsmRole = new aws.iam.Role(
+  "ec2-ssm-role",
+  {
+    name: "EC2SSMRole",
+    description: "Allows EC2 instances to communicate with SSM for Session Manager access",
+    assumeRolePolicy: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "ec2.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    }),
+    tags: {
+      ManagedBy: "pulumi",
+      Purpose: "SSM Session Manager access for EC2 instances",
+    },
+  },
+  { provider: devAccountProvider }
+);
+
+new aws.iam.RolePolicyAttachment(
+  "ec2-ssm-core-policy",
+  {
+    role: ec2SsmRole.name,
+    policyArn: "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+  },
+  { provider: devAccountProvider }
+);
+
+const ec2SsmInstanceProfile = new aws.iam.InstanceProfile(
+  "ec2-ssm-instance-profile",
+  {
+    name: "EC2SSMInstanceProfile",
+    role: ec2SsmRole.name,
+    tags: {
+      ManagedBy: "pulumi",
+      Purpose: "SSM Session Manager access for EC2 instances",
+    },
+  },
+  { provider: devAccountProvider }
+);
+
+// ---------------------------------------------------------------------------
 // Dev Box Security Group (cross-account — lives in dev account)
 // ---------------------------------------------------------------------------
 // The dev box security group is an existing resource adopted via `pulumi import`.
@@ -217,20 +289,10 @@ new aws.ssoadmin.AccountAssignment("engineers-prod-readOnly", {
 // ---------------------------------------------------------------------------
 
 const devBoxSecurityGroupId = cfg.get("devBoxSecurityGroupId");
-const devAccountRoleArn = cfg.get("devAccountRoleArn");
 
 let devBoxSgId: pulumi.Output<string> | undefined;
 
 if (devBoxSecurityGroupId) {
-  // Explicit provider for dev account resources — assumes a role in the dev
-  // account so this management-account stack can manage cross-account resources.
-  // If devAccountRoleArn is not set, falls back to ambient credentials (useful
-  // when running with dev-account credentials directly).
-  const devAccountProvider = new aws.Provider("dev-account", {
-    region: "us-west-1",
-    ...(devAccountRoleArn ? { assumeRole: { roleArn: devAccountRoleArn } } : {}),
-  });
-
   const devBoxSg = new aws.ec2.SecurityGroup(
     "dev-box-sg",
     {
@@ -274,3 +336,6 @@ export const readOnlyPermissionSetArn = readOnlyPermissionSet.arn;
 export const adminsGroupId = adminsGroup.groupId;
 export const engineersGroupId = engineersGroup.groupId;
 export { devBoxSgId as devBoxSecurityGroupId };
+export const ec2SsmRoleArn = ec2SsmRole.arn;
+export const ec2SsmInstanceProfileArn = ec2SsmInstanceProfile.arn;
+export const ec2SsmInstanceProfileName = ec2SsmInstanceProfile.name;


### PR DESCRIPTION
Closes #452

## Summary

Adds Pulumi-managed IAM resources for SSM Session Manager access to the dev box:

- **EC2SSMRole** — IAM role with `ec2.amazonaws.com` trust policy and `AmazonSSMManagedInstanceCore` managed policy
- **EC2SSMInstanceProfile** — Instance profile wrapping the role
- Exports: role ARN, instance profile ARN, instance profile name
- **SSM setup runbook** (`packages/aws-infra/docs/ssm-setup-runbook.md`) with step-by-step guide for deployment, instance profile attachment, SSM agent verification, and session testing

### Refactoring

Extracted the `devAccountProvider` from the security group `if` block to a shared cross-account provider used by both the IAM resources and the security group. The provider now derives its region from `aws.config.region` (stack config) instead of hardcoding `us-west-1`, following the brownfield adoption learning from #453.

### Deployment

After `pulumi up`, the operator must attach the instance profile to the dev box:

```bash
aws ec2 associate-iam-instance-profile \
  --iam-instance-profile Name=EC2SSMInstanceProfile \
  --instance-id i-0d1244b687e204a01 \
  --profile dev
```

See `packages/aws-infra/docs/ssm-setup-runbook.md` for the full procedure including SSM agent verification and session testing.