### PR TITLE
sjawhar-legion-488: prune dead worker worktrees on health tick

### DIFF
--- a/.legion/retro.json
+++ b/.legion/retro.json
@@ -2,9 +2,10 @@
   "skipped": false,
   "docsCreated": [
     "docs/solutions/daemon/pre-cleanup-branch-push-verification.md",
-    "docs/solutions/best-practices/jj-bookmark-template-syntax-gotchas.md"
+    "docs/solutions/best-practices/jj-bookmark-template-syntax-gotchas.md",
+    "docs/solutions/daemon/dead-worker-workspace-reclamation.md"
   ],
   "schemaVersion": 1,
   "phase": "retro",
-  "completed": "2026-04-13T15:48:04.601Z"
+  "completed": "2026-04-13T15:59:20.586Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,43 +1,27 @@
 {
   "critical": 0,
-  "important": 3,
-  "minor": 3,
+  "important": 0,
+  "minor": 2,
   "verdict": "approved",
   "keyFindings": [
     {
-      "severity": "P2",
-      "file": "packages/opencode-plugin/src/__tests__/omo-replacement-matrix.test.ts",
-      "description": "Area 3 agent tests lock in OMO's Greek mythology role names — may need adjustment if downstream uses a mapping lookup instead of renaming agents"
-    },
-    {
-      "severity": "P2",
-      "file": "packages/opencode-plugin/src/__tests__/omo-replacement-matrix.test.ts",
-      "description": "Area 2 tests prescribe specific public API method names (getDepth, getDescendantCount, enforceSpawnLimits) that may not match the final implementation design"
-    },
-    {
-      "severity": "P2",
-      "file": "packages/opencode-plugin/src/__tests__/omo-replacement-matrix.test.ts",
-      "description": "Function.length arity checks (lines 146, 172) won't detect implementations using default parameters"
+      "severity": "P3",
+      "file": "packages/daemon/src/daemon/server.ts",
+      "description": "No issueStateCache cleanup for dead workers (correct: dead worker != done issue, cache needed for redispatch)"
     },
     {
       "severity": "P3",
-      "file": "packages/opencode-plugin/src/__tests__/omo-replacement-matrix.test.ts",
-      "description": "Header comment references #200 but PR closes #270 — both correct but could confuse readers"
-    },
-    {
-      "severity": "P3",
-      "file": "packages/opencode-plugin/src/__tests__/omo-replacement-matrix.test.ts",
-      "description": "No meta-test enforcing 'all 23 tests fail' invariant"
-    },
-    {
-      "severity": "P3",
-      "file": "packages/opencode-plugin/src/__tests__/omo-replacement-matrix.test.ts",
-      "description": "asRecord helper could use a JSDoc note explaining its purpose"
+      "file": "packages/daemon/src/daemon/server.ts",
+      "description": "Legacy workspace-based workers skip filesystem cleanup but get state removed (correct: external directories not daemon-owned)"
     }
   ],
-  "learningsInjected": [],
-  "learningsHelpful": [],
+  "learningsInjected": [
+    "docs/solutions/daemon/session-liveness-detection-pattern.md"
+  ],
+  "learningsHelpful": [
+    "docs/solutions/daemon/session-liveness-detection-pattern.md"
+  ],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-13T14:55:33.538Z"
+  "completed": "2026-04-13T15:52:34.021Z"
 }

--- a/docs/solutions/daemon/dead-worker-workspace-reclamation.md
+++ b/docs/solutions/daemon/dead-worker-workspace-reclamation.md
@@ -1,0 +1,112 @@
+---
+title: "Two-Pass Dead Worker Workspace Reclamation"
+category: daemon
+tags:
+  - health-tick
+  - dead-worker
+  - cleanup
+  - workspace-management
+  - jj-workspaces
+  - two-pass-pattern
+  - failure-isolation
+  - testing
+date: 2026-04-13
+status: active
+module: daemon
+related_issues:
+  - "488"
+symptoms:
+  - "jj workspace add fails because workspace already exists"
+  - "new workers dispatched for an issue get 0 messages and appear busy"
+  - "dead workers leave orphaned jj workspaces after daemon restart"
+  - "workspace cleanup blocks future dispatch to the same issue"
+---
+
+# Two-Pass Dead Worker Workspace Reclamation
+
+## Problem
+
+When workers crash or are aborted during daemon restarts, they leave orphaned jj workspaces and git worktrees on disk. The liveness sweep (see `session-liveness-detection-pattern.md`) correctly marks these workers as `dead`, but their workspaces persist. When the controller later dispatches a new worker for the same issue, `jj workspace add` fails because the workspace name is already taken, producing a worker that appears busy (status `starting`) but never processes any messages.
+
+## Solution: Health-Tick Cleanup After Liveness Sweep
+
+Add a `cleanupDeadWorkers()` function that runs on every health tick, immediately after the liveness sweep. This placement ensures workers reaped in the current tick are eligible for cleanup in the same tick, rather than waiting for the next one.
+
+The function is exposed on the `startServer` return object (alongside `fetchAndProcessState`), not as an HTTP endpoint. Dead worker cleanup is an internal daemon concern — exposing it externally would add an untested surface for an operation that should be autonomous.
+
+### Guard Conditions
+
+Cleanup runs only when `serveHealthy && !restartReason`, matching the same compound guard used by the liveness sweep. The call is wrapped in try/catch with a `(non-fatal)` warning — workspace cleanup failure must never take down the health tick or trigger serve restarts.
+
+```typescript
+if (serveHealthy && !restartReason) {
+  try {
+    await cleanupDeadWorkers();
+  } catch (error) {
+    console.warn(`[health-tick] dead worker cleanup failed: ... (non-fatal)`);
+  }
+}
+```
+
+## The Two-Pass Pattern
+
+Multiple dead workers can exist for the same issue (e.g., an implement worker and a test worker both die). The workspace is shared per issue, so cleanup must happen only once per issue, but state removal happens per worker. This creates a natural two-pass structure:
+
+### Pass 1: Workspace Cleanup (Deduplicated by Issue ID)
+
+```
+for each dead worker:
+  extract issueId from workerId
+  if already cleaned or already failed for this issueId: skip
+  run cleanupWorkspace(paths, legionId, issueId, repoRef, repoManagerDeps)
+    → jj workspace forget + rm -rf
+  track success in cleanedWorkspaceIssueIds
+  on failure: track in failedWorkspaceIssueIds
+```
+
+### Pass 2: State Removal (Per Worker, Gated on Pass 1)
+
+```
+for each dead worker:
+  if issueId is in failedWorkspaceIssueIds: SKIP (preserve for retry)
+  delete serve session
+  detach from Envoy
+  unsubscribe all Envoy topics
+  remove from workers map + crashHistory map
+  increment cleanedWorkers count
+
+if cleanedWorkers > 0: persistState()
+```
+
+**Critical invariant**: If workspace cleanup fails for an issue, ALL workers for that issue are preserved. This prevents a scenario where the daemon forgets about a worker but leaves its worktree on disk — which would be worse than an extra dead entry that retries on the next tick.
+
+## Why Two Passes Instead of One
+
+A single-pass approach would attempt workspace cleanup and state removal in the same loop. The problem: if you have workers A (implement) and B (test) for the same issue, and A's workspace cleanup succeeds, you'd remove A's state, then try to clean B's workspace (which was already removed by A). The second `jj workspace forget` might fail with a "workspace not found" error, which would then block B's state removal.
+
+The two-pass pattern avoids this by separating the concern cleanly:
+- Pass 1 answers: "Is the workspace for this issue cleaned up?"
+- Pass 2 answers: "For each worker whose issue workspace is clean, remove the worker state."
+
+This is the same pattern used by `cleanupDoneIssueWorkers()` for cleaning up workers whose issues have transitioned to DONE.
+
+## Duplication Note
+
+`cleanupDeadWorkers` and `cleanupDoneIssueWorkers` share ~80% of their structure. The trigger differs (status === "dead" vs issue status === DONE) and the done-issue variant also cleans up `issueStateCache` and `trackedIssueIds`. A future refactor could extract a shared `cleanupWorkersMatching(predicate)` helper with an optional post-cleanup callback for the variant-specific cleanup.
+
+## Testing Pattern: Direct Function Handle
+
+The dead worker tests need access to the `cleanupDeadWorkers` function handle, which the shared `startTestServer` helper doesn't expose. The tests use `startServer` directly with `originalFetch` and local URLs, accepting the setup duplication in exchange for precise control.
+
+The `StartServerDependency` type uses `Partial<Pick<ServerHandle, "cleanupDeadWorkers">>` to make the function optional for callers that don't need it — matching the existing pattern for `fetchAndProcessState`.
+
+## Lifecycle Summary
+
+This completes the dead worker lifecycle in the daemon:
+
+1. **Detection**: Liveness sweep marks workers as `dead` (issue 447, `session-liveness-detection-pattern.md`)
+2. **Workspace reclamation**: `cleanupDeadWorkers()` removes jj workspace + directory (this PR, issue 488)
+3. **State removal**: Same function removes worker entries, crash history, sessions, Envoy subscriptions
+4. **Re-dispatch**: Controller can now dispatch a new worker for the same issue without workspace conflicts
+
+Previously, step 2-3 required manual intervention or a daemon restart.

--- a/docs/solutions/index.json
+++ b/docs/solutions/index.json
@@ -30,7 +30,8 @@
       "daemon/multi-backend-mutation-target-pattern.md",
       "daemon/self-fetch-endpoint-composition.md",
       "daemon/pre-cleanup-branch-push-verification.md",
-      "best-practices/jj-bookmark-template-syntax-gotchas.md"
+      "best-practices/jj-bookmark-template-syntax-gotchas.md",
+      "daemon/dead-worker-workspace-reclamation.md"
     ],
     "packages/daemon/src/cli": [
       "daemon/controller-lifecycle-separation.md",
@@ -96,7 +97,8 @@
       "daemon/deferred-review-comments-pattern.md",
       "daemon/graceful-worker-shutdown.md",
       "daemon/optional-dep-fallback-and-early-return-guard.md",
-      "daemon/pre-cleanup-branch-push-verification.md"
+      "daemon/pre-cleanup-branch-push-verification.md",
+      "daemon/dead-worker-workspace-reclamation.md"
     ],
     "tag:cli-interaction": ["integration-patterns/tmux-askuserquestion-navigation.md"],
     "tag:code-review": ["daemon/deferred-review-comments-pattern.md"],
@@ -159,7 +161,8 @@
       "daemon/worker-directory-resolution.md",
       "best-practices/git-stash-jj-working-copy-interference.md",
       "daemon/pre-cleanup-branch-push-verification.md",
-      "best-practices/jj-bookmark-template-syntax-gotchas.md"
+      "best-practices/jj-bookmark-template-syntax-gotchas.md",
+      "daemon/dead-worker-workspace-reclamation.md"
     ],
     "tag:keyboard-navigation": ["integration-patterns/tmux-askuserquestion-navigation.md"],
     "tag:labels": ["integration-issues/linear-mcp-label-resolution.md"],
@@ -263,7 +266,8 @@
       "daemon/shared-serve-retro.md",
       "delegation/delegation-hardening-retro.md",
       "daemon/session-liveness-detection-pattern.md",
-      "daemon/optional-dep-fallback-and-early-return-guard.md"
+      "daemon/optional-dep-fallback-and-early-return-guard.md",
+      "daemon/dead-worker-workspace-reclamation.md"
     ],
     "tag:tmux": ["integration-patterns/tmux-askuserquestion-navigation.md"],
     "tag:validation": ["daemon/workspace-validation-retro.md"],
@@ -271,7 +275,8 @@
     "tag:worker-isolation": ["daemon/worker-directory-resolution.md"],
     "tag:worker-lifecycle": [
       "integration-issues/external-repo-pr-auto-transition-gap.md",
-      "daemon/session-liveness-detection-pattern.md"
+      "daemon/session-liveness-detection-pattern.md",
+      "daemon/dead-worker-workspace-reclamation.md"
     ],
     "tag:worker-spawning": ["daemon/worker-directory-fix.md"],
     "tag:workers": ["skill-patterns/worker-skill-failure-modes.md"],
@@ -306,9 +311,15 @@
     "tag:timer": ["delegation/bun-node-timer-type-portability.md"],
     "tag:portability": ["delegation/bun-node-timer-type-portability.md"],
     "packages/daemon/src/daemon/runtime": ["daemon/session-liveness-detection-pattern.md"],
-    "tag:health-tick": ["daemon/session-liveness-detection-pattern.md"],
+    "tag:health-tick": [
+      "daemon/session-liveness-detection-pattern.md",
+      "daemon/dead-worker-workspace-reclamation.md"
+    ],
     "tag:liveness": ["daemon/session-liveness-detection-pattern.md"],
-    "tag:dead-worker": ["daemon/session-liveness-detection-pattern.md"],
+    "tag:dead-worker": [
+      "daemon/session-liveness-detection-pattern.md",
+      "daemon/dead-worker-workspace-reclamation.md"
+    ],
     "tag:jj": [
       "best-practices/git-stash-jj-working-copy-interference.md",
       "best-practices/jj-bookmark-template-syntax-gotchas.md"
@@ -364,6 +375,9 @@
     "tag:fail-safe": ["daemon/pre-cleanup-branch-push-verification.md"],
     "tag:destructive-operations": ["daemon/pre-cleanup-branch-push-verification.md"],
     "tag:bookmark-parsing": ["best-practices/jj-bookmark-template-syntax-gotchas.md"],
-    "tag:template-syntax": ["best-practices/jj-bookmark-template-syntax-gotchas.md"]
+    "tag:template-syntax": ["best-practices/jj-bookmark-template-syntax-gotchas.md"],
+    "tag:two-pass-pattern": ["daemon/dead-worker-workspace-reclamation.md"],
+    "tag:failure-isolation": ["daemon/dead-worker-workspace-reclamation.md"],
+    "tag:workspace-management": ["daemon/dead-worker-workspace-reclamation.md"]
   }
 }

--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -2054,6 +2054,347 @@ describe("daemon server", () => {
     });
   });
 
+  describe("dead worker cleanup", () => {
+    const paths: LegionPaths = {
+      dataDir: "/tmp/legion-data",
+      stateDir: "/tmp/legion-state",
+      reposDir: "/tmp/legion-data/repos",
+      workspacesDir: "/tmp/legion-data/workspaces",
+      legionsFile: "/tmp/legion-state/legions.json",
+      forLegion: (projectId: string) => ({
+        legionStateDir: `/tmp/legion-state/legions/${projectId}`,
+        workersFile: `/tmp/legion-state/legions/${projectId}/workers.json`,
+        feedbackFile: `/tmp/legion-state/legions/${projectId}/feedback.jsonl`,
+        logDir: `/tmp/legion-state/legions/${projectId}/logs`,
+        workspacesDir: `/tmp/legion-data/workspaces/${projectId}`,
+      }),
+      repoClonePath: (host: string, owner: string, repo: string) =>
+        `/tmp/legion-data/repos/${host}/${owner}/${repo}`,
+    };
+
+    function makeRepoManagerDeps(overrides?: Partial<RepoManagerDeps>): RepoManagerDeps {
+      return {
+        runJj: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+        exists: async () => true,
+        rmDir: async () => {},
+        symlink: async () => {},
+        ...overrides,
+      };
+    }
+
+    async function createRepoWorker(issueId: string) {
+      const response = await requestJson("/workers", {
+        method: "POST",
+        body: JSON.stringify({
+          issueId,
+          mode: "implement",
+          repo: "acme/widgets",
+        }),
+      });
+      expect(response.status).toBe(200);
+      return (await response.json()) as { id: string; sessionId: string };
+    }
+
+    it("cleans up workspaces for dead workers via cleanupDeadWorkers", async () => {
+      const rmDirCalls: string[] = [];
+      const jjCalls: string[][] = [];
+      const { server, stop, cleanupDeadWorkers } = startServer({
+        port: 0,
+        hostname: "127.0.0.1",
+        legionId,
+        paths,
+        adapter: makeAdapter(),
+        repoManagerDeps: makeRepoManagerDeps({
+          runJj: async (args) => {
+            jjCalls.push(args);
+            return { exitCode: 0, stdout: "", stderr: "" };
+          },
+          rmDir: async (workspacePath: string) => {
+            rmDirCalls.push(workspacePath);
+          },
+        }),
+        stateFilePath: path.join(
+          await mkdtemp(path.join(os.tmpdir(), "legion-dead-")),
+          "workers.json"
+        ),
+      });
+      const localBaseUrl = `http://127.0.0.1:${server.port}`;
+      try {
+        // Create a worker, then mark it dead
+        const createRes = await originalFetch(`${localBaseUrl}/workers`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            issueId: "acme-widgets-60",
+            mode: "implement",
+            repo: "acme/widgets",
+          }),
+        });
+        expect(createRes.status).toBe(200);
+        const created = (await createRes.json()) as { id: string; sessionId: string };
+
+        const patchRes = await originalFetch(`${localBaseUrl}/workers/${created.id}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ status: "dead" }),
+        });
+        expect(patchRes.status).toBe(200);
+
+        // Run cleanup
+        await cleanupDeadWorkers();
+
+        // Verify workspace was cleaned: jj workspace forget + rmDir
+        const forgetCall = jjCalls.find((args) => args[0] === "workspace" && args[1] === "forget");
+        expect(forgetCall).toBeDefined();
+        expect(forgetCall).toContain("acme-widgets-60");
+        expect(rmDirCalls).toEqual([`/tmp/legion-data/workspaces/${legionId}/acme-widgets-60`]);
+
+        // Verify worker was removed from the map
+        const workersRes = await originalFetch(`${localBaseUrl}/workers`);
+        const workers = (await workersRes.json()) as WorkerEntry[];
+        expect(workers).toEqual([]);
+      } finally {
+        stop();
+      }
+    });
+
+    it("does not clean up running workers", async () => {
+      const rmDirCalls: string[] = [];
+      await startTestServer({
+        paths,
+        repoManagerDeps: makeRepoManagerDeps({
+          rmDir: async (workspacePath: string) => {
+            rmDirCalls.push(workspacePath);
+          },
+        }),
+      });
+
+      // Create a worker but leave it in "starting" status (default)
+      await createRepoWorker("acme-widgets-61");
+
+      // Run cleanup via fetchAndProcessState (which triggers cleanup path)
+      // Dead worker cleanup only targets status === "dead"
+      const workersRes = await requestJson("/workers");
+      const workers = (await workersRes.json()) as WorkerEntry[];
+      expect(workers).toHaveLength(1);
+      expect(rmDirCalls).toEqual([]);
+    });
+
+    it("preserves dead worker state when workspace cleanup fails", async () => {
+      const { server, stop, cleanupDeadWorkers } = startServer({
+        port: 0,
+        hostname: "127.0.0.1",
+        legionId,
+        paths,
+        adapter: makeAdapter(),
+        repoManagerDeps: makeRepoManagerDeps({
+          runJj: async () => {
+            throw new Error("jj workspace forget failed");
+          },
+        }),
+        stateFilePath: path.join(
+          await mkdtemp(path.join(os.tmpdir(), "legion-dead-")),
+          "workers.json"
+        ),
+      });
+      const localBaseUrl = `http://127.0.0.1:${server.port}`;
+      try {
+        // Create and mark dead
+        const createRes = await originalFetch(`${localBaseUrl}/workers`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            issueId: "acme-widgets-62",
+            mode: "implement",
+            repo: "acme/widgets",
+          }),
+        });
+        expect(createRes.status).toBe(200);
+        const created = (await createRes.json()) as { id: string };
+
+        await originalFetch(`${localBaseUrl}/workers/${created.id}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ status: "dead" }),
+        });
+
+        // Suppress console.warn for expected error log
+        console.warn = () => {};
+
+        // Run cleanup — should fail workspace cleanup but not crash
+        await cleanupDeadWorkers();
+
+        // Worker should still exist because workspace cleanup failed
+        const workersRes = await originalFetch(`${localBaseUrl}/workers`);
+        const workers = (await workersRes.json()) as WorkerEntry[];
+        expect(workers).toHaveLength(1);
+        expect(workers[0]?.status).toBe("dead");
+      } finally {
+        stop();
+      }
+    });
+
+    it("is idempotent — second call is a no-op after first succeeds", async () => {
+      const rmDirCalls: string[] = [];
+      const { server, stop, cleanupDeadWorkers } = startServer({
+        port: 0,
+        hostname: "127.0.0.1",
+        legionId,
+        paths,
+        adapter: makeAdapter(),
+        repoManagerDeps: makeRepoManagerDeps({
+          rmDir: async (workspacePath: string) => {
+            rmDirCalls.push(workspacePath);
+          },
+        }),
+        stateFilePath: path.join(
+          await mkdtemp(path.join(os.tmpdir(), "legion-dead-")),
+          "workers.json"
+        ),
+      });
+      const localBaseUrl = `http://127.0.0.1:${server.port}`;
+      try {
+        const createRes = await originalFetch(`${localBaseUrl}/workers`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            issueId: "acme-widgets-63",
+            mode: "implement",
+            repo: "acme/widgets",
+          }),
+        });
+        expect(createRes.status).toBe(200);
+        const created = (await createRes.json()) as { id: string };
+
+        await originalFetch(`${localBaseUrl}/workers/${created.id}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ status: "dead" }),
+        });
+
+        // First cleanup removes the worker
+        await cleanupDeadWorkers();
+        expect(rmDirCalls).toHaveLength(1);
+
+        // Second cleanup is a no-op
+        await cleanupDeadWorkers();
+        expect(rmDirCalls).toHaveLength(1);
+      } finally {
+        stop();
+      }
+    });
+
+    it("cleans up multiple dead workers for the same issue", async () => {
+      const rmDirCalls: string[] = [];
+      const { server, stop, cleanupDeadWorkers } = startServer({
+        port: 0,
+        hostname: "127.0.0.1",
+        legionId,
+        paths,
+        adapter: makeAdapter(),
+        repoManagerDeps: makeRepoManagerDeps({
+          rmDir: async (workspacePath: string) => {
+            rmDirCalls.push(workspacePath);
+          },
+        }),
+        stateFilePath: path.join(
+          await mkdtemp(path.join(os.tmpdir(), "legion-dead-")),
+          "workers.json"
+        ),
+      });
+      const localBaseUrl = `http://127.0.0.1:${server.port}`;
+      try {
+        // Create two workers for the same issue (different modes)
+        for (const mode of ["implement", "test"]) {
+          const createRes = await originalFetch(`${localBaseUrl}/workers`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              issueId: "acme-widgets-64",
+              mode,
+              repo: "acme/widgets",
+            }),
+          });
+          expect(createRes.status).toBe(200);
+          const created = (await createRes.json()) as { id: string };
+
+          await originalFetch(`${localBaseUrl}/workers/${created.id}`, {
+            method: "PATCH",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ status: "dead" }),
+          });
+        }
+
+        await cleanupDeadWorkers();
+
+        // Workspace cleanup should happen once (deduplicated by issue ID)
+        expect(rmDirCalls).toHaveLength(1);
+        expect(rmDirCalls[0]).toContain("acme-widgets-64");
+
+        // Both workers should be removed
+        const workersRes = await originalFetch(`${localBaseUrl}/workers`);
+        const workers = (await workersRes.json()) as WorkerEntry[];
+        expect(workers).toEqual([]);
+      } finally {
+        stop();
+      }
+    });
+
+    it("allows new dispatch after dead worker is cleaned up", async () => {
+      const { server, stop, cleanupDeadWorkers } = startServer({
+        port: 0,
+        hostname: "127.0.0.1",
+        legionId,
+        paths,
+        adapter: makeAdapter(),
+        repoManagerDeps: makeRepoManagerDeps(),
+        stateFilePath: path.join(
+          await mkdtemp(path.join(os.tmpdir(), "legion-dead-")),
+          "workers.json"
+        ),
+      });
+      const localBaseUrl = `http://127.0.0.1:${server.port}`;
+      try {
+        // Create, mark dead, cleanup
+        const createRes = await originalFetch(`${localBaseUrl}/workers`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            issueId: "acme-widgets-65",
+            mode: "implement",
+            repo: "acme/widgets",
+          }),
+        });
+        expect(createRes.status).toBe(200);
+        const created = (await createRes.json()) as { id: string };
+
+        await originalFetch(`${localBaseUrl}/workers/${created.id}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ status: "dead" }),
+        });
+
+        await cleanupDeadWorkers();
+
+        // Should be able to create a new worker for the same issue
+        const newRes = await originalFetch(`${localBaseUrl}/workers`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            issueId: "acme-widgets-65",
+            mode: "implement",
+            repo: "acme/widgets",
+          }),
+        });
+        expect(newRes.status).toBe(200);
+        const newWorker = (await newRes.json()) as { id: string };
+        expect(newWorker.id).toBe("acme-widgets-65-implement");
+      } finally {
+        stop();
+      }
+    });
+  });
+
   describe("POST /workers/:id/prompt", () => {
     const baseWorkerEntry: WorkerEntry = {
       id: "leg-42-implement",

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -33,7 +33,8 @@ import {
 type ServerHandle = ReturnType<typeof startServer>;
 type StartServerDependency = (
   ...args: Parameters<typeof startServer>
-) => Pick<ServerHandle, "server" | "stop"> & Partial<Pick<ServerHandle, "fetchAndProcessState">>;
+) => Pick<ServerHandle, "server" | "stop"> &
+  Partial<Pick<ServerHandle, "fetchAndProcessState" | "cleanupDeadWorkers">>;
 
 interface DaemonDependencies {
   adapter: RuntimeAdapter;
@@ -453,6 +454,7 @@ export async function startDaemon(
   let server: ServerHandle["server"];
   let stop: ServerHandle["stop"];
   let fetchAndProcessState: ServerHandle["fetchAndProcessState"];
+  let cleanupDeadWorkers: ServerHandle["cleanupDeadWorkers"];
   let bindAttempts = 0;
 
   while (true) {
@@ -489,6 +491,7 @@ export async function startDaemon(
       server = serverHandle.server;
       stop = serverHandle.stop;
       fetchAndProcessState = serverHandle.fetchAndProcessState ?? (async () => {});
+      cleanupDeadWorkers = serverHandle.cleanupDeadWorkers ?? (async () => {});
       break;
     } catch (error) {
       const err = error as NodeJS.ErrnoException;
@@ -772,6 +775,18 @@ export async function startDaemon(
             } catch (livenessErr) {
               console.warn(`[liveness] Session liveness check failed (non-fatal): ${livenessErr}`);
             }
+          }
+        }
+
+        // Clean up dead worker workspaces (non-blocking)
+        // Runs after liveness sweep so newly-reaped workers are included.
+        if (serveHealthy && !restartReason) {
+          try {
+            await cleanupDeadWorkers();
+          } catch (error) {
+            console.warn(
+              `[health-tick] dead worker cleanup failed: ${error instanceof Error ? error.message : String(error)} (non-fatal)`
+            );
           }
         }
 

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -294,6 +294,7 @@ export function startServer(opts: ServerOptions): {
   server: Server;
   stop: () => void;
   fetchAndProcessState: () => Promise<void>;
+  cleanupDeadWorkers: () => Promise<void>;
 } {
   const hostname = opts.hostname ?? "127.0.0.1";
   const port = opts.port ?? 13370;
@@ -2023,6 +2024,103 @@ export function startServer(opts: ServerOptions): {
     },
   });
 
+  /**
+   * Clean up workspaces for dead workers on the health tick.
+   *
+   * For each worker with status === "dead":
+   * 1. jj workspace forget + rm -rf the workspace directory
+   * 2. Delete the serve session
+   * 3. Detach from Envoy
+   * 4. Remove worker + crash history from in-memory maps
+   * 5. Persist state
+   *
+   * This prevents dead worktrees from blocking future dispatches to the same issue.
+   */
+  const cleanupDeadWorkers = async (): Promise<void> => {
+    await stateLoaded;
+
+    const deadWorkerIds: string[] = [];
+    for (const [workerId, entry] of workers.entries()) {
+      if (entry.status === "dead") {
+        deadWorkerIds.push(workerId);
+      }
+    }
+
+    if (deadWorkerIds.length === 0) {
+      return;
+    }
+
+    const failedWorkspaceIssueIds = new Set<string>();
+    const cleanedWorkspaceIssueIds = new Set<string>();
+    let cleanedWorkers = 0;
+
+    // First pass: attempt workspace cleanup (once per issue)
+    for (const workerId of deadWorkerIds) {
+      const entry = workers.get(workerId);
+      if (!entry) continue;
+
+      const issueId = extractIssueIdFromWorkerId(workerId)?.toLowerCase();
+      if (!issueId) continue;
+
+      if (cleanedWorkspaceIssueIds.has(issueId) || failedWorkspaceIssueIds.has(issueId)) {
+        continue;
+      }
+
+      if (opts.paths && typeof entry.repo === "string") {
+        const repoRef = parseIssueRepo(entry.repo);
+        if (repoRef) {
+          try {
+            await cleanupWorkspace(
+              opts.paths,
+              opts.legionId,
+              issueId,
+              repoRef,
+              opts.repoManagerDeps
+            );
+            cleanedWorkspaceIssueIds.add(issueId);
+          } catch (error) {
+            console.warn(
+              `[dead-worker-cleanup] workspace cleanup failed for ${issueId}: ${error instanceof Error ? error.message : String(error)}`
+            );
+            failedWorkspaceIssueIds.add(issueId);
+          }
+        }
+      }
+    }
+
+    // Second pass: remove worker state only for issues where workspace was cleaned (or no workspace)
+    for (const workerId of deadWorkerIds) {
+      const entry = workers.get(workerId);
+      if (!entry) continue;
+
+      const issueId = extractIssueIdFromWorkerId(workerId)?.toLowerCase();
+
+      // Skip issues where workspace cleanup failed — preserve state for retry
+      if (issueId && failedWorkspaceIssueIds.has(issueId)) {
+        continue;
+      }
+
+      try {
+        await opts.adapter.deleteSession(entry.sessionId);
+      } catch (error) {
+        console.warn(
+          `[dead-worker-cleanup] session delete failed for ${entry.id}: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+
+      detachWorkerFromEnvoy(entry, "dead-worker-cleanup", envoyUrl);
+      unsubscribeAllWorkerTopics(entry.sessionId, envoyUrl);
+      workers.delete(entry.id);
+      crashHistory.delete(entry.id);
+      cleanedWorkers += 1;
+    }
+
+    if (cleanedWorkers > 0) {
+      await persistState();
+      console.log(`[dead-worker-cleanup] Cleaned ${cleanedWorkers} dead workers`);
+    }
+  };
+
   const fetchAndProcessState = async (): Promise<void> => {
     const legionId = opts.legionId;
     const parts = legionId.split("/");
@@ -2076,5 +2174,6 @@ export function startServer(opts: ServerOptions): {
       server.stop(true);
     },
     fetchAndProcessState,
+    cleanupDeadWorkers,
   };
 }


### PR DESCRIPTION
Closes #488

## Summary

Dead workers that crashed or were aborted during daemon restarts leave orphaned jj workspaces and git worktrees. When new workers are dispatched for the same issues, `jj workspace add` fails because the workspace already exists, causing 0-message workers that appear busy but never process.

This PR adds a `cleanupDeadWorkers()` function to the daemon server that runs on every health tick (after the liveness sweep that marks workers as dead). For each dead worker, it:

1. Runs `jj workspace forget` + `rm -rf` on the workspace directory (via existing `cleanupWorkspace` helper)
2. Deletes the serve session
3. Detaches from Envoy
4. Removes the worker + crash history from in-memory maps
5. Persists state

The cleanup follows the same two-pass pattern as the existing `cleanupDoneIssueWorkers`:
- First pass: workspace cleanup (deduplicated per issue, failures tracked)
- Second pass: state removal (only for issues where workspace cleanup succeeded)

If workspace cleanup fails, the worker state is preserved for retry on the next tick.

### Files Changed
- `packages/daemon/src/daemon/server.ts` — new `cleanupDeadWorkers()` function, exposed from `startServer` return
- `packages/daemon/src/daemon/index.ts` — call `cleanupDeadWorkers()` in health tick after liveness sweep
- `packages/daemon/src/daemon/__tests__/server.test.ts` — 6 new tests covering: basic cleanup, running workers untouched, failure resilience, idempotency, multi-worker same-issue dedup, dispatch-after-cleanup