### PR TITLE
sjawhar-legion-510: replace personal Tailscale auth with OAuth client for tsnet

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,14 +1,30 @@
 {
   "filesChanged": [
-    "packages/daemon/src/daemon/__tests__/server.test.ts"
+    "packages/envoy/internal/tsnet/config.go",
+    "packages/envoy/internal/tsnet/config_test.go",
+    "packages/envoy/internal/tsnet/server.go",
+    "packages/envoy/infra/machines.ts",
+    "packages/envoy/infra/services.ts",
+    "packages/envoy/infra/index.ts",
+    "packages/envoy/infra/__tests__/services.test.ts",
+    "packages/envoy/infra/Pulumi.prod.yaml",
+    "packages/envoy/deploy/compose/listener.compose.yml",
+    "packages/envoy/README.md"
   ],
   "trickyParts": [
-    "6 direct startServer() calls in server.test.ts bypassed the startTestServer() helper and were missing envoyUrl: '' — these were in the dead worker cleanup and shutdown sections, not caught in earlier review rounds because the audit focused on startTestServer() rather than all startServer() calls"
+    "Tailscale OAuth client secrets can be used directly as auth keys via URL-style parameters (?ephemeral=false&preauthorized=true&tags=...) — this is documented in Tailscale's OAuth docs but not obvious. The Go config constructs this composite auth key from separate env vars.",
+    "OAuth client ID is read but not directly used in the auth key construction — Tailscale's convention only needs the secret. The ID is required by the config for validation and future API token generation use cases.",
+    "Mutual exclusion between OAuth and legacy auth key prevents accidental double-configuration that could cause confusing auth behavior."
   ],
-  "deviations": [],
-  "openQuestions": [],
+  "deviations": [
+    "No plan was filed for this issue — implemented directly from the issue description. The issue had clear requirements and a well-defined scope."
+  ],
+  "openQuestions": [
+    "The OAuth client ID is validated but not used in the auth key — if future features need to generate API tokens (e.g., for DNS or device management), the ID will be needed for the token endpoint call.",
+    "Production deployment requires manually creating an OAuth client in the Tailscale admin console and setting the Pulumi secrets — this is a one-time manual step documented in the PR."
+  ],
   "subPlanningNeeded": false,
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-13T16:44:04.524Z"
+  "completed": "2026-04-13T19:42:44.852Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,18 +1,28 @@
 {
   "critical": 0,
   "important": 0,
-  "minor": 1,
+  "minor": 3,
   "verdict": "approved",
   "keyFindings": [
     {
       "severity": "P3",
-      "file": "packages/daemon/src/daemon/__tests__/mock-envoy-server.ts",
-      "description": "MockEnvoyServer.subscribeError is declared in the interface, initialized in state, and reset in reset(), but the subscribe handler never checks it. Dead code — no test uses it."
+      "file": "packages/envoy/infra/README.md",
+      "description": "Stale tsnetAuthKey reference at line 86 — should document tsnetOAuthClientId and tsnetOAuthClientSecret instead"
+    },
+    {
+      "severity": "P3",
+      "file": "packages/envoy/internal/tsnet/config.go",
+      "description": "tags query parameter on OAuth secret works in practice but is not explicitly documented by Tailscale for the URL-parameter syntax — consider adding a comment noting this is an implementation-level convention"
+    },
+    {
+      "severity": "P3",
+      "file": "packages/envoy/infra/__tests__/services.test.ts",
+      "description": "OAuth test assertions use array length instead of content verification due to Pulumi Output constraint — acceptable but fragile"
     }
   ],
   "learningsInjected": [],
   "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-13T17:16:56.752Z"
+  "completed": "2026-04-13T20:15:42.792Z"
 }

--- a/docs/solutions/envoy/tailscale-oauth-tsnet-auth-patterns.md
+++ b/docs/solutions/envoy/tailscale-oauth-tsnet-auth-patterns.md
@@ -1,0 +1,143 @@
+---
+title: "Tailscale OAuth Client Auth for tsnet Deployments"
+category: envoy
+tags:
+  - tailscale
+  - tsnet
+  - oauth
+  - config-resolution
+  - backward-compatibility
+  - infrastructure
+  - pulumi
+date: 2026-04-13
+status: active
+module: envoy
+related_issues:
+  - "510"
+symptoms:
+  - "ENVOY_TSNET_AUTH_KEY and ENVOY_TSNET_OAUTH_CLIENT_SECRET are mutually exclusive"
+  - "ENVOY_TSNET_TAGS is required when using OAuth credentials"
+  - "tsnet authentication requires manual login URL visit"
+  - "how to use Tailscale OAuth client with tsnet"
+---
+
+# Tailscale OAuth Client Auth for tsnet Deployments
+
+## Context
+
+Tailscale's tsnet library embeds a Tailscale node into a Go process. Authentication
+typically requires a `TS_AUTHKEY` — but for production, you want OAuth client credentials
+(rotatable, org-scoped, no human-in-the-loop). The mechanism for doing this is documented
+but non-obvious.
+
+## Key Learning: OAuth Secret as Auth Key
+
+**Tailscale's OAuth client secrets can be used directly as tsnet auth keys** by appending
+URL-style parameters:
+
+```
+<client_secret>?ephemeral=false&preauthorized=true&tags=tag:envoy
+```
+
+This is documented in [Tailscale's OAuth client docs](https://tailscale.com/kb/1215/oauth-clients)
+but easy to miss. The client secret doubles as an auth key when formatted this way.
+
+Important nuances:
+- The **OAuth client ID is not part of the auth key** — only the secret is used. The ID
+  exists for validation (both halves configured) and potential future API token generation.
+- **Tags are required** with OAuth credentials — Tailscale requires tagged authentication
+  for non-personal nodes.
+- The node registers as **non-ephemeral and preauthorized** — it persists in the tailnet
+  and doesn't need admin approval.
+
+## Pattern: Resolve Complex Config at the Boundary
+
+The implementation uses a `resolveAuthKey()` function that encapsulates all the auth
+mode logic:
+
+```go
+func resolveAuthKey() (string, error) {
+    // Read all env vars
+    // Detect which mode (OAuth vs legacy vs none)
+    // Validate mutual exclusion
+    // Construct final auth key string
+    return authKey, nil
+}
+```
+
+The rest of the codebase (`server.go`, etc.) sees only a single `AuthKey` string — it
+doesn't know or care whether it came from OAuth credentials or a legacy key. This kept
+the change surface minimal: only `config.go` needed logic changes.
+
+**When to use this pattern:** Any time you have multiple ways to configure the same
+value (credential rotation, migration from one provider to another, dev vs prod paths).
+Resolve at the config boundary so consumers remain simple.
+
+## Pattern: Backward-Compatible Migration via Mutual Exclusion
+
+Rather than removing the legacy `ENVOY_TSNET_AUTH_KEY`, the implementation:
+1. Keeps the old path working unchanged
+2. Adds the new OAuth path
+3. Errors if both are configured simultaneously
+
+This prevents silent misconfiguration where the wrong credential wins. The error message
+explicitly says "mutually exclusive" so operators know to remove one.
+
+## Gotchas
+
+### Partial OAuth config triggers validation
+
+Setting _either_ `ENVOY_TSNET_OAUTH_CLIENT_ID` or `ENVOY_TSNET_OAUTH_CLIENT_SECRET`
+(but not both) triggers the OAuth path, which then fails validation. This is intentional
+— it catches partial configuration — but could surprise someone who sets only the ID
+thinking it's inert.
+
+### Docker compose passes empty strings, not absent vars
+
+`${ENVOY_TSNET_OAUTH_CLIENT_ID:-}` defaults to empty string, so the env var is always
+present in the container (just empty). The Go code's `strings.TrimSpace` + empty check
+is load-bearing for this deployment path.
+
+### Tags must coordinate across infra and Go layers
+
+Tags come from the machine config YAML (`Pulumi.prod.yaml`), while OAuth credentials
+come from Pulumi secrets. They must be coordinated — OAuth requires tags — but there's
+no infra-level validation. The Go code catches the mismatch at runtime, which is late
+in the deployment cycle.
+
+## Testing Pattern: Env Var Isolation for Multi-Mode Config
+
+When testing multiple auth modes, each test helper must clear the _other_ mode's env vars
+to prevent cross-test leakage:
+
+```go
+func setTsnetEnv(t *testing.T, ...) {
+    // Set legacy vars
+    t.Setenv("ENVOY_TSNET_OAUTH_CLIENT_ID", "")     // Clear OAuth
+    t.Setenv("ENVOY_TSNET_OAUTH_CLIENT_SECRET", "")
+    t.Setenv("ENVOY_TSNET_TAGS", "")
+}
+
+func setOAuthEnv(t *testing.T, ...) {
+    // Set OAuth vars
+    t.Setenv("ENVOY_TSNET_AUTH_KEY", "")  // Clear legacy
+}
+```
+
+Without this, test ordering can cause false passes/failures when env vars leak.
+
+## Testing Pattern: Length-Based Assertions for Pulumi Outputs
+
+Pulumi `Output` objects can't be compared as strings in tests. The Pulumi tests use
+`envs.length` assertions to verify optional env vars are included/excluded. This is
+pragmatic but fragile — adding an unrelated env var breaks all length assertions.
+Prefer prefix-based checks where possible:
+
+```ts
+// Fragile: breaks if any new env var is added
+expect(envs.length).toBe(6);
+
+// Better: checks presence of specific env
+const hasTagsEnv = envs.some((e) => typeof e === "string" && e.startsWith("ENVOY_TSNET_TAGS="));
+expect(hasTagsEnv).toBe(true);
+```

--- a/docs/solutions/index.json
+++ b/docs/solutions/index.json
@@ -271,7 +271,10 @@
       "testing/call-site-audit-for-test-isolation.md"
     ],
     "tag:mock-server": ["testing/mock-envoy-server-pattern.md"],
-    "tag:envoy": ["testing/mock-envoy-server-pattern.md"],
+    "tag:envoy": [
+      "testing/mock-envoy-server-pattern.md",
+      "envoy/tailscale-oauth-tsnet-auth-patterns.md"
+    ],
     "tag:audit-pattern": ["testing/call-site-audit-for-test-isolation.md"],
     "tag:testing": [
       "best-practices/prefer-autospec-over-asyncmock-pytest-20260202.md",
@@ -354,7 +357,8 @@
     ],
     "tag:pulumi": [
       "infra/pulumi-aws-identity-center-patterns.md",
-      "infra/pulumi-cross-account-brownfield-adoption.md"
+      "infra/pulumi-cross-account-brownfield-adoption.md",
+      "envoy/tailscale-oauth-tsnet-auth-patterns.md"
     ],
     "tag:aws": [
       "infra/pulumi-aws-identity-center-patterns.md",
@@ -373,7 +377,10 @@
     "tag:state-delta": ["daemon/targeted-delta-filtering-pattern.md"],
     "tag:tracking": ["daemon/targeted-delta-filtering-pattern.md"],
     "tag:notifications": ["daemon/targeted-delta-filtering-pattern.md"],
-    "tag:backward-compatibility": ["daemon/targeted-delta-filtering-pattern.md"],
+    "tag:backward-compatibility": [
+      "daemon/targeted-delta-filtering-pattern.md",
+      "envoy/tailscale-oauth-tsnet-auth-patterns.md"
+    ],
     "tag:interface-design": ["daemon/multi-backend-mutation-target-pattern.md"],
     "tag:multi-backend": ["daemon/multi-backend-mutation-target-pattern.md"],
     "tag:issue-tracker": ["daemon/multi-backend-mutation-target-pattern.md"],
@@ -394,6 +401,17 @@
     "tag:template-syntax": ["best-practices/jj-bookmark-template-syntax-gotchas.md"],
     "tag:two-pass-pattern": ["daemon/dead-worker-workspace-reclamation.md"],
     "tag:failure-isolation": ["daemon/dead-worker-workspace-reclamation.md"],
-    "tag:workspace-management": ["daemon/dead-worker-workspace-reclamation.md"]
+    "tag:workspace-management": ["daemon/dead-worker-workspace-reclamation.md"],
+    "packages/envoy/internal/tsnet": ["envoy/tailscale-oauth-tsnet-auth-patterns.md"],
+    "packages/envoy/infra": [
+      "envoy/tailscale-oauth-tsnet-auth-patterns.md",
+      "envoy/pulumi-remote-docker-patterns.md"
+    ],
+    "packages/envoy/deploy": ["envoy/tailscale-oauth-tsnet-auth-patterns.md"],
+    "tag:tailscale": ["envoy/tailscale-oauth-tsnet-auth-patterns.md"],
+    "tag:tsnet": ["envoy/tailscale-oauth-tsnet-auth-patterns.md"],
+    "tag:oauth": ["envoy/tailscale-oauth-tsnet-auth-patterns.md"],
+    "tag:config-resolution": ["envoy/tailscale-oauth-tsnet-auth-patterns.md"],
+    "tag:infrastructure": ["envoy/tailscale-oauth-tsnet-auth-patterns.md"]
   }
 }

--- a/packages/envoy/README.md
+++ b/packages/envoy/README.md
@@ -40,6 +40,9 @@ Current secret names:
 
 - `ENVOY_SLACK_SIGNING_SECRET`
 - `ENVOY_GITHUB_WEBHOOK_SECRET`
+- `ENVOY_TSNET_OAUTH_CLIENT_ID` — Tailscale OAuth client ID (preferred for tsnet auth)
+- `ENVOY_TSNET_OAUTH_CLIENT_SECRET` — Tailscale OAuth client secret (preferred for tsnet auth)
+- `ENVOY_TSNET_AUTH_KEY` — legacy Tailscale auth key (mutually exclusive with OAuth)
 
 ## Layout
 

--- a/packages/envoy/deploy/compose/listener.compose.yml
+++ b/packages/envoy/deploy/compose/listener.compose.yml
@@ -21,6 +21,11 @@ services:
       ENVOY_TSNET_ENABLED: ${ENVOY_TSNET_ENABLED:-false}
       ENVOY_TSNET_HOSTNAME: ${ENVOY_TSNET_HOSTNAME:-}
       ENVOY_TSNET_STATE_DIR: ${ENVOY_TSNET_STATE_DIR:-/var/lib/envoy-tsnet/listener}
+      # OAuth credentials (preferred — create in Tailscale admin console)
+      ENVOY_TSNET_OAUTH_CLIENT_ID: ${ENVOY_TSNET_OAUTH_CLIENT_ID:-}
+      ENVOY_TSNET_OAUTH_CLIENT_SECRET: ${ENVOY_TSNET_OAUTH_CLIENT_SECRET:-}
+      ENVOY_TSNET_TAGS: ${ENVOY_TSNET_TAGS:-}
+      # Legacy auth key (mutually exclusive with OAuth)
       ENVOY_TSNET_AUTH_KEY: ${ENVOY_TSNET_AUTH_KEY:-}
       ENVOY_WEBHOOKS: ${ENVOY_WEBHOOKS:-}
       ENVOY_GITHUB_WEBHOOK_SECRET: ${ENVOY_GITHUB_WEBHOOK_SECRET:-}

--- a/packages/envoy/infra/Pulumi.prod.yaml
+++ b/packages/envoy/infra/Pulumi.prod.yaml
@@ -11,6 +11,7 @@ config:
         tsnet:
           hostname: envoy-listener-sami-agents-mx
           stateDir: /var/lib/envoy-tsnet/listener-sami-agents-mx
+          tags: "tag:envoy"
         webhooks:
           github: true
           slack: true

--- a/packages/envoy/infra/__tests__/services.test.ts
+++ b/packages/envoy/infra/__tests__/services.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { computeNatsUrls, computeTsnetEnvs } from "../services";
 import type { MachineConfig } from "../machines";
+import { computeNatsUrls, computeTsnetEnvs } from "../services";
 
 describe("computeNatsUrls", () => {
   const machines = [
@@ -38,6 +38,17 @@ describe("computeTsnetEnvs", () => {
     },
   };
 
+  const tsnetMachineWithTags: MachineConfig = {
+    ...baseMachine,
+    listener: {
+      tsnet: {
+        hostname: "envoy-listener-test",
+        stateDir: "/var/lib/envoy-tsnet/listener-test",
+        tags: "tag:envoy",
+      },
+    },
+  };
+
   const emptySecrets = {
     githubWebhookSecret: {} as any,
     slackSigningSecret: {} as any,
@@ -52,24 +63,53 @@ describe("computeTsnetEnvs", () => {
     const envs = computeTsnetEnvs(tsnetMachine, emptySecrets);
     expect(envs).toContain("ENVOY_TSNET_ENABLED=true");
     expect(envs).toContain("ENVOY_TSNET_HOSTNAME=envoy-listener-test");
-    expect(envs).toContain(
-      "ENVOY_TSNET_STATE_DIR=/var/lib/envoy-tsnet/listener-test",
-    );
+    expect(envs).toContain("ENVOY_TSNET_STATE_DIR=/var/lib/envoy-tsnet/listener-test");
   });
 
-  test("includes auth key when secret provided", () => {
+  test("includes tags when configured on machine", () => {
+    const envs = computeTsnetEnvs(tsnetMachineWithTags, emptySecrets);
+    expect(envs).toContain("ENVOY_TSNET_TAGS=tag:envoy");
+  });
+
+  test("omits tags when not configured on machine", () => {
+    const envs = computeTsnetEnvs(tsnetMachine, emptySecrets);
+    const hasTagsEnv = envs.some((e) => typeof e === "string" && e.startsWith("ENVOY_TSNET_TAGS="));
+    expect(hasTagsEnv).toBe(false);
+  });
+
+  test("includes OAuth client ID when secret provided", () => {
     const secrets = {
       ...emptySecrets,
-      tsnetAuthKey: {} as any,
+      tsnetOAuthClientId: {} as any,
     };
-    const envs = computeTsnetEnvs(tsnetMachine, secrets);
-    // Auth key is a pulumi.interpolate output — verify it's in the array
-    // (exact value is a Pulumi Output, not a plain string)
-    expect(envs.length).toBe(4); // enabled + hostname + stateDir + authKey
+    const envs = computeTsnetEnvs(tsnetMachineWithTags, secrets);
+    // OAuth client ID is a pulumi.interpolate output — verify extra entry
+    expect(envs.length).toBe(5); // enabled + hostname + stateDir + tags + clientId
   });
 
-  test("omits auth key when not provided", () => {
-    const envs = computeTsnetEnvs(tsnetMachine, emptySecrets);
-    expect(envs.length).toBe(3); // enabled + hostname + stateDir
+  test("includes OAuth client secret when secret provided", () => {
+    const secrets = {
+      ...emptySecrets,
+      tsnetOAuthClientSecret: {} as any,
+    };
+    const envs = computeTsnetEnvs(tsnetMachineWithTags, secrets);
+    expect(envs.length).toBe(5); // enabled + hostname + stateDir + tags + clientSecret
+  });
+
+  test("includes both OAuth credentials when provided", () => {
+    const secrets = {
+      ...emptySecrets,
+      tsnetOAuthClientId: {} as any,
+      tsnetOAuthClientSecret: {} as any,
+    };
+    const envs = computeTsnetEnvs(tsnetMachineWithTags, secrets);
+    // enabled + hostname + stateDir + tags + clientId + clientSecret
+    expect(envs.length).toBe(6);
+  });
+
+  test("omits OAuth credentials when not provided", () => {
+    const envs = computeTsnetEnvs(tsnetMachineWithTags, emptySecrets);
+    // enabled + hostname + stateDir + tags (no OAuth)
+    expect(envs.length).toBe(4);
   });
 });

--- a/packages/envoy/infra/index.ts
+++ b/packages/envoy/infra/index.ts
@@ -19,13 +19,15 @@ const machines = cfg.requireObject<MachineConfig[]>("machines");
 const githubWebhookSecret = cfg.getSecret("githubWebhookSecret");
 const slackSigningSecret = cfg.getSecret("slackSigningSecret");
 const ghostWisprSigningSecret = cfg.getSecret("ghostWisprSigningSecret");
-const tsnetAuthKey = cfg.getSecret("tsnetAuthKey");
+const tsnetOAuthClientId = cfg.getSecret("tsnetOAuthClientId");
+const tsnetOAuthClientSecret = cfg.getSecret("tsnetOAuthClientSecret");
 
 const secrets = {
   githubWebhookSecret,
   slackSigningSecret,
   ghostWisprSigningSecret,
-  tsnetAuthKey,
+  tsnetOAuthClientId,
+  tsnetOAuthClientSecret,
 };
 
 // Registry auth for GHCR (private packages)

--- a/packages/envoy/infra/machines.ts
+++ b/packages/envoy/infra/machines.ts
@@ -9,6 +9,8 @@ export interface TsnetConfig {
   hostname: string;
   /** Persistent state directory — must be unique per service to avoid identity collisions. */
   stateDir: string;
+  /** Comma-separated Tailscale tags for the node (e.g., "tag:envoy"). Required when using OAuth credentials. */
+  tags?: string;
 }
 
 export interface ListenerConfig {

--- a/packages/envoy/infra/services.ts
+++ b/packages/envoy/infra/services.ts
@@ -35,7 +35,8 @@ interface ServiceSecrets {
   githubWebhookSecret?: pulumi.Output<string>;
   slackSigningSecret?: pulumi.Output<string>;
   ghostWisprSigningSecret?: pulumi.Output<string>;
-  tsnetAuthKey?: pulumi.Output<string>;
+  tsnetOAuthClientId?: pulumi.Output<string>;
+  tsnetOAuthClientSecret?: pulumi.Output<string>;
 }
 
 function getNatsUrls(machine: MachineConfig, allMachines: MachineConfig[]): string {
@@ -57,6 +58,10 @@ function countNatsPeers(allMachines: MachineConfig[]): number {
 /**
  * Compute tsnet environment variables for a listener container.
  * Returns empty array when tsnet is not configured.
+ *
+ * OAuth credentials (client ID + secret) are preferred over a legacy auth key.
+ * Tags from the machine config are passed when OAuth is configured. The Go
+ * listener constructs the final auth key string from these components.
  */
 export function computeTsnetEnvs(
   machine: MachineConfig,
@@ -70,8 +75,12 @@ export function computeTsnetEnvs(
     "ENVOY_TSNET_ENABLED=true",
     `ENVOY_TSNET_HOSTNAME=${tsnet.hostname}`,
     `ENVOY_TSNET_STATE_DIR=${tsnet.stateDir}`,
-    ...(secrets.tsnetAuthKey
-      ? [pulumi.interpolate`ENVOY_TSNET_AUTH_KEY=${secrets.tsnetAuthKey}`]
+    ...(tsnet.tags ? [`ENVOY_TSNET_TAGS=${tsnet.tags}`] : []),
+    ...(secrets.tsnetOAuthClientId
+      ? [pulumi.interpolate`ENVOY_TSNET_OAUTH_CLIENT_ID=${secrets.tsnetOAuthClientId}`]
+      : []),
+    ...(secrets.tsnetOAuthClientSecret
+      ? [pulumi.interpolate`ENVOY_TSNET_OAUTH_CLIENT_SECRET=${secrets.tsnetOAuthClientSecret}`]
       : []),
   ];
 }

--- a/packages/envoy/internal/tsnet/config.go
+++ b/packages/envoy/internal/tsnet/config.go
@@ -25,9 +25,9 @@ type Config struct {
 	// Required when Enabled is true.
 	StateDir string
 
-	// AuthKey is the Tailscale auth key for headless registration. Only
-	// needed for initial node registration; not required on every restart
-	// if state is persisted.
+	// AuthKey is a computed auth key derived from OAuth credentials or a
+	// legacy TS_AUTHKEY. Empty when no credentials are configured (state
+	// directory provides identity on restart).
 	AuthKey string
 }
 
@@ -36,7 +36,15 @@ type Config struct {
 //   - ENVOY_TSNET_ENABLED (bool, default "false")
 //   - ENVOY_TSNET_HOSTNAME (string, required when enabled)
 //   - ENVOY_TSNET_STATE_DIR (string, required when enabled)
-//   - ENVOY_TSNET_AUTH_KEY (string, optional)
+//   - ENVOY_TSNET_OAUTH_CLIENT_ID (string, optional — OAuth client ID)
+//   - ENVOY_TSNET_OAUTH_CLIENT_SECRET (string, optional — OAuth client secret)
+//   - ENVOY_TSNET_TAGS (string, optional — comma-separated tags, required with OAuth)
+//   - ENVOY_TSNET_AUTH_KEY (string, optional — legacy auth key, mutually exclusive with OAuth)
+//
+// OAuth credentials take precedence over a legacy auth key. When OAuth
+// credentials are provided, the client secret is used directly as the tsnet
+// auth key with tag and ephemeral parameters appended (Tailscale's OAuth
+// secret-as-authkey convention). Tags are required when using OAuth.
 func LoadConfig() (Config, error) {
 	enabled := strings.TrimSpace(os.Getenv("ENVOY_TSNET_ENABLED"))
 	if enabled == "" || enabled == "false" || enabled == "0" {
@@ -56,7 +64,10 @@ func LoadConfig() (Config, error) {
 		return Config{}, fmt.Errorf("ENVOY_TSNET_STATE_DIR is required when ENVOY_TSNET_ENABLED=true")
 	}
 
-	authKey := strings.TrimSpace(os.Getenv("ENVOY_TSNET_AUTH_KEY"))
+	authKey, err := resolveAuthKey()
+	if err != nil {
+		return Config{}, err
+	}
 
 	return Config{
 		Enabled:  true,
@@ -64,4 +75,41 @@ func LoadConfig() (Config, error) {
 		StateDir: stateDir,
 		AuthKey:  authKey,
 	}, nil
+}
+
+// resolveAuthKey derives the tsnet auth key from environment variables.
+// OAuth credentials (client secret + tags) take precedence over a legacy
+// ENVOY_TSNET_AUTH_KEY. Both being set is an error to prevent confusion.
+func resolveAuthKey() (string, error) {
+	oauthID := strings.TrimSpace(os.Getenv("ENVOY_TSNET_OAUTH_CLIENT_ID"))
+	oauthSecret := strings.TrimSpace(os.Getenv("ENVOY_TSNET_OAUTH_CLIENT_SECRET"))
+	tags := strings.TrimSpace(os.Getenv("ENVOY_TSNET_TAGS"))
+	legacyKey := strings.TrimSpace(os.Getenv("ENVOY_TSNET_AUTH_KEY"))
+
+	hasOAuth := oauthID != "" || oauthSecret != ""
+	hasLegacy := legacyKey != ""
+
+	if hasOAuth && hasLegacy {
+		return "", fmt.Errorf("ENVOY_TSNET_AUTH_KEY and ENVOY_TSNET_OAUTH_CLIENT_SECRET are mutually exclusive; use one or the other")
+	}
+
+	if !hasOAuth {
+		return legacyKey, nil
+	}
+
+	// OAuth path: both ID and secret are required together.
+	if oauthID == "" {
+		return "", fmt.Errorf("ENVOY_TSNET_OAUTH_CLIENT_ID is required when ENVOY_TSNET_OAUTH_CLIENT_SECRET is set")
+	}
+	if oauthSecret == "" {
+		return "", fmt.Errorf("ENVOY_TSNET_OAUTH_CLIENT_SECRET is required when ENVOY_TSNET_OAUTH_CLIENT_ID is set")
+	}
+	if tags == "" {
+		return "", fmt.Errorf("ENVOY_TSNET_TAGS is required when using OAuth credentials (e.g. 'tag:envoy')")
+	}
+
+	// Tailscale convention: an OAuth client secret can be passed directly as
+	// an auth key with URL-style parameters. The node registers as non-
+	// ephemeral and preauthorized, tagged with the specified tags.
+	return oauthSecret + "?ephemeral=false&preauthorized=true&tags=" + tags, nil
 }

--- a/packages/envoy/internal/tsnet/config_test.go
+++ b/packages/envoy/internal/tsnet/config_test.go
@@ -2,6 +2,7 @@ package tsnet
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -15,11 +16,31 @@ func setTsnetEnv(t *testing.T, enabled, hostname, stateDir, authKey string) {
 	} {
 		t.Setenv(kv.key, kv.val)
 	}
+	// Clear OAuth env vars by default so they don't leak between tests.
+	t.Setenv("ENVOY_TSNET_OAUTH_CLIENT_ID", "")
+	t.Setenv("ENVOY_TSNET_OAUTH_CLIENT_SECRET", "")
+	t.Setenv("ENVOY_TSNET_TAGS", "")
 }
 
+func setOAuthEnv(t *testing.T, enabled, hostname, stateDir, clientID, clientSecret, tags string) {
+	t.Helper()
+	t.Setenv("ENVOY_TSNET_ENABLED", enabled)
+	t.Setenv("ENVOY_TSNET_HOSTNAME", hostname)
+	t.Setenv("ENVOY_TSNET_STATE_DIR", stateDir)
+	t.Setenv("ENVOY_TSNET_AUTH_KEY", "")
+	t.Setenv("ENVOY_TSNET_OAUTH_CLIENT_ID", clientID)
+	t.Setenv("ENVOY_TSNET_OAUTH_CLIENT_SECRET", clientSecret)
+	t.Setenv("ENVOY_TSNET_TAGS", tags)
+}
+
+// --- Disabled / basic tests (unchanged) ---
+
 func TestLoadConfig_Disabled_DefaultEmpty(t *testing.T) {
-	// All env vars unset — should default to disabled.
-	for _, key := range []string{"ENVOY_TSNET_ENABLED", "ENVOY_TSNET_HOSTNAME", "ENVOY_TSNET_STATE_DIR", "ENVOY_TSNET_AUTH_KEY"} {
+	for _, key := range []string{
+		"ENVOY_TSNET_ENABLED", "ENVOY_TSNET_HOSTNAME", "ENVOY_TSNET_STATE_DIR",
+		"ENVOY_TSNET_AUTH_KEY", "ENVOY_TSNET_OAUTH_CLIENT_ID",
+		"ENVOY_TSNET_OAUTH_CLIENT_SECRET", "ENVOY_TSNET_TAGS",
+	} {
 		os.Unsetenv(key)
 	}
 	cfg, err := LoadConfig()
@@ -53,26 +74,6 @@ func TestLoadConfig_Disabled_Zero(t *testing.T) {
 	}
 }
 
-func TestLoadConfig_Enabled_AllFields(t *testing.T) {
-	setTsnetEnv(t, "true", "envoy-listener-test", "/var/lib/tsnet/test", "tskey-auth-test123")
-	cfg, err := LoadConfig()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !cfg.Enabled {
-		t.Fatal("expected enabled")
-	}
-	if cfg.Hostname != "envoy-listener-test" {
-		t.Fatalf("expected hostname 'envoy-listener-test', got %q", cfg.Hostname)
-	}
-	if cfg.StateDir != "/var/lib/tsnet/test" {
-		t.Fatalf("expected state dir '/var/lib/tsnet/test', got %q", cfg.StateDir)
-	}
-	if cfg.AuthKey != "tskey-auth-test123" {
-		t.Fatalf("expected auth key 'tskey-auth-test123', got %q", cfg.AuthKey)
-	}
-}
-
 func TestLoadConfig_Enabled_One(t *testing.T) {
 	setTsnetEnv(t, "1", "envoy-listener-test", "/var/lib/tsnet/test", "")
 	cfg, err := LoadConfig()
@@ -81,17 +82,6 @@ func TestLoadConfig_Enabled_One(t *testing.T) {
 	}
 	if !cfg.Enabled {
 		t.Fatal("expected enabled with 1")
-	}
-}
-
-func TestLoadConfig_Enabled_AuthKeyOptional(t *testing.T) {
-	setTsnetEnv(t, "true", "envoy-listener-test", "/var/lib/tsnet/test", "")
-	cfg, err := LoadConfig()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg.AuthKey != "" {
-		t.Fatalf("expected empty auth key, got %q", cfg.AuthKey)
 	}
 }
 
@@ -139,5 +129,136 @@ func TestLoadConfig_WhitespaceHandling(t *testing.T) {
 	}
 	if cfg.AuthKey != "tskey-123" {
 		t.Fatalf("expected trimmed auth key, got %q", cfg.AuthKey)
+	}
+}
+
+// --- Legacy auth key tests ---
+
+func TestLoadConfig_LegacyAuthKey_AllFields(t *testing.T) {
+	setTsnetEnv(t, "true", "envoy-listener-test", "/var/lib/tsnet/test", "tskey-auth-test123")
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.Enabled {
+		t.Fatal("expected enabled")
+	}
+	if cfg.Hostname != "envoy-listener-test" {
+		t.Fatalf("expected hostname 'envoy-listener-test', got %q", cfg.Hostname)
+	}
+	if cfg.StateDir != "/var/lib/tsnet/test" {
+		t.Fatalf("expected state dir '/var/lib/tsnet/test', got %q", cfg.StateDir)
+	}
+	if cfg.AuthKey != "tskey-auth-test123" {
+		t.Fatalf("expected auth key 'tskey-auth-test123', got %q", cfg.AuthKey)
+	}
+}
+
+func TestLoadConfig_LegacyAuthKey_Optional(t *testing.T) {
+	setTsnetEnv(t, "true", "envoy-listener-test", "/var/lib/tsnet/test", "")
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AuthKey != "" {
+		t.Fatalf("expected empty auth key, got %q", cfg.AuthKey)
+	}
+}
+
+// --- OAuth credential tests ---
+
+func TestLoadConfig_OAuth_AllFields(t *testing.T) {
+	setOAuthEnv(t, "true", "envoy-listener-test", "/var/lib/tsnet/test",
+		"tsid-client-abc123", "tskey-client-secret-xyz", "tag:envoy")
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.Enabled {
+		t.Fatal("expected enabled")
+	}
+	expected := "tskey-client-secret-xyz?ephemeral=false&preauthorized=true&tags=tag:envoy"
+	if cfg.AuthKey != expected {
+		t.Fatalf("expected auth key %q, got %q", expected, cfg.AuthKey)
+	}
+}
+
+func TestLoadConfig_OAuth_MultipleTags(t *testing.T) {
+	setOAuthEnv(t, "true", "envoy-listener-test", "/var/lib/tsnet/test",
+		"tsid-client-abc123", "tskey-client-secret-xyz", "tag:envoy,tag:server")
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "tskey-client-secret-xyz?ephemeral=false&preauthorized=true&tags=tag:envoy,tag:server"
+	if cfg.AuthKey != expected {
+		t.Fatalf("expected auth key %q, got %q", expected, cfg.AuthKey)
+	}
+}
+
+func TestLoadConfig_OAuth_MissingClientID(t *testing.T) {
+	setOAuthEnv(t, "true", "envoy-listener-test", "/var/lib/tsnet/test",
+		"", "tskey-client-secret-xyz", "tag:envoy")
+	_, err := LoadConfig()
+	if err == nil {
+		t.Fatal("expected error for missing OAuth client ID")
+	}
+	if !strings.Contains(err.Error(), "ENVOY_TSNET_OAUTH_CLIENT_ID") {
+		t.Fatalf("expected error about client ID, got: %s", err.Error())
+	}
+}
+
+func TestLoadConfig_OAuth_MissingClientSecret(t *testing.T) {
+	setOAuthEnv(t, "true", "envoy-listener-test", "/var/lib/tsnet/test",
+		"tsid-client-abc123", "", "tag:envoy")
+	_, err := LoadConfig()
+	if err == nil {
+		t.Fatal("expected error for missing OAuth client secret")
+	}
+	if !strings.Contains(err.Error(), "ENVOY_TSNET_OAUTH_CLIENT_SECRET") {
+		t.Fatalf("expected error about client secret, got: %s", err.Error())
+	}
+}
+
+func TestLoadConfig_OAuth_MissingTags(t *testing.T) {
+	setOAuthEnv(t, "true", "envoy-listener-test", "/var/lib/tsnet/test",
+		"tsid-client-abc123", "tskey-client-secret-xyz", "")
+	_, err := LoadConfig()
+	if err == nil {
+		t.Fatal("expected error for missing tags")
+	}
+	if !strings.Contains(err.Error(), "ENVOY_TSNET_TAGS") {
+		t.Fatalf("expected error about tags, got: %s", err.Error())
+	}
+}
+
+func TestLoadConfig_OAuth_ConflictWithLegacyKey(t *testing.T) {
+	t.Setenv("ENVOY_TSNET_ENABLED", "true")
+	t.Setenv("ENVOY_TSNET_HOSTNAME", "envoy-listener-test")
+	t.Setenv("ENVOY_TSNET_STATE_DIR", "/var/lib/tsnet/test")
+	t.Setenv("ENVOY_TSNET_AUTH_KEY", "tskey-auth-test123")
+	t.Setenv("ENVOY_TSNET_OAUTH_CLIENT_ID", "tsid-client-abc123")
+	t.Setenv("ENVOY_TSNET_OAUTH_CLIENT_SECRET", "tskey-client-secret-xyz")
+	t.Setenv("ENVOY_TSNET_TAGS", "tag:envoy")
+
+	_, err := LoadConfig()
+	if err == nil {
+		t.Fatal("expected error for conflicting auth methods")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("expected mutual exclusion error, got: %s", err.Error())
+	}
+}
+
+func TestLoadConfig_OAuth_WhitespaceHandling(t *testing.T) {
+	setOAuthEnv(t, " true ", " envoy-test ", " /var/lib/test ",
+		" tsid-client-abc ", " tskey-secret-xyz ", " tag:envoy ")
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "tskey-secret-xyz?ephemeral=false&preauthorized=true&tags=tag:envoy"
+	if cfg.AuthKey != expected {
+		t.Fatalf("expected auth key %q, got %q", expected, cfg.AuthKey)
 	}
 }

--- a/packages/envoy/internal/tsnet/server.go
+++ b/packages/envoy/internal/tsnet/server.go
@@ -17,7 +17,9 @@ type Server struct {
 }
 
 // New creates a tsnet Server from the given Config. The caller must call
-// Close when finished.
+// Close when finished. The AuthKey field may contain either a legacy
+// Tailscale auth key or an OAuth client secret with URL-style parameters
+// (constructed by LoadConfig from OAuth env vars).
 func New(cfg Config) *Server {
 	ts := &tsnet.Server{
 		Hostname: cfg.Hostname,


### PR DESCRIPTION
Closes #510

## Summary

Replace personal Tailscale auth key (`ENVOY_TSNET_AUTH_KEY`) with organizational OAuth client credentials for tsnet node registration. OAuth clients are the recommended approach for production tsnet deployments — they're automatable, scoped to the org, and support key rotation without re-auth.

### Changes

**Go (packages/envoy/internal/tsnet/)**
- `config.go`: Add `resolveAuthKey()` that supports three auth modes:
  - **OAuth** (preferred): `ENVOY_TSNET_OAUTH_CLIENT_ID` + `ENVOY_TSNET_OAUTH_CLIENT_SECRET` + `ENVOY_TSNET_TAGS` → constructs auth key using Tailscale's OAuth-secret-as-authkey convention with `?ephemeral=false&preauthorized=true&tags=...`
  - **Legacy**: `ENVOY_TSNET_AUTH_KEY` still works for backward compat
  - **None**: State directory provides identity on restart
  - Mutual exclusion: setting both OAuth and legacy is a config error
- `config_test.go`: 17 tests covering OAuth happy path, multiple tags, missing fields, conflict detection, whitespace handling, and legacy backward compat
- `server.go`: Updated doc comments

**Pulumi infra (packages/envoy/infra/)**
- `machines.ts`: Added `tags` field to `TsnetConfig`
- `services.ts`: Replaced `tsnetAuthKey` with `tsnetOAuthClientId` + `tsnetOAuthClientSecret` env var injection
- `index.ts`: Reads new Pulumi secrets `tsnetOAuthClientId`/`tsnetOAuthClientSecret`
- `Pulumi.prod.yaml`: Added `tags: "tag:envoy"` to production tsnet config
- `services.test.ts`: 15 tests covering tags, OAuth credential injection, and omission

**Docker Compose (deploy/compose/listener.compose.yml)**
- Added OAuth env vars (`ENVOY_TSNET_OAUTH_CLIENT_ID`, `ENVOY_TSNET_OAUTH_CLIENT_SECRET`, `ENVOY_TSNET_TAGS`)
- Kept legacy `ENVOY_TSNET_AUTH_KEY` for backward compat

### Required OAuth Scopes

Create a Tailscale OAuth client with the `auth_keys` scope and `tag:envoy` (or your chosen tag). The node registers as non-ephemeral and preauthorized.

### Migration

1. Create an OAuth client in Tailscale admin console with `auth_keys` scope and `tag:envoy`
2. Set `pulumi config set --secret envoy:tsnetOAuthClientId <client-id>`
3. Set `pulumi config set --secret envoy:tsnetOAuthClientSecret <client-secret>`
4. Remove old `pulumi config rm envoy:tsnetAuthKey` (if set)
5. Deploy — the listener's Go config reads the new env vars and constructs the auth key automatically