### PR TITLE
sjawhar-legion-274: add JSON error recovery hook

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,14 +1,20 @@
 {
   "filesChanged": [
-    "packages/daemon/src/daemon/__tests__/server.test.ts"
+    "packages/opencode-plugin/src/hooks/json-error-recovery.ts",
+    "packages/opencode-plugin/src/hooks/__tests__/json-error-recovery.test.ts",
+    "packages/opencode-plugin/src/index.ts",
+    ".legion/implement.json"
   ],
   "trickyParts": [
-    "6 direct startServer() calls in server.test.ts bypassed the startTestServer() helper and were missing envoyUrl: '' — these were in the dead worker cleanup and shutdown sections, not caught in earlier review rounds because the audit focused on startTestServer() rather than all startServer() calls"
+    "Single-quote replacement required a character-by-character parser to handle escaped quotes and mixed quote types correctly — regex-only approach would break on edge cases like double quotes inside single-quoted strings",
+    "Unquoted key regex must only match keys (after { or ,) not values — using lookbehind-like pattern with capture groups",
+    "Hook runs before circuit-breaker so that circuit-breaker hashes repaired (canonical) args, not malformed originals",
+    "Address-comments round: resolved .legion/implement.json merge conflict from rebase, aligned sessionID type signature with sibling hook, added multi-arg repair test"
   ],
   "deviations": [],
   "openQuestions": [],
   "subPlanningNeeded": false,
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-13T16:44:04.524Z"
+  "completed": "2026-04-13T18:08:59.812Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,18 +1,13 @@
 {
   "critical": 0,
   "important": 0,
-  "minor": 1,
+  "minor": 0,
   "verdict": "approved",
-  "keyFindings": [
-    {
-      "severity": "P3",
-      "file": "packages/daemon/src/daemon/__tests__/mock-envoy-server.ts",
-      "description": "MockEnvoyServer.subscribeError is declared in the interface, initialized in state, and reset in reset(), but the subscribe handler never checks it. Dead code — no test uses it."
-    }
-  ],
+  "keyFindings": [],
   "learningsInjected": [],
   "learningsHelpful": [],
+  "note": "Re-review after implementer addressed prior feedback. All 3 prior findings (P1 merge conflict, P3 sessionID type, P3 multi-arg test) resolved. All acceptance criteria verified. CI green.",
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-13T17:16:56.752Z"
+  "completed": "2026-04-13T18:18:26.126Z"
 }

--- a/docs/solutions/architecture-patterns/opencode-plugin-hook-authoring-patterns.md
+++ b/docs/solutions/architecture-patterns/opencode-plugin-hook-authoring-patterns.md
@@ -8,17 +8,24 @@ tags:
   - config
   - factory-pattern
   - session-cleanup
+  - hook-ordering
+  - json-repair
+  - text-parsing
 date: 2026-04-13
 status: active
 module: opencode-plugin
 related_issues:
   - "272"
+  - "274"
 symptoms:
   - "hook sees empty args"
   - "output.args vs input.args"
   - "how to add a new hook"
   - "config not taking effect"
   - "session cleanup memory leak"
+  - "hook execution order matters"
+  - "regex fails on nested quotes"
+  - "char-by-char vs regex for string transforms"
 ---
 
 # OpenCode Plugin Hook Authoring Patterns
@@ -171,3 +178,113 @@ function sortedStringify(value: unknown): string {
 This ensures `{b:1, a:2}` and `{a:2, b:1}` produce identical strings.
 The replacer recursively sorts nested objects too. No external hash
 library needed — the string itself is the comparison key.
+
+## 6. Hook Ordering in `tool.execute.before`
+
+Hooks in the same hook point run sequentially in registration order (see `index.ts`).
+**Order matters when hooks have semantic dependencies.**
+
+Example from #274: `jsonErrorRecoveryHook` must run **before** `circuitBreakerHook`:
+
+```typescript
+"tool.execute.before": async (input, output) => {
+  jsonErrorRecoveryHook(input, output);      // ← normalizes args first
+  circuitBreakerHook["tool.execute.before"](input, output);  // ← hashes normalized args
+  subagentQuestionBlockerHook(input, output);
+  // ...
+}
+```
+
+Why: circuit-breaker hashes `output.args` to detect repetitive tool calls.
+If JSON recovery ran after circuit-breaker, the same logical call with
+`{'key': 'val'}` (single-quoted) and `{"key": "val"}` (double-quoted) would
+produce different hashes, defeating dedup. Recovery first ensures the
+circuit-breaker always sees canonical JSON.
+
+**General principle:** normalizers/canonicalizers go first, detectors/blockers
+go second, transformers go last. When adding a new hook, ask: "does any
+existing hook read `output.args` after my hook writes it?"
+
+## 7. Guard-and-Skip Pattern for Arg Iteration
+
+When a hook needs to inspect all tool arguments (not just a known key):
+
+```typescript
+for (const key of Object.keys(output.args)) {
+  const value = output.args[key];
+  if (typeof value !== "string") continue;    // type guard
+  if (!looksLikeJson(value)) continue;         // cheap heuristic guard
+  // expensive operation only on candidates
+}
+```
+
+This avoids assuming which arg contains the data you care about — agents
+may pass JSON in any argument. The heuristic guard (`looksLikeJson` checks
+for leading `{` or `[`) prevents expensive parsing on non-candidates.
+
+**Test the multi-key case:** if the hook iterates all args, verify it handles
+multiple matching args in one call (e.g., `{ a: "{'k':'v'}", b: "{x: 1,}" }`).
+This gap was caught in code review for #274.
+
+## 8. Char-by-Char Parsing vs Regex for String Transforms
+
+**Use regex** for structural transforms outside strings (trailing commas,
+quoting bareword keys):
+
+```typescript
+// Trailing commas: safe — regex operates on structural tokens
+repaired = repaired.replace(/,\s*([}\]])/g, "$1");
+
+// Unquoted keys: safe — anchored after { or , (structural positions)
+repaired = repaired.replace(/([{,]\s*)([a-zA-Z_$][a-zA-Z0-9_$]*)(\s*:)/g, '$1"$2"$3');
+```
+
+**Use a character-by-character state machine** when the transform must
+understand string boundaries (anything involving quotes, escaping, nesting):
+
+```typescript
+// Single→double quote conversion: MUST use char-by-char
+// because regex can't reliably handle:
+//   - escaped quotes within strings
+//   - double quotes inside single-quoted strings needing escaping
+//   - mixed quote types: {'key': "it's a value"}
+function replaceSingleQuotes(input: string): string {
+  const chars: string[] = [];
+  let i = 0;
+  while (i < input.length) {
+    if (input[i] === '"') { /* pass through double-quoted string */ }
+    else if (input[i] === "'") { /* convert to double-quoted, escape inner " */ }
+    else { chars.push(input[i]); i++; }
+  }
+  return chars.join("");
+}
+```
+
+**When multiple transforms compose**, order matters: single quotes → unquoted
+keys → trailing commas. Single quotes first because the unquoted-key regex
+assumes strings are already double-quoted. Trailing commas last because
+earlier transforms may leave trailing commas as artifacts.
+
+## 9. Pure Function + Thin Hook Wrapper
+
+Export the core logic as a pure function alongside the hook:
+
+```typescript
+// Pure, independently testable
+export function repairJson(input: string): string | null { ... }
+
+// Thin wrapper: walks args, calls pure function, mutates output
+export function jsonErrorRecoveryHook(input, output): void {
+  for (const key of Object.keys(output.args)) {
+    const repaired = repairJson(output.args[key]);
+    if (repaired !== null && repaired !== value) output.args[key] = repaired;
+  }
+}
+```
+
+This gives test suites two levels:
+- **Unit tests** on the pure function: exercise edge cases without constructing
+  hook input/output shapes
+- **Integration tests** on the hook: verify arg iteration, passthrough, multi-key behavior
+
+The pure function export also enables reuse outside the hook context.

--- a/docs/solutions/index.json
+++ b/docs/solutions/index.json
@@ -394,6 +394,12 @@
     "tag:template-syntax": ["best-practices/jj-bookmark-template-syntax-gotchas.md"],
     "tag:two-pass-pattern": ["daemon/dead-worker-workspace-reclamation.md"],
     "tag:failure-isolation": ["daemon/dead-worker-workspace-reclamation.md"],
-    "tag:workspace-management": ["daemon/dead-worker-workspace-reclamation.md"]
+    "tag:workspace-management": ["daemon/dead-worker-workspace-reclamation.md"],
+    "tag:hook-ordering": ["architecture-patterns/opencode-plugin-hook-authoring-patterns.md"],
+    "tag:json-repair": ["architecture-patterns/opencode-plugin-hook-authoring-patterns.md"],
+    "tag:text-parsing": ["architecture-patterns/opencode-plugin-hook-authoring-patterns.md"],
+    "packages/opencode-plugin/src": [
+      "architecture-patterns/opencode-plugin-hook-authoring-patterns.md"
+    ]
   }
 }

--- a/packages/opencode-plugin/src/hooks/__tests__/json-error-recovery.test.ts
+++ b/packages/opencode-plugin/src/hooks/__tests__/json-error-recovery.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "bun:test";
+import { jsonErrorRecoveryHook, repairJson } from "../json-error-recovery";
+
+function makeInput(tool: string, sessionID = "s-1") {
+  return { tool, sessionID, callID: "c-1" };
+}
+
+function makeOutput(args: Record<string, unknown>) {
+  return { args };
+}
+
+/** Assert result is non-null, parse as JSON, and return. */
+function expectRepaired(input: string): unknown {
+  const result = repairJson(input);
+  expect(result).not.toBeNull();
+  return JSON.parse(result as string);
+}
+
+describe("repairJson", () => {
+  describe("trailing commas", () => {
+    it("removes trailing comma in object", () => {
+      expect(expectRepaired('{"a": 1,}')).toEqual({ a: 1 });
+    });
+
+    it("removes trailing comma in array", () => {
+      expect(expectRepaired("[1, 2, 3,]")).toEqual([1, 2, 3]);
+    });
+
+    it("removes multiple trailing commas in nested structures", () => {
+      expect(expectRepaired('{"a": [1, 2,], "b": {"c": 3,},}')).toEqual({
+        a: [1, 2],
+        b: { c: 3 },
+      });
+    });
+  });
+
+  describe("single quotes", () => {
+    it("converts single-quoted keys and values to double quotes", () => {
+      expect(expectRepaired("{'key': 'val'}")).toEqual({ key: "val" });
+    });
+
+    it("handles mixed single and double quotes", () => {
+      expect(expectRepaired("{'key': \"val\"}")).toEqual({ key: "val" });
+    });
+
+    it("preserves single quotes inside double-quoted strings", () => {
+      expect(expectRepaired('{"key": "it\'s a value"}')).toEqual({ key: "it's a value" });
+    });
+  });
+
+  describe("unquoted keys", () => {
+    it("quotes unquoted keys", () => {
+      expect(expectRepaired('{key: "val"}')).toEqual({ key: "val" });
+    });
+
+    it("quotes multiple unquoted keys", () => {
+      expect(expectRepaired('{name: "test", count: 42}')).toEqual({ name: "test", count: 42 });
+    });
+
+    it("handles underscored keys", () => {
+      expect(expectRepaired('{my_key: "val"}')).toEqual({ my_key: "val" });
+    });
+  });
+
+  describe("combined malformations", () => {
+    it("handles unquoted keys with trailing comma", () => {
+      expect(expectRepaired('{key: "val",}')).toEqual({ key: "val" });
+    });
+
+    it("handles single quotes with trailing comma", () => {
+      expect(expectRepaired("{'key': 'val',}")).toEqual({ key: "val" });
+    });
+  });
+
+  describe("valid JSON passthrough", () => {
+    it("returns valid JSON unchanged", () => {
+      expect(expectRepaired('{"key": "val"}')).toEqual({ key: "val" });
+    });
+
+    it("returns valid array JSON unchanged", () => {
+      expect(expectRepaired("[1, 2, 3]")).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe("unrecoverable input", () => {
+    it("returns null for completely unparseable garbage", () => {
+      expect(repairJson("not json at all")).toBeNull();
+    });
+
+    it("returns null for partial JSON that can't be fixed", () => {
+      expect(repairJson("{key: }")).toBeNull();
+    });
+
+    it("returns null for empty string", () => {
+      expect(repairJson("")).toBeNull();
+    });
+  });
+});
+
+describe("jsonErrorRecoveryHook", () => {
+  describe("repairs JSON string args", () => {
+    it("repairs a malformed JSON string in args", () => {
+      const output = makeOutput({ content: "{'key': 'val'}" });
+      jsonErrorRecoveryHook(makeInput("write"), output);
+      expect(output.args.content).toBe('{"key": "val"}');
+    });
+
+    it("repairs trailing comma in JSON arg", () => {
+      const output = makeOutput({ content: '{"a": 1,}' });
+      jsonErrorRecoveryHook(makeInput("write"), output);
+      expect(output.args.content).toBe('{"a": 1}');
+    });
+
+    it("repairs unquoted keys in JSON arg", () => {
+      const output = makeOutput({ content: '{key: "val"}' });
+      jsonErrorRecoveryHook(makeInput("write"), output);
+      expect(output.args.content).toBe('{"key": "val"}');
+    });
+  });
+
+  describe("passthrough behavior", () => {
+    it("does not modify valid JSON strings", () => {
+      const output = makeOutput({ content: '{"key": "val"}' });
+      jsonErrorRecoveryHook(makeInput("write"), output);
+      expect(output.args.content).toBe('{"key": "val"}');
+    });
+
+    it("does not modify non-JSON string args", () => {
+      const output = makeOutput({ command: "ls -la" });
+      jsonErrorRecoveryHook(makeInput("bash"), output);
+      expect(output.args.command).toBe("ls -la");
+    });
+
+    it("does not modify non-string args", () => {
+      const output = makeOutput({ count: 42, flag: true });
+      jsonErrorRecoveryHook(makeInput("bash"), output);
+      expect(output.args.count).toBe(42);
+      expect(output.args.flag).toBe(true);
+    });
+
+    it("does not modify args that are not objects", () => {
+      const output = { args: "not an object" as unknown as Record<string, unknown> };
+      jsonErrorRecoveryHook(makeInput("bash"), output);
+      expect(output.args as unknown).toBe("not an object");
+    });
+  });
+
+  describe("unrecoverable JSON propagation", () => {
+    it("does not modify unrecoverable malformed JSON", () => {
+      const output = makeOutput({ content: "totally not json {{{" });
+      jsonErrorRecoveryHook(makeInput("write"), output);
+      expect(output.args.content).toBe("totally not json {{{");
+    });
+  });
+
+  describe("multi-arg repair", () => {
+    it("repairs multiple JSON args in same output", () => {
+      const output = makeOutput({ a: "{'k': 'v'}", b: "{x: 1,}" });
+      jsonErrorRecoveryHook(makeInput("write"), output);
+      expect(output.args.a).toBe('{"k": "v"}');
+      expect(output.args.b).toBe('{"x": 1}');
+    });
+  });
+
+  describe("only repairs JSON-like strings", () => {
+    it("does not attempt repair on plain text strings", () => {
+      const output = makeOutput({ description: "Hello world" });
+      jsonErrorRecoveryHook(makeInput("write"), output);
+      expect(output.args.description).toBe("Hello world");
+    });
+
+    it("does not attempt repair on strings without braces or brackets", () => {
+      const output = makeOutput({ path: "/home/user/file.json" });
+      jsonErrorRecoveryHook(makeInput("read"), output);
+      expect(output.args.path).toBe("/home/user/file.json");
+    });
+  });
+});

--- a/packages/opencode-plugin/src/hooks/json-error-recovery.ts
+++ b/packages/opencode-plugin/src/hooks/json-error-recovery.ts
@@ -1,0 +1,132 @@
+import { isRecord } from "./utils";
+
+/**
+ * Attempt to repair common JSON malformations.
+ *
+ * Handles:
+ * - Trailing commas: `{a: 1,}` → `{a: 1}`
+ * - Single quotes: `{'key': 'val'}` → `{"key": "val"}`
+ * - Unquoted keys: `{key: "val"}` → `{"key": "val"}`
+ *
+ * Returns the repaired JSON string if successful, or null if unrecoverable.
+ */
+export function repairJson(input: string): string | null {
+  if (!input) return null;
+
+  // Try parsing as-is first (fast path for valid JSON)
+  try {
+    JSON.parse(input);
+    return input;
+  } catch {
+    // Continue to repair attempts
+  }
+
+  let repaired = input;
+
+  // Step 1: Replace single-quoted strings with double-quoted strings.
+  // This handles: {'key': 'val'} → {"key": "val"}
+  // We walk character by character to handle escaping correctly.
+  repaired = replaceSingleQuotes(repaired);
+
+  // Step 2: Quote unquoted keys.
+  // This handles: {key: "val"} → {"key": "val"}
+  // Match word characters after { or , that are followed by :
+  repaired = repaired.replace(/([{,]\s*)([a-zA-Z_$][a-zA-Z0-9_$]*)(\s*:)/g, '$1"$2"$3');
+
+  // Step 3: Remove trailing commas before } or ]
+  // This handles: {a: 1,} → {a: 1} and [1, 2,] → [1, 2]
+  repaired = repaired.replace(/,\s*([}\]])/g, "$1");
+
+  // Verify the repaired string is valid JSON
+  try {
+    JSON.parse(repaired);
+    return repaired;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Replace single-quoted strings with double-quoted strings in a JSON-like string.
+ * Handles escaped quotes within strings.
+ */
+function replaceSingleQuotes(input: string): string {
+  const chars: string[] = [];
+  let i = 0;
+  while (i < input.length) {
+    if (input[i] === '"') {
+      // Already in a double-quoted string — pass through until closing "
+      chars.push('"');
+      i++;
+      while (i < input.length && input[i] !== '"') {
+        if (input[i] === "\\" && i + 1 < input.length) {
+          chars.push(input[i], input[i + 1]);
+          i += 2;
+        } else {
+          chars.push(input[i]);
+          i++;
+        }
+      }
+      if (i < input.length) {
+        chars.push('"');
+        i++;
+      }
+    } else if (input[i] === "'") {
+      // Single-quoted string — convert to double quotes
+      chars.push('"');
+      i++;
+      while (i < input.length && input[i] !== "'") {
+        if (input[i] === "\\" && i + 1 < input.length) {
+          chars.push(input[i], input[i + 1]);
+          i += 2;
+        } else if (input[i] === '"') {
+          // Escape double quotes that appear inside the now-double-quoted string
+          chars.push('\\"');
+          i++;
+        } else {
+          chars.push(input[i]);
+          i++;
+        }
+      }
+      chars.push('"');
+      if (i < input.length) i++;
+    } else {
+      chars.push(input[i]);
+      i++;
+    }
+  }
+  return chars.join("");
+}
+
+/**
+ * Check if a string looks like it could be JSON (starts with { or [).
+ */
+function looksLikeJson(value: string): boolean {
+  const trimmed = value.trimStart();
+  return trimmed.startsWith("{") || trimmed.startsWith("[");
+}
+
+/**
+ * tool.execute.before hook that detects malformed JSON in tool arguments
+ * and attempts auto-repair for common patterns.
+ *
+ * If repair succeeds, the repaired value replaces the original in output.args.
+ * If repair fails, the original value is preserved (downstream sees original error).
+ */
+export function jsonErrorRecoveryHook(
+  _input: { tool: string; sessionID: string; callID: string },
+  output: { args: Record<string, unknown> }
+): void {
+  if (!isRecord(output) || !isRecord(output.args)) return;
+
+  for (const key of Object.keys(output.args)) {
+    const value = output.args[key];
+    if (typeof value !== "string") continue;
+    if (!looksLikeJson(value)) continue;
+
+    const repaired = repairJson(value);
+    if (repaired !== null && repaired !== value) {
+      output.args[key] = repaired;
+    }
+  }
+}

--- a/packages/opencode-plugin/src/index.ts
+++ b/packages/opencode-plugin/src/index.ts
@@ -11,6 +11,7 @@ import { createCircuitBreakerHook } from "./hooks/circuit-breaker";
 import { COMPACTION_CONTEXT_TEMPLATE } from "./hooks/compaction-context-injector";
 import { createCompactionTodoPreserverHook } from "./hooks/compaction-todo-preserver";
 import { createGitHubAppCredentialsHook } from "./hooks/github-app-credentials";
+import { jsonErrorRecoveryHook } from "./hooks/json-error-recovery";
 import { nonInteractiveEnvHook } from "./hooks/non-interactive-env";
 import { createOutputCompressionHook } from "./hooks/output-compression";
 import { createPreemptiveCompactionHook } from "./hooks/preemptive-compaction";
@@ -193,6 +194,7 @@ const OpenCodeLegion: Plugin = async (ctx) => {
       anthropicEffortHook(input, output);
     },
     "tool.execute.before": async (input, output) => {
+      jsonErrorRecoveryHook(input, output);
       circuitBreakerHook["tool.execute.before"](input, output);
       subagentQuestionBlockerHook(input, output);
       const toolInput = isRecord(input) ? (input as ToolExecuteInput) : undefined;


### PR DESCRIPTION
Closes #274

## Summary

Adds a `tool.execute.before` hook that auto-repairs common JSON malformations in tool arguments, reducing agent retries on trivial JSON errors.

### Repairs handled:
- **Trailing commas**: `{"a": 1,}` -> `{"a": 1}`
- **Single quotes**: `{'key': 'val'}` -> `{"key": "val"}`
- **Unquoted keys**: `{key: "val"}` -> `{"key": "val"}`

### Behavior:
- Valid JSON passes through unchanged
- Non-JSON string args are not touched
- Unrecoverable malformed JSON is left intact (original error propagates)
- Hook runs before circuit-breaker so repaired args get canonical hashing
- Only attempts repair on strings that look like JSON (start with `{` or `[`)

### Files changed:
- `packages/opencode-plugin/src/hooks/json-error-recovery.ts` — hook implementation
- `packages/opencode-plugin/src/hooks/__tests__/json-error-recovery.test.ts` — 26 TDD tests
- `packages/opencode-plugin/src/index.ts` — wiring into `tool.execute.before` pipeline