### PR TITLE
sjawhar-legion-270: OMO replacement matrix contract tests (T1)

### DIFF
--- a/.github/workflows/pr-and-main.yaml
+++ b/.github/workflows/pr-and-main.yaml
@@ -64,5 +64,5 @@ jobs:
         working-directory: packages/daemon
 
       - name: Test opencode-plugin
-        run: bun test
+        run: bun test --path-ignore-patterns '**/omo-replacement-matrix*'
         working-directory: packages/opencode-plugin

--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,12 +1,18 @@
 {
   "filesChanged": [
-    "packages/envoy/cmd/listener/main.go"
+    "packages/opencode-plugin/src/__tests__/omo-replacement-matrix.test.ts",
+    ".github/workflows/pr-and-main.yaml"
   ],
-  "trickyParts": [],
-  "deviations": [],
+  "trickyParts": [
+    "Contract tests designed to FAIL conflict with CI requiring green tests. Resolved by adding --path-ignore-patterns to CI workflow to exclude contract tests from default bun test, while keeping them runnable explicitly via direct path."
+  ],
+  "deviations": [
+    "Converted it.todo() back to it() with active assertions per tester feedback — spec requires non-zero exit with >= 15 failures, not skipped todos",
+    "Modified .github/workflows/pr-and-main.yaml to exclude contract tests from CI — necessary to satisfy both spec (tests must fail) and CI (must be green)"
+  ],
   "openQuestions": [],
   "subPlanningNeeded": false,
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-13T13:18:44.721Z"
+  "completed": "2026-04-13T14:42:11.826Z"
 }

--- a/.legion/retro.json
+++ b/.legion/retro.json
@@ -1,10 +1,9 @@
 {
   "skipped": false,
   "docsCreated": [
-    "docs/solutions/daemon/multi-backend-mutation-target-pattern.md",
-    "docs/solutions/daemon/self-fetch-endpoint-composition.md"
+    "docs/solutions/testing/intentionally-failing-contract-tests.md"
   ],
   "schemaVersion": 1,
   "phase": "retro",
-  "completed": "2026-04-13T07:08:22.727Z"
+  "completed": "2026-04-13T15:06:20.510Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,28 +1,43 @@
 {
   "critical": 0,
-  "important": 0,
+  "important": 3,
   "minor": 3,
   "verdict": "approved",
   "keyFindings": [
     {
-      "severity": "P3",
-      "file": "packages/daemon/src/daemon/server.ts",
-      "description": "--stage casts payload.stage as WorkerModeLiteral without local validation"
+      "severity": "P2",
+      "file": "packages/opencode-plugin/src/__tests__/omo-replacement-matrix.test.ts",
+      "description": "Area 3 agent tests lock in OMO's Greek mythology role names — may need adjustment if downstream uses a mapping lookup instead of renaming agents"
+    },
+    {
+      "severity": "P2",
+      "file": "packages/opencode-plugin/src/__tests__/omo-replacement-matrix.test.ts",
+      "description": "Area 2 tests prescribe specific public API method names (getDepth, getDescendantCount, enforceSpawnLimits) that may not match the final implementation design"
+    },
+    {
+      "severity": "P2",
+      "file": "packages/opencode-plugin/src/__tests__/omo-replacement-matrix.test.ts",
+      "description": "Function.length arity checks (lines 146, 172) won't detect implementations using default parameters"
     },
     {
       "severity": "P3",
-      "file": "packages/daemon/src/state/backends/github.ts",
-      "description": "runGhCommand is not injectable/testable like fetch.ts:CommandRunner pattern"
+      "file": "packages/opencode-plugin/src/__tests__/omo-replacement-matrix.test.ts",
+      "description": "Header comment references #200 but PR closes #270 — both correct but could confuse readers"
     },
     {
       "severity": "P3",
-      "file": "packages/daemon/src/state/backends/github.ts",
-      "description": "No integration tests for transitionIssue GraphQL mutation parsing paths"
+      "file": "packages/opencode-plugin/src/__tests__/omo-replacement-matrix.test.ts",
+      "description": "No meta-test enforcing 'all 23 tests fail' invariant"
+    },
+    {
+      "severity": "P3",
+      "file": "packages/opencode-plugin/src/__tests__/omo-replacement-matrix.test.ts",
+      "description": "asRecord helper could use a JSDoc note explaining its purpose"
     }
   ],
   "learningsInjected": [],
   "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-13T06:59:03.836Z"
+  "completed": "2026-04-13T14:55:33.538Z"
 }

--- a/.legion/test.json
+++ b/.legion/test.json
@@ -1,25 +1,16 @@
 {
-  "passed": 22,
+  "passed": 5,
   "failed": 0,
   "failures": [],
-  "documentationFeedback": "Design doc thorough. Controller skill section well-documented with examples. Minor: design doc mentions repo? body param but implementation resolves from cache.",
+  "documentationFeedback": "PR body is thorough with coverage table and changes-from-tester-feedback section. Test file header and section comments are clear. Minor gap: no note in test file about CI exclusion pattern.",
   "observations": [
-    "All P1 and P2 review findings correctly addressed",
-    "IssueMutationTarget with resolveTarget() is a clean solution for hyphenated-owner problem",
-    "Non-blocking try/catch on remove_worker_active_and_redispatch label removal is correct design",
-    "No tests for transition_to_* actions, relay_user_feedback prompt, or resolveTarget source preference (P2 test gaps)",
-    "3 pre-existing test failures unrelated to PR (killStaleServe flaky, @pulumi/docker missing)"
+    "Previous test failures (it.todo exit code 0) correctly fixed by converting to it() with active assertions",
+    "CI workflow excludes contract tests via --path-ignore-patterns — sound approach for intentionally-failing tests",
+    "Function arity checks (createPreemptiveCompactionHook.length, getModelOverlay.length) are slightly fragile but acceptable for contract tests"
   ],
-  "learningsInjected": [
-    "docs/solutions/daemon/controller-lifecycle-separation.md",
-    "docs/solutions/integration-patterns/controller-worker-protocol.md",
-    "docs/solutions/integration-issues/github-graphql-pr-draft-status.md"
-  ],
-  "learningsHelpful": [
-    "docs/solutions/daemon/controller-lifecycle-separation.md",
-    "docs/solutions/integration-patterns/controller-worker-protocol.md"
-  ],
+  "learningsInjected": [],
+  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "test",
-  "completed": "2026-04-13T06:51:35.642Z"
+  "completed": "2026-04-13T14:48:16.831Z"
 }

--- a/docs/solutions/index.json
+++ b/docs/solutions/index.json
@@ -344,6 +344,11 @@
     "tag:endpoint-composition": ["daemon/self-fetch-endpoint-composition.md"],
     "tag:http": ["daemon/self-fetch-endpoint-composition.md"],
     "tag:technical-debt": ["daemon/self-fetch-endpoint-composition.md"],
-    "tag:server": ["daemon/self-fetch-endpoint-composition.md"]
+    "tag:server": ["daemon/self-fetch-endpoint-composition.md"],
+    "packages/opencode-plugin/src/__tests__": ["testing/intentionally-failing-contract-tests.md"],
+    ".github/workflows": ["testing/intentionally-failing-contract-tests.md"],
+    "tag:contract-tests": ["testing/intentionally-failing-contract-tests.md"],
+    "tag:omo-replacement": ["testing/intentionally-failing-contract-tests.md"],
+    "tag:path-ignore-patterns": ["testing/intentionally-failing-contract-tests.md"]
   }
 }

--- a/docs/solutions/testing/intentionally-failing-contract-tests.md
+++ b/docs/solutions/testing/intentionally-failing-contract-tests.md
@@ -1,0 +1,97 @@
+---
+title: "Intentionally-Failing Contract Tests and CI Exclusion"
+category: testing
+tags:
+  - contract-tests
+  - ci
+  - bun-test
+  - omo-replacement
+  - path-ignore-patterns
+  - test-design
+date: 2026-04-13
+status: active
+related_issues:
+  - "270"
+symptoms:
+  - "contract tests designed to fail break CI"
+  - "it.todo() produces exit code 0 instead of non-zero"
+  - "tests must fail but CI must be green"
+  - "bun test --path-ignore-patterns"
+---
+
+# Intentionally-Failing Contract Tests and CI Exclusion
+
+## Context
+
+When writing contract tests that define an acceptance gate (all tests must FAIL initially, proving
+capability gaps), there is a fundamental tension: CI requires green builds, but the spec requires
+non-zero exit with failing tests. This came up in the OMO replacement matrix (issue #270).
+
+## Key Learnings
+
+### 1. `it.todo()` Is Not a Failing Test
+
+`it.todo()` marks a test as "not yet written" — it produces exit code 0 with "N todo, 0 fail."
+This is semantically different from a test that proves a gap exists.
+
+- **`it.todo()`** = placeholder = exit 0 = CI green = **no proof of gap**
+- **`it()` with real assertion** = active test = exit 1 = **proves the gap**
+
+For contract tests, always use active assertions (`expect(module.foo).toBeDefined()`) that will
+fail when the feature is missing. Reserve `it.todo()` for tests you haven't written yet.
+
+### 2. CI Exclusion via `--path-ignore-patterns`
+
+Bun's test runner supports `--path-ignore-patterns` to exclude files from the default test run:
+
+```yaml
+# .github/workflows/pr-and-main.yaml
+- name: Test opencode-plugin
+  run: bun test --path-ignore-patterns '**/omo-replacement-matrix*'
+```
+
+This keeps contract tests runnable on demand (`bun test path/to/file.test.ts`) while excluding
+them from CI. The exclusion is a glob pattern, not a label — if more contract test files are
+added, each needs its own exclusion or the pattern needs to be broadened.
+
+**Maintainability concern:** There is no automated mechanism to remove the exclusion once all tests
+pass. Consider adding a comment in the workflow file noting when to remove it (e.g., "remove when
+T6/T8/T10/T11/T16-T21 are complete").
+
+**Better for future use:** Use a consistent naming convention like `*.contract.test.ts` or
+`*.matrix.test.ts` so a single CI exclusion pattern covers the entire class.
+
+### 3. Contract Test Design: Behavior Over API Surface
+
+Contract tests should assert observable behavior, not specific API surface. Three patterns to
+watch for:
+
+| Anti-Pattern | Why It's Fragile | Better Approach |
+|-------------|------------------|-----------------|
+| `expect(Proto.getDepth).toBeDefined()` | Prescribes method name | Test behavior: "spawning at depth > N is rejected" |
+| `Function.length` for arity checks | Default params, rest params, destructured params all affect `.length` | Call with options object, verify option is respected |
+| Hardcoded role names (`"atlas"`) | Constrains implementation to exact strings | Test via a mapping layer or role lookup |
+
+These were P2 findings in the review — non-blocking for this PR but important for implementers
+of subsequent tasks who may need to adjust these tests.
+
+### 4. The `asRecord()` Helper Pattern
+
+For dynamic property access on typed modules without `any` casts:
+
+```typescript
+function asRecord(value: unknown): Record<string, unknown> {
+  return value as Record<string, unknown>;
+}
+
+// Usage: check if an export exists without TypeScript errors
+expect(asRecord(pluginIndex).discoverSkills).toBeDefined();
+```
+
+This is clean and reusable for any test asserting existence of not-yet-implemented exports.
+
+## When to Apply
+
+- Writing acceptance-gate tests that must fail initially
+- Excluding known-failing test suites from CI without disabling them
+- Designing contract tests for capability gaps in a multi-task migration

--- a/packages/opencode-plugin/src/__tests__/omo-replacement-matrix.test.ts
+++ b/packages/opencode-plugin/src/__tests__/omo-replacement-matrix.test.ts
@@ -1,0 +1,192 @@
+/**
+ * OMO Replacement Matrix — Contract Tests (T1)
+ *
+ * Part of #200: Replace oh-my-opencode (OMO) with opencode-legion.
+ *
+ * ALL tests in this file MUST FAIL on initial run. They define the acceptance
+ * gate for subsequent tasks (T6, T8, T10, T11, T16-T21). A passing test here
+ * means either (a) the feature was already implemented, or (b) the test is wrong.
+ *
+ * Test strategy: Import from existing modules and assert that specific named
+ * exports or behaviors are absent. This produces meaningful failures (not
+ * "cannot find module") while proving the gaps.
+ *
+ * When implementing a capability, the corresponding test(s) will start passing —
+ * that's the acceptance signal.
+ *
+ * Clean-room implementation — no OMO source code copied.
+ */
+
+import { describe, expect, it } from "bun:test";
+import tsconfig from "../../tsconfig.json";
+import { createAgents } from "../agents";
+import * as delegationIndex from "../delegation";
+import { BackgroundTaskManager } from "../delegation";
+import * as pluginIndex from "../index";
+import * as overlaysIndex from "../overlays";
+
+// Helper: cast module/object to a string-keyed record for dynamic property access.
+function asRecord(value: unknown): Record<string, unknown> {
+  return value as Record<string, unknown>;
+}
+
+// ─── Area 1: Skill System ────────────────────────────────────────────────────
+// OMO gates MCP tools behind skills — tools only load when the skill is active.
+// opencode-legion has no skill system yet (confirmed: no "skill" keyword in src/).
+// These tests assert the missing exports that the skill system must provide.
+
+describe("Area 1: Skill system", () => {
+  it("exports discoverSkills from plugin index", () => {
+    expect(asRecord(pluginIndex).discoverSkills).toBeDefined();
+  });
+
+  it("exports parseSkill from plugin index", () => {
+    expect(asRecord(pluginIndex).parseSkill).toBeDefined();
+  });
+
+  // Key architectural requirement: tools keyed by (sessionID, skillName, serverName)
+  it("exports createSkillMcpManager from plugin index", () => {
+    expect(asRecord(pluginIndex).createSkillMcpManager).toBeDefined();
+  });
+
+  it("exports injectSkill from plugin index", () => {
+    expect(asRecord(pluginIndex).injectSkill).toBeDefined();
+  });
+});
+
+// ─── Area 2: Spawn Limits ────────────────────────────────────────────────────
+// OMO tracks spawn depth and descendant budget to prevent runaway delegation.
+// BackgroundTaskManager has private depth tracking (resolveSpawnContext,
+// validateAndReserveSpawn) but no PUBLIC API for querying depth/descendants.
+// LaunchOptions has no maxDepth field — limits are only in SpawnLimitsConfig.
+// These tests assert the missing PUBLIC interface that consumers need.
+
+describe("Area 2: Spawn limits", () => {
+  // resolveSpawnContext is private — needs a public getDepth(sessionId)
+  it("BackgroundTaskManager exposes a public getDepth method", () => {
+    const proto = asRecord(BackgroundTaskManager.prototype);
+    expect(proto.getDepth).toBeDefined();
+  });
+
+  // rootDescendantCounts is private — needs a public getDescendantCount(sessionId)
+  it("BackgroundTaskManager exposes a public getDescendantCount method", () => {
+    const proto = asRecord(BackgroundTaskManager.prototype);
+    expect(proto.getDescendantCount).toBeDefined();
+  });
+
+  // SpawnLimitsConfig has maxDepth as a per-instance config value, but no exported constant
+  it("exports MAX_SPAWN_DEPTH constant from delegation index", () => {
+    expect(asRecord(delegationIndex).MAX_SPAWN_DEPTH).toBeDefined();
+  });
+
+  // validateAndReserveSpawn is private — needs a public enforceSpawnLimits API
+  it("BackgroundTaskManager exposes a public enforceSpawnLimits method", () => {
+    const proto = asRecord(BackgroundTaskManager.prototype);
+    expect(proto.enforceSpawnLimits).toBeDefined();
+  });
+});
+
+// ─── Area 3: Agents ──────────────────────────────────────────────────────────
+// OMO defines 4 named roles: Atlas, Hephaestus, Prometheus, Athena.
+// opencode-legion has 10 agents with different names (orchestrator, executor, etc.).
+// These todos assert the OMO role names SHOULD be present (as aliases or mappings).
+
+describe("Area 3: Agents (OMO role mapping)", () => {
+  it("Atlas agent role alias is present in createAgents() output", () => {
+    const agentNames = createAgents().map((a) => a.name);
+    expect(agentNames).toContain("atlas");
+  });
+
+  it("Hephaestus agent role alias is present in createAgents() output", () => {
+    const agentNames = createAgents().map((a) => a.name);
+    expect(agentNames).toContain("hephaestus");
+  });
+
+  it("Prometheus agent role alias is present in createAgents() output", () => {
+    const agentNames = createAgents().map((a) => a.name);
+    expect(agentNames).toContain("prometheus");
+  });
+
+  it("Athena agent role alias is present in createAgents() output", () => {
+    const agentNames = createAgents().map((a) => a.name);
+    expect(agentNames).toContain("athena");
+  });
+});
+
+// ─── Area 4: Tool Guards ─────────────────────────────────────────────────────
+// OMO has a write-existing-file guard that blocks writes to files not yet read.
+// opencode-legion has stop-continuation-guard (placeholder) and subagent-question-blocker,
+// but NO write-existing-file guard.
+
+describe("Area 4: Tool guards", () => {
+  it("exports createWriteExistingFileGuard from plugin index", () => {
+    expect(asRecord(pluginIndex).createWriteExistingFileGuard).toBeDefined();
+  });
+
+  // The guard returns { event, "chat.message", stop, isStopped, clear } — no tool.execute.before
+  it("stop-continuation-guard wires a tool.execute.before hook", async () => {
+    const { createStopContinuationGuardHook } = await import("../hooks/stop-continuation-guard");
+    const guard = createStopContinuationGuardHook();
+    expect(asRecord(guard)["tool.execute.before"]).toBeDefined();
+  });
+
+  it("exports createReadFileRegistry for per-session read-file tracking", () => {
+    expect(asRecord(pluginIndex).createReadFileRegistry).toBeDefined();
+  });
+});
+
+// ─── Area 5: Context Management ──────────────────────────────────────────────
+// OMO has a configurable context window monitor. opencode-legion has preemptive-compaction
+// with a HARDCODED 0.78 threshold. The missing piece: configurable threshold.
+
+describe("Area 5: Context management", () => {
+  // Currently takes 1 param (ctx). Needs to accept (ctx, options) with threshold.
+  it("createPreemptiveCompactionHook accepts a threshold option", async () => {
+    const { createPreemptiveCompactionHook } = await import("../hooks/preemptive-compaction");
+    expect(createPreemptiveCompactionHook.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("compaction threshold is configurable via plugin config", () => {
+    expect(asRecord(pluginIndex).CONFIGURABLE_COMPACTION_THRESHOLD).toBeDefined();
+  });
+
+  // Template currently has sections for User Requests, Final Goal, etc. but NOT Tool Call History
+  it("compaction state preservation captures tool call history", async () => {
+    const { COMPACTION_CONTEXT_TEMPLATE } = await import("../hooks/compaction-context-injector");
+    expect(COMPACTION_CONTEXT_TEMPLATE).toContain("Tool Call History");
+  });
+});
+
+// ─── Area 6: Model Fallback ──────────────────────────────────────────────────
+// OMO has chain-based model fallback (if primary fails, try next in chain).
+// opencode-legion has getModelOverlay() for per-provider system prompts but NO
+// fallback chain or retry-with-different-model logic.
+
+describe("Area 6: Model fallback", () => {
+  it("exports createModelFallbackChain from overlays", () => {
+    expect(asRecord(overlaysIndex).createModelFallbackChain).toBeDefined();
+  });
+
+  // Currently: getModelOverlay(providerID, modelID) -> 2 params. Needs fallbacks? param.
+  it("getModelOverlay supports fallback chain configuration", () => {
+    expect(overlaysIndex.getModelOverlay.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("exports createRetryWithFallback from delegation index", () => {
+    expect(asRecord(delegationIndex).createRetryWithFallback).toBeDefined();
+  });
+});
+
+// ─── Area 7: Code Quality ────────────────────────────────────────────────────
+// OMO enforces stricter TypeScript options. opencode-legion has strict: true and
+// Biome, but is missing stricter options that OMO requires.
+
+describe("Area 7: Code quality (stricter gates)", () => {
+  it("tsconfig enables noUncheckedIndexedAccess", () => {
+    expect(tsconfig.compilerOptions).toHaveProperty("noUncheckedIndexedAccess", true);
+  });
+
+  it("tsconfig enables exactOptionalPropertyTypes", () => {
+    expect(tsconfig.compilerOptions).toHaveProperty("exactOptionalPropertyTypes", true);
+  });
+});


### PR DESCRIPTION
Closes #270

## Summary

Adds `packages/opencode-plugin/src/__tests__/omo-replacement-matrix.test.ts` with 23 contract
tests covering all 7 OMO capability areas. ALL tests fail on first run — this is intentional.
They define the acceptance gate for subsequent tasks (T6, T8, T10, T11, T16-T21).

## Test Results

```
bun test packages/opencode-plugin/src/__tests__/omo-replacement-matrix.test.ts

 0 pass
 23 fail
 23 expect() calls
Ran 23 tests across 1 file. [97.00ms]
```

All 23 tests fail with meaningful error messages:
- `Received: undefined` for missing exports (discoverSkills, parseSkill, etc.)
- `Expected to contain: "atlas"` with full agent list shown for OMO role mapping
- `Expected: >= 2, Received: 1` for function arity checks
- `Expected path: "noUncheckedIndexedAccess"` for tsconfig property checks
- No "cannot find module" errors — all imports resolve, assertions prove the gaps

Exit code: 1 (non-zero, as required by spec)

## Changes from tester feedback

Converted all 23 `it.todo()` calls back to `it()` with active assertions, per spec requirement
that tests must FAIL (not be skipped). The tester correctly identified that `it.todo()` produced
exit code 0 with "23 todo, 0 fail" — not meeting the spec's "non-zero exit with >= 15 failures".

## Coverage

| Area | Tests | Gap |
|------|-------|-----|
| 1. Skill system | 4 | Full gap — no skill keyword in src/ |
| 2. Spawn limits | 4 | Public API gap — private depth tracking exists but no public getDepth/getDescendantCount |
| 3. Agents | 4 | Naming gap — OMO roles (Atlas, Hephaestus, Prometheus, Athena) not mapped |
| 4. Tool guards | 3 | Write guard missing, stop-continuation-guard tool.execute.before not wired |
| 5. Context management | 3 | Configurable threshold missing (hardcoded 0.78) |
| 6. Model fallback | 3 | Fallback chain missing |
| 7. Code quality | 2 | Stricter tsconfig options missing (noUncheckedIndexedAccess, exactOptionalPropertyTypes) |

## Verification

- `bunx biome check packages/opencode-plugin/src/__tests__/omo-replacement-matrix.test.ts` — clean
- `bunx tsc --noEmit -p packages/opencode-plugin/tsconfig.json` — clean
- `bun test packages/opencode-plugin/src/__tests__/integration.test.ts` — 72 pass, 0 fail (existing tests unaffected)