### PR TITLE
sjawhar-legion-495: add subscribe/unsubscribe request logging to listener

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,21 +1,12 @@
 {
   "filesChanged": [
-    "packages/daemon/src/state/backends/issue-tracker.ts",
-    "packages/daemon/src/state/backends/github.ts",
-    "packages/daemon/src/state/backends/linear.ts",
-    "packages/daemon/src/daemon/server.ts",
-    "packages/daemon/src/state/backends/__tests__/mutations.test.ts"
+    "packages/envoy/cmd/listener/main.go"
   ],
-  "trickyParts": [
-    "Threading IssueSource through the IssueTracker interface required updating the interface, both implementations (GitHub + Linear), all callers in server.ts, and the mutation tests — a wider surface area than the other fixes",
-    "The remove_worker_active_and_redispatch fix needed to be non-blocking (try/catch) to avoid label removal failures preventing the redispatch"
-  ],
-  "deviations": [
-    "Envoy fast-path for auto-progression (P2 #6) not implemented — this was already a documented deliberate deferral from the original implementation. The daemon has no established Envoy consumer pattern; the 60s health tick fallback provides the same functionality with higher latency."
-  ],
+  "trickyParts": [],
+  "deviations": [],
   "openQuestions": [],
   "subPlanningNeeded": false,
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-13T06:43:08.023Z"
+  "completed": "2026-04-13T13:18:44.721Z"
 }

--- a/packages/envoy/cmd/listener/main.go
+++ b/packages/envoy/cmd/listener/main.go
@@ -336,12 +336,13 @@ func main() {
 			Dir       string   `json:"dir"`
 			Topics    []string `json:"topics"`
 			Port      int      `json:"port"`
-		Title     string   `json:"title"`
+			Title     string   `json:"title"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			http.Error(w, "invalid json", http.StatusBadRequest)
 			return
 		}
+		log.Printf("listener subscribe session=%s topics=%v port=%d dir=%s", body.SessionID, body.Topics, body.Port, body.Dir)
 		d := deps.Load()
 		item, err := d.registry.Upsert(store.Interest{
 			SessionID: body.SessionID,
@@ -378,6 +379,7 @@ func main() {
 			http.Error(w, "invalid json", http.StatusBadRequest)
 			return
 		}
+		log.Printf("listener unsubscribe session=%s topics=%v", body.SessionID, body.Topics)
 		d := deps.Load()
 		if err := d.registry.Remove(body.SessionID, body.Topics); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Closes #495

## Summary

Add `log.Printf` calls to the Envoy listener's subscribe and unsubscribe HTTP handlers to log session ID, topics, port, and dir on each request. This enables tracing which caller is re-subscribing dead sessions.

**Changes:**
- Subscribe handler (`/v1/interests/subscribe`): logs session ID, topics, port, and dir after body decode
- Unsubscribe handler (`/v1/interests/unsubscribe`): logs session ID and topics after body decode