### PR TITLE
sjawhar-legion-520: add tmux requirement for long-running commands to worker skills

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,20 +1,16 @@
 {
   "filesChanged": [
-    "packages/opencode-plugin/src/hooks/json-error-recovery.ts",
-    "packages/opencode-plugin/src/hooks/__tests__/json-error-recovery.test.ts",
-    "packages/opencode-plugin/src/index.ts",
-    ".legion/implement.json"
+    ".opencode/skills/legion-worker/SKILL.md",
+    ".opencode/skills/legion-worker/workflows/implement.md",
+    ".opencode/skills/legion-worker/workflows/test.md"
   ],
   "trickyParts": [
-    "Single-quote replacement required a character-by-character parser to handle escaped quotes and mixed quote types correctly — regex-only approach would break on edge cases like double quotes inside single-quoted strings",
-    "Unquoted key regex must only match keys (after { or ,) not values — using lookbehind-like pattern with capture groups",
-    "Hook runs before circuit-breaker so that circuit-breaker hashes repaired (canonical) args, not malformed originals",
-    "Address-comments round: resolved .legion/implement.json merge conflict from rebase, aligned sessionID type signature with sibling hook, added multi-arg repair test"
+    "Issue referenced smoke-test.md but the actual file is test.md — used test.md as the target"
   ],
-  "deviations": [],
+  "deviations": ["None — followed the issue directive exactly"],
   "openQuestions": [],
   "subPlanningNeeded": false,
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-13T18:08:59.812Z"
+  "completed": "2026-04-13T20:00:40.537Z"
 }

--- a/.legion/retro.json
+++ b/.legion/retro.json
@@ -1,10 +1,7 @@
 {
-  "skipped": false,
-  "docsCreated": [
-    "docs/solutions/testing/mock-envoy-server-pattern.md",
-    "docs/solutions/testing/call-site-audit-for-test-isolation.md"
-  ],
+  "skipped": true,
+  "reason": "no significant learnings — documentation-only change with self-documenting patterns",
   "schemaVersion": 1,
   "phase": "retro",
-  "completed": "2026-04-13T17:29:20.204Z"
+  "completed": "2026-04-13T20:19:04.007Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -3,11 +3,17 @@
   "important": 0,
   "minor": 0,
   "verdict": "approved",
-  "keyFindings": [],
+  "keyFindings": [
+    {
+      "severity": "P3",
+      "file": ".opencode/skills/legion-worker/workflows/implement.md",
+      "description": "Section 3.5 placement between Analyze and Pre-Ship Verification is slightly late for a rule that applies 'throughout implementation', but mitigated by Essential Rule #8 in SKILL.md"
+    }
+  ],
   "learningsInjected": [],
   "learningsHelpful": [],
   "note": "Re-review after implementer addressed prior feedback. All 3 prior findings (P1 merge conflict, P3 sessionID type, P3 multi-arg test) resolved. All acceptance criteria verified. CI green.",
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-13T18:18:26.126Z"
+  "completed": "2026-04-13T20:12:03.343Z"
 }

--- a/.opencode/skills/legion-worker/SKILL.md
+++ b/.opencode/skills/legion-worker/SKILL.md
@@ -37,6 +37,16 @@ Use the **backend** from your prompt to choose GitHub CLI or Linear MCP commands
 5. **Clean up on exit** - remove `worker-active` label when exiting (done or blocked)
 6. **Notify the controller via Envoy** — after adding `worker-done`, send exactly one completion notification so the controller doesn't have to wait for its next polling cycle. Use `envoy_publish(topic="notifications.role.legion-controller", message="Worker done: <issue> <mode> <outcome>")`. If `envoy_publish` fails, that's fine — the label is the source of truth.
 7. **Never stall on subagents** — when spawning background tasks (cross-family review, Oracle, spec compliance, etc.), always set `timeout_seconds` (typically 180s). If the subagent times out or fails, skip that step and continue with the workflow. Your primary obligation is to complete the workflow and signal `worker-done`. Subagent steps are quality improvements, not hard prerequisites — the downstream human/bot review is the authoritative quality gate.
+8. **Never block bash with long-running commands** — any command expected to take >60 seconds (builds, deploys, serves, eval runs, smoke tests) MUST run in a tmux session. Workers that block their bash session get killed by tool timeouts.
+   ```bash
+   # Run long command in background tmux session
+   tmux new-session -d -s <name> '<command>'
+   # Monitor progress
+   tmux capture-pane -t <name> -p | tail -20
+   # Check if still running
+   tmux has-session -t <name> 2>/dev/null && echo "running" || echo "done"
+   ```
+   Never run `bun run serve`, `pulumi up`, long test suites, or similar commands directly in bash.
 
 ## Skill Discipline
 

--- a/.opencode/skills/legion-worker/workflows/implement.md
+++ b/.opencode/skills/legion-worker/workflows/implement.md
@@ -185,6 +185,21 @@ Invoke `/analyze` to run cleanup agents.
 
 **If `/analyze` fails or times out (>3 min):** Skip and proceed to Pre-Ship Verification. The pre-ship checks will catch anything critical. Note "Analyze skipped (timeout)" in the handoff.
 
+### 3.5. Long-Running Commands
+
+Any command expected to take >60 seconds (builds, deploys, eval pipelines, serve commands) MUST run in a tmux session. Never block your bash session with long-running commands — tool timeouts will kill them.
+
+```bash
+# Run in background tmux session
+tmux new-session -d -s build '<command>'
+# Monitor progress
+tmux capture-pane -t build -p | tail -20
+# Check if still running
+tmux has-session -t build 2>/dev/null && echo "running" || echo "done"
+```
+
+This applies throughout implementation — builds, deploys, `pulumi up`, long test suites, `bun run serve`, etc. Short commands (<60s) like `bun test`, `bunx tsc --noEmit`, and `bunx biome check` can run directly.
+
 ### 4. Pre-Ship Verification
 
 All checks must pass before creating PR:

--- a/.opencode/skills/legion-worker/workflows/test.md
+++ b/.opencode/skills/legion-worker/workflows/test.md
@@ -206,9 +206,19 @@ for i in $(seq 1 30); do
 done
 ```
 
-**Long-running commands:** Some verification commands (eval runs, build pipelines, integration suites) exceed the bash tool's default timeout (~120s). If a command is killed by timeout:
-- Re-run with a longer `timeout` parameter if supported by your tool
-- Or run in tmux: `tmux new-session -d -s test '<command>'`, then poll with `tmux capture-pane -t test -p | tail -5`
+**Long-running commands (MANDATORY tmux rule):** Any command expected to take >60 seconds (serve commands, eval runs, build pipelines, integration suites) MUST run in a tmux session. Never block your bash session — tool timeouts will kill it and waste the attempt.
+
+```bash
+# Run long-running command in tmux (REQUIRED for >60s commands)
+tmux new-session -d -s test '<command>'
+# Monitor progress
+tmux capture-pane -t test -p | tail -20
+# Check if still running
+tmux has-session -t test 2>/dev/null && echo "running" || echo "done"
+```
+
+This is not optional. 5 consecutive smoke test failures were caused by workers running serve commands directly in bash. Use tmux for the serve, normal bash for test commands (curl, CLI invocations, etc.).
+
 - Do NOT treat a timeout as a test failure — it means the command didn't finish, not that it failed
 
 ### 5. Execute Acceptance Criteria (This Is the Actual Test)


### PR DESCRIPTION
Closes #520

## Summary

Adds a mandatory tmux rule for any command expected to take >60 seconds across worker skills. This prevents bash tool timeouts from killing long-running commands (builds, deploys, serves, eval runs).

Changes:
- **SKILL.md** — New Essential Rule #8: never block bash with long-running commands, with tmux pattern
- **implement.md** — New section 3.5 reinforcing tmux for builds/deploys during implementation
- **test.md** — Strengthened existing long-running commands guidance from optional to mandatory, with context about the 5 failed smoke test attempts that motivated this rule