### PR TITLE
sjawhar-legion-515: add web dashboard UI

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,18 +1,21 @@
 {
   "filesChanged": [
-    ".opencode/skills/legion-worker/workflows/smoke-testing.md",
-    ".changelog/516.md"
+    "packages/daemon/src/daemon/dashboard-ui.ts",
+    "packages/daemon/src/daemon/server.ts",
+    "packages/daemon/src/daemon/__tests__/server.test.ts",
+    "packages/daemon/src/daemon/AGENTS.md"
   ],
   "trickyParts": [
-    "Resolved rebase conflicts in .legion/implement.json and .legion/review.json caused by concurrent merges to main",
-    "Renamed smoke-test.md to smoke-testing.md to match existing references in test.md and plan.md"
+    "Keeping the HTML/CSS/JS self-contained in a single TypeScript string template while maintaining readability and proper escaping"
   ],
-  "deviations": [],
-  "openQuestions": [],
+  "deviations": [
+    "No plan phase existed for this issue — implemented directly from issue spec and dispatch prompt. The issue mentioned broader features (reports, visual artifacts, feedback) but dispatch scoped to MVP: single HTML page with worker status, pipeline, tokens, auto-refresh."
+  ],
+  "openQuestions": [
+    "Future iterations could add: interactive feedback (approve/reject plans), report viewing, visual artifact rendering, WebSocket for real-time updates instead of polling"
+  ],
   "subPlanningNeeded": false,
-  "learningsInjected": [],
-  "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-13T21:07:45.345Z"
+  "completed": "2026-04-13T22:33:20.858Z"
 }

--- a/.legion/retro.json
+++ b/.legion/retro.json
@@ -1,7 +1,9 @@
 {
-  "skipped": true,
-  "reason": "no significant learnings — documentation-only change with self-documenting patterns",
+  "skipped": false,
+  "docsCreated": [
+    "docs/solutions/daemon/inline-html-dashboard-pattern.md"
+  ],
   "schemaVersion": 1,
   "phase": "retro",
-  "completed": "2026-04-13T20:19:04.007Z"
+  "completed": "2026-04-13T22:50:45.412Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,28 +1,23 @@
 {
   "critical": 0,
   "important": 0,
-  "minor": 3,
+  "minor": 2,
   "verdict": "approved",
   "keyFindings": [
     {
       "severity": "P3",
-      "file": "packages/opencode-plugin/src/hooks/write-existing-file-guard.ts",
-      "description": "Extra args?: unknown on tool.execute.before input type — cosmetic, code correctly reads from output.args"
+      "file": "packages/daemon/src/daemon/dashboard-ui.ts",
+      "description": "statusClass()/phaseClass()/issueStatusClass() insert values into CSS class names without escaping — low risk since values are server-controlled enums"
     },
     {
       "severity": "P3",
-      "file": "packages/opencode-plugin/src/hooks/write-existing-file-guard.ts",
-      "description": "No test for mixed-case tool names to validate toLowerCase guard"
-    },
-    {
-      "severity": "P3",
-      "file": "packages/opencode-plugin/src/hooks/__tests__/write-existing-file-guard.test.ts",
-      "description": "console.warn noise in test output — consider global mock in beforeEach"
+      "file": "packages/daemon/src/daemon/dashboard-ui.ts",
+      "description": "timer variable assigned but never read (dead store) — cosmetic only"
     }
   ],
   "learningsInjected": [],
   "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-13T22:19:22.263Z"
+  "completed": "2026-04-13T22:41:32.032Z"
 }

--- a/docs/solutions/daemon/inline-html-dashboard-pattern.md
+++ b/docs/solutions/daemon/inline-html-dashboard-pattern.md
@@ -1,0 +1,137 @@
+---
+title: "Inline HTML Dashboard Pattern: Self-Contained UI in TypeScript Template Literals"
+category: daemon
+tags:
+  - dashboard
+  - html
+  - template-literal
+  - zero-dependency
+  - mvp
+  - server
+  - http
+date: 2026-04-13
+status: active
+module: daemon
+related_issues:
+  - "515"
+symptoms:
+  - "need to serve a web UI from the daemon without a build step"
+  - "how to embed HTML/CSS/JS in a TypeScript file"
+  - "dashboard served from daemon HTTP server"
+---
+
+# Inline HTML Dashboard Pattern
+
+## Context
+
+Issue #515 added a web dashboard UI to the Legion daemon. The approach: a single
+TypeScript function (`getDashboardHtml()`) returns a complete HTML document as a
+template literal string. The daemon serves it at `GET /dashboard/ui` with a 6-line
+route handler.
+
+## The Pattern
+
+### Architecture
+
+```
+GET /dashboard/ui  →  getDashboardHtml()  →  static HTML shell
+                                              ↓ (client-side)
+                                         fetch("/dashboard")  →  JSON API (already existed)
+                                              ↓
+                                         vanilla JS renders DOM
+```
+
+Key separation: the HTML is a **static shell** with client-side JS that fetches data
+from the existing JSON endpoint. No server-side rendering, no data baked into the HTML.
+This means the JSON API and the UI are independently testable and evolvable.
+
+### Server Integration
+
+The entire integration in `server.ts` is:
+
+```typescript
+import { getDashboardHtml } from "./dashboard-ui";
+
+// In the route handler:
+if (method === "GET" && url.pathname === "/dashboard/ui") {
+  return new Response(getDashboardHtml(), {
+    status: 200,
+    headers: { "content-type": "text/html; charset=utf-8" },
+  });
+}
+```
+
+The `getDashboardHtml()` function has **zero imports and zero parameters** — it's a
+pure function that always returns the same string.
+
+### Template Literal Escaping Gotchas
+
+The entire HTML/CSS/JS document lives inside a JavaScript template literal. This
+creates escaping challenges:
+
+1. **Client-side JS must avoid template literals.** The implementer used string
+   concatenation (`+`) and `.forEach` callbacks instead of template literals and
+   arrow functions. This sidesteps the escaping problem entirely — backticks inside
+   the outer template literal would terminate it.
+
+2. **CSS Unicode escapes need double backslash.** `content: "\25B6"` in CSS becomes
+   `content: "\\25B6"` inside the template literal. The backslash is consumed once
+   by JS string parsing.
+
+3. **Regex backslashes need double escaping.** `/\s+/g` in the client JS becomes
+   `/\\s+/g` inside the template literal. Easy to miss — the regex works fine in a
+   standalone `.js` file but silently breaks inside a template literal with single
+   backslash.
+
+4. **No `${` sequences in client JS.** Template literal interpolation markers in the
+   client code would be evaluated at build time, not runtime. The implementation
+   avoids this by not using template literals on the client side.
+
+### When This Pattern Works
+
+- **MVP dashboards** — under ~500 lines total, read-only, polling-based
+- **Admin/debug UIs** — status pages, health dashboards, log viewers
+- **Single-page tools** — no routing, no authentication, no complex state
+- **Zero-dependency constraint** — when adding a bundler or framework would be overkill
+
+### When to Migrate Away
+
+- **Interactive controls** — forms, approve/reject buttons, inline editing. The
+  `innerHTML`-based re-render destroys form state on every cycle.
+- **Multiple pages/views** — no client-side routing, URL state management, or back
+  button support.
+- **Growing complexity** — once the file exceeds ~500 lines, the lack of IDE
+  support for HTML/CSS/JS inside a template literal becomes a significant drag.
+  No syntax highlighting, no autocomplete, no linting.
+- **Real-time updates** — polling works for dashboard refresh but WebSocket/SSE
+  would be better for interactive use. The daemon already has Envoy for event
+  routing.
+
+## Trade-offs Made
+
+| Decision | Benefit | Cost |
+|----------|---------|------|
+| Inline HTML in TS | Zero build step, zero asset pipeline | No IDE support for embedded HTML/CSS/JS |
+| Client-side fetch | Reuses existing JSON API, cacheable HTML | Two HTTP requests on load, blank on JS failure |
+| ES5-compatible JS | No transpilation needed | Verbose syntax (`.forEach`, `var`, no arrow functions) |
+| 30s polling | Simple, works behind any proxy | Up to 30s stale, wastes bandwidth when idle |
+| Minimal tests (2) | Low maintenance, tests the integration seam | No coverage of client-side rendering logic |
+
+## Testing Approach
+
+The tests verify the **integration seam** only:
+
+1. Route returns `200` with `text/html; charset=utf-8` content type
+2. Response contains key markers (`<!DOCTYPE html>`, `Legion Dashboard`, `fetch("/dashboard")`)
+
+This is sufficient because:
+- The HTML is static (no server-side data to verify)
+- Client-side rendering correctness depends on the browser, not the server
+- The JSON API (`/dashboard`) has its own test coverage
+
+## Key Insight
+
+The real value of this approach is **clean API separation**. Because the UI is just a
+consumer of an existing JSON endpoint, it can be replaced later with a proper frontend
+build (React, Svelte, etc.) without changing any backend code. The `/dashboard` JSON
+contract is the stable interface — the inline HTML is a disposable MVP.

--- a/docs/solutions/index.json
+++ b/docs/solutions/index.json
@@ -21,9 +21,7 @@
       "task-index-patterns.md"
     ],
     "packages/daemon/src/daemon": [
-      "daemon/worker-directory-resolution.md",
       "daemon/workspace-validation-retro.md",
-      "daemon/controller-observability.md",
       "daemon/session-liveness-detection-pattern.md",
       "daemon/optional-dep-fallback-and-early-return-guard.md",
       "daemon/targeted-delta-filtering-pattern.md",
@@ -31,7 +29,8 @@
       "daemon/self-fetch-endpoint-composition.md",
       "daemon/pre-cleanup-branch-push-verification.md",
       "best-practices/jj-bookmark-template-syntax-gotchas.md",
-      "daemon/dead-worker-workspace-reclamation.md"
+      "daemon/dead-worker-workspace-reclamation.md",
+      "daemon/inline-html-dashboard-pattern.md"
     ],
     "packages/daemon/src/__tests__": [
       "testing/mock-envoy-server-pattern.md",
@@ -400,6 +399,11 @@
     "tag:text-parsing": ["architecture-patterns/opencode-plugin-hook-authoring-patterns.md"],
     "packages/opencode-plugin/src": [
       "architecture-patterns/opencode-plugin-hook-authoring-patterns.md"
-    ]
+    ],
+    "tag:dashboard": ["daemon/inline-html-dashboard-pattern.md"],
+    "tag:html": ["daemon/inline-html-dashboard-pattern.md"],
+    "tag:template-literal": ["daemon/inline-html-dashboard-pattern.md"],
+    "tag:zero-dependency": ["daemon/inline-html-dashboard-pattern.md"],
+    "tag:mvp": ["daemon/inline-html-dashboard-pattern.md"]
   }
 }

--- a/packages/daemon/src/daemon/AGENTS.md
+++ b/packages/daemon/src/daemon/AGENTS.md
@@ -16,6 +16,7 @@ HTTP server + shared `opencode serve` instance. One long-lived serve process han
 | `POST` | `/workers/prune` | Bulk-remove workers + crash history by issue ID — `{issueIds: string[]}` → `{pruned, crashHistoryPruned}` |
 | `POST` | `/shutdown` | Graceful shutdown — stop shared serve, persist state |
 | `GET` | `/dashboard` | Aggregated worker summary grouped by repo+issue, with activity, stats, and recent events |
+| `GET` | `/dashboard/ui` | Single-page HTML dashboard — fetches `/dashboard` JSON, auto-refreshes 30s, responsive |
 | `GET`    | `/state/track`          | List tracked issue IDs — `{trackedIssues: string[]}` |
 | `POST`   | `/state/track`          | Manually track an issue — `{issueId}` → `{tracked: true}` |
 | `DELETE` | `/state/track/:issueId` | Manually untrack an issue → `{untracked: true}` |
@@ -31,6 +32,7 @@ HTTP server + shared `opencode serve` instance. One long-lived serve process han
 |------|---------------|
 | `index.ts` | Daemon lifecycle: `startDaemon()`, shared serve startup, health tick loop, signal handlers. Controller creates a session on shared serve. Uses DI via `DaemonDependencies` interface for testability. |
 | `server.ts` | HTTP routing, request validation, in-memory worker map. `POST /workers` creates session on shared serve (instant). `DELETE /workers` removes tracking only. |
+| `dashboard-ui.ts` | `getDashboardHtml()` — single-page HTML/CSS/JS dashboard served at `/dashboard/ui`. No framework; inline styles and vanilla JS. |
 | `serve-manager.ts` | `spawnSharedServe()` — runs one `opencode serve`. `waitForHealthy()` — polls readiness. `createSession()` — creates session on shared serve. `stopServe()` — graceful shutdown. `healthCheck()` — `/global/health`. |
 | `config.ts` | `DaemonConfig` interface, `loadConfig()` reads env vars. Defaults: daemon port 13370, shared serve port 13381 (`baseWorkerPort`), check interval 60s. **Controller mode:** `LEGION_CONTROLLER_SESSION_ID` env var (optional, must start with `ses_` if set, hard fails on invalid format). |
 | `state-file.ts` | `readStateFile()` / `writeStateFile()` — atomic JSON persistence to `~/.legion/{legionId}/workers.json`. Includes `controller?: ControllerState` field for controller lifecycle. Legacy `controller-controller` worker entries are stripped on read. |

--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -5040,6 +5040,27 @@ describe("daemon server", () => {
     });
   });
 
+  describe("GET /dashboard/ui", () => {
+    it("returns HTML page with correct content-type", async () => {
+      await startTestServer();
+      const response = await originalFetch(`${baseUrl}/dashboard/ui`);
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
+      const html = await response.text();
+      expect(html).toContain("<!DOCTYPE html>");
+      expect(html).toContain("Legion Dashboard");
+      expect(html).toContain('fetch("/dashboard")');
+    });
+
+    it("includes auto-refresh and responsive meta tag", async () => {
+      await startTestServer();
+      const response = await originalFetch(`${baseUrl}/dashboard/ui`);
+      const html = await response.text();
+      expect(html).toContain('name="viewport"');
+      expect(html).toContain("REFRESH_INTERVAL = 30");
+    });
+  });
+
   describe("GET /state/track", () => {
     it("returns empty list when no issues tracked", async () => {
       await startTestServer({});

--- a/packages/daemon/src/daemon/dashboard-ui.ts
+++ b/packages/daemon/src/daemon/dashboard-ui.ts
@@ -1,0 +1,411 @@
+/**
+ * Single-page dashboard UI served as inline HTML/CSS/JS.
+ * Fetches GET /dashboard JSON and renders worker status, pipeline, tokens.
+ * Auto-refreshes every 30 seconds. No framework dependencies.
+ */
+export function getDashboardHtml(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Legion Dashboard</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg:#0d1117;--surface:#161b22;--border:#30363d;--text:#e6edf3;
+  --text-muted:#8b949e;--accent:#58a6ff;--green:#3fb950;--yellow:#d29922;
+  --red:#f85149;--orange:#db6d28;--purple:#bc8cff;
+  --radius:8px;--gap:12px;
+}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
+  background:var(--bg);color:var(--text);line-height:1.5;min-height:100vh}
+a{color:var(--accent);text-decoration:none}
+a:hover{text-decoration:underline}
+
+.container{max-width:1200px;margin:0 auto;padding:var(--gap)}
+header{display:flex;align-items:center;justify-content:space-between;
+  padding:var(--gap);border-bottom:1px solid var(--border);flex-wrap:wrap;gap:8px}
+header h1{font-size:1.25rem;font-weight:600}
+.meta{font-size:0.8rem;color:var(--text-muted);display:flex;align-items:center;gap:8px}
+.refresh-indicator{width:8px;height:8px;border-radius:50%;background:var(--green);
+  display:inline-block;transition:background 0.3s}
+.refresh-indicator.fetching{background:var(--yellow);animation:pulse 1s infinite}
+@keyframes pulse{0%,100%{opacity:1}50%{opacity:0.4}}
+
+/* Summary cards */
+.summary{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));
+  gap:var(--gap);margin:var(--gap) 0}
+.card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);
+  padding:var(--gap)}
+.card-label{font-size:0.75rem;color:var(--text-muted);text-transform:uppercase;
+  letter-spacing:0.05em;margin-bottom:4px}
+.card-value{font-size:1.5rem;font-weight:700}
+.card-detail{font-size:0.75rem;color:var(--text-muted);margin-top:4px}
+
+/* Pipeline */
+.pipeline{display:flex;gap:4px;align-items:center;flex-wrap:wrap;margin:var(--gap) 0;
+  padding:var(--gap);background:var(--surface);border:1px solid var(--border);
+  border-radius:var(--radius);overflow-x:auto}
+.pipeline-stage{padding:6px 12px;border-radius:16px;font-size:0.75rem;font-weight:600;
+  white-space:nowrap;background:var(--border);color:var(--text-muted);position:relative}
+.pipeline-stage.active{background:var(--accent);color:#fff}
+.pipeline-stage .count{margin-left:4px;opacity:0.8}
+.pipeline-arrow{color:var(--text-muted);font-size:0.7rem}
+
+/* Repo groups */
+.repo-group{margin:var(--gap) 0}
+.repo-header{font-size:0.9rem;font-weight:600;color:var(--text-muted);
+  padding:8px 0;border-bottom:1px solid var(--border);margin-bottom:8px}
+
+/* Issue row */
+.issue{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);
+  margin-bottom:var(--gap);overflow:hidden}
+.issue-header{display:flex;align-items:center;gap:8px;padding:10px var(--gap);
+  border-bottom:1px solid var(--border);flex-wrap:wrap}
+.issue-number{font-weight:700;color:var(--accent);font-size:0.9rem}
+.issue-title{font-size:0.85rem;color:var(--text);flex:1;min-width:100px}
+.issue-status{font-size:0.7rem;padding:2px 8px;border-radius:12px;font-weight:600;
+  white-space:nowrap}
+
+/* Worker row */
+.worker{display:grid;grid-template-columns:1fr auto;gap:8px;padding:8px var(--gap);
+  border-bottom:1px solid var(--border);align-items:center}
+.worker:last-child{border-bottom:none}
+.worker-info{display:flex;align-items:center;gap:8px;flex-wrap:wrap;min-width:0}
+.worker-phase{font-size:0.75rem;padding:2px 8px;border-radius:12px;font-weight:600;
+  white-space:nowrap}
+.worker-status{font-size:0.7rem;padding:2px 6px;border-radius:10px;font-weight:600}
+.worker-id{font-size:0.75rem;color:var(--text-muted);overflow:hidden;text-overflow:ellipsis;
+  white-space:nowrap}
+.worker-activity{display:flex;gap:12px;font-size:0.75rem;color:var(--text-muted);
+  flex-wrap:wrap;justify-content:flex-end}
+.worker-activity span{white-space:nowrap}
+
+/* Status colors */
+.status-running{background:rgba(63,185,80,0.15);color:var(--green)}
+.status-starting{background:rgba(210,153,34,0.15);color:var(--yellow)}
+.status-stopped{background:rgba(139,148,158,0.15);color:var(--text-muted)}
+.status-dead{background:rgba(248,81,73,0.15);color:var(--red)}
+
+/* Phase colors */
+.phase-architect{background:rgba(188,140,255,0.15);color:var(--purple)}
+.phase-plan{background:rgba(88,166,255,0.15);color:var(--accent)}
+.phase-implement{background:rgba(63,185,80,0.15);color:var(--green)}
+.phase-test{background:rgba(210,153,34,0.15);color:var(--yellow)}
+.phase-review{background:rgba(219,109,40,0.15);color:var(--orange)}
+.phase-merge{background:rgba(139,148,158,0.15);color:var(--text-muted)}
+
+/* Issue status colors */
+.issue-status-triage{background:rgba(139,148,158,0.15);color:var(--text-muted)}
+.issue-status-todo{background:rgba(88,166,255,0.15);color:var(--accent)}
+.issue-status-in-progress{background:rgba(63,185,80,0.15);color:var(--green)}
+.issue-status-testing{background:rgba(210,153,34,0.15);color:var(--yellow)}
+.issue-status-needs-review{background:rgba(219,109,40,0.15);color:var(--orange)}
+.issue-status-done{background:rgba(139,148,158,0.15);color:var(--text-muted)}
+.issue-status-retro{background:rgba(188,140,255,0.15);color:var(--purple)}
+
+/* Events */
+.events{margin:var(--gap) 0}
+.events-title{font-size:0.85rem;font-weight:600;color:var(--text-muted);
+  margin-bottom:8px;cursor:pointer;user-select:none}
+.events-title::before{content:"\\25B6 ";font-size:0.65rem}
+.events-title.open::before{content:"\\25BC "}
+.events-list{display:none;background:var(--surface);border:1px solid var(--border);
+  border-radius:var(--radius);max-height:300px;overflow-y:auto}
+.events-list.open{display:block}
+.event-row{display:flex;gap:8px;padding:6px var(--gap);border-bottom:1px solid var(--border);
+  font-size:0.75rem;align-items:baseline;flex-wrap:wrap}
+.event-row:last-child{border-bottom:none}
+.event-time{color:var(--text-muted);white-space:nowrap;min-width:60px}
+.event-type{font-weight:600;white-space:nowrap}
+.event-detail{color:var(--text-muted);overflow:hidden;text-overflow:ellipsis}
+
+/* Empty state */
+.empty{text-align:center;padding:48px var(--gap);color:var(--text-muted)}
+.empty-icon{font-size:2rem;margin-bottom:8px}
+.empty-text{font-size:0.9rem}
+
+/* Error banner */
+.error-banner{background:rgba(248,81,73,0.1);border:1px solid var(--red);color:var(--red);
+  padding:8px var(--gap);border-radius:var(--radius);margin:var(--gap) 0;font-size:0.85rem;
+  display:none}
+.error-banner.visible{display:block}
+
+/* Countdown */
+.countdown{font-variant-numeric:tabular-nums}
+
+/* Responsive */
+@media(max-width:600px){
+  header{flex-direction:column;align-items:flex-start}
+  .summary{grid-template-columns:repeat(2,1fr)}
+  .worker{grid-template-columns:1fr}
+  .worker-activity{justify-content:flex-start;margin-top:4px}
+  .pipeline{justify-content:center}
+}
+</style>
+</head>
+<body>
+<header>
+  <h1>Legion Dashboard</h1>
+  <div class="meta">
+    <span class="refresh-indicator" id="indicator"></span>
+    <span>Auto-refresh <span class="countdown" id="countdown">30</span>s</span>
+    <span id="updated"></span>
+  </div>
+</header>
+<div class="container">
+  <div class="error-banner" id="error"></div>
+  <div class="summary" id="summary"></div>
+  <div id="pipeline"></div>
+  <div id="groups"></div>
+  <div class="events" id="events-section"></div>
+</div>
+<script>
+(function(){
+  "use strict";
+  var REFRESH_INTERVAL = 30;
+  var countdown = REFRESH_INTERVAL;
+  var timer = null;
+  var eventsOpen = false;
+
+  var PHASES = ["architect","plan","implement","test","review","merge"];
+
+  function $(id){ return document.getElementById(id); }
+  function esc(s){ var d = document.createElement("div"); d.textContent = s; return d.innerHTML; }
+  function relTime(iso){
+    if(!iso) return "";
+    var diff = Date.now() - new Date(iso).getTime();
+    if(diff < 60000) return Math.floor(diff/1000) + "s ago";
+    if(diff < 3600000) return Math.floor(diff/60000) + "m ago";
+    if(diff < 86400000) return Math.floor(diff/3600000) + "h ago";
+    return Math.floor(diff/86400000) + "d ago";
+  }
+  function fmtTokens(n){
+    if(n == null || n === 0) return "0";
+    if(n >= 1000000) return (n/1000000).toFixed(1) + "M";
+    if(n >= 1000) return (n/1000).toFixed(1) + "k";
+    return String(n);
+  }
+  function statusClass(s){ return "status-" + (s || "unknown"); }
+  function phaseClass(p){ return "phase-" + (p || "unknown"); }
+  function issueStatusClass(s){
+    if(!s) return "";
+    return "issue-status-" + s.toLowerCase().replace(/\\s+/g, "-");
+  }
+
+  function renderSummary(data){
+    var s = data.summary;
+    var totalTokens = 0;
+    var activeWorkers = 0;
+    Object.keys(data.groups).forEach(function(repo){
+      var issues = data.groups[repo];
+      Object.keys(issues).forEach(function(num){
+        issues[num].workers.forEach(function(w){
+          if(w.activity && w.activity.tokensUsed) totalTokens += w.activity.tokensUsed;
+          if(w.status === "running") activeWorkers++;
+        });
+      });
+    });
+    var html = "";
+    html += '<div class="card"><div class="card-label">Total Workers</div>';
+    html += '<div class="card-value">' + s.totalWorkers + '</div>';
+    html += '<div class="card-detail">' + activeWorkers + ' active</div></div>';
+
+    html += '<div class="card"><div class="card-label">Tokens Used</div>';
+    html += '<div class="card-value">' + fmtTokens(totalTokens) + '</div></div>';
+
+    var statusEntries = Object.keys(s.byStatus);
+    if(statusEntries.length > 0){
+      html += '<div class="card"><div class="card-label">By Status</div>';
+      html += '<div class="card-detail">';
+      statusEntries.forEach(function(k){
+        html += '<span class="worker-status ' + statusClass(k) + '" style="margin-right:4px">';
+        html += esc(k) + ': ' + s.byStatus[k] + '</span> ';
+      });
+      html += '</div></div>';
+    }
+
+    var phaseEntries = Object.keys(s.byPhase);
+    if(phaseEntries.length > 0){
+      html += '<div class="card"><div class="card-label">By Phase</div>';
+      html += '<div class="card-detail">';
+      phaseEntries.forEach(function(k){
+        html += '<span class="worker-phase ' + phaseClass(k) + '" style="margin-right:4px">';
+        html += esc(k) + ': ' + s.byPhase[k] + '</span> ';
+      });
+      html += '</div></div>';
+    }
+
+    $("summary").innerHTML = html;
+  }
+
+  function renderPipeline(data){
+    var phaseCounts = {};
+    PHASES.forEach(function(p){ phaseCounts[p] = 0; });
+    Object.keys(data.groups).forEach(function(repo){
+      var issues = data.groups[repo];
+      Object.keys(issues).forEach(function(num){
+        issues[num].workers.forEach(function(w){
+          if(w.phase && phaseCounts[w.phase] !== undefined){
+            phaseCounts[w.phase]++;
+          }
+        });
+      });
+    });
+    var html = '<div class="pipeline">';
+    PHASES.forEach(function(p, i){
+      var count = phaseCounts[p];
+      var cls = count > 0 ? " active" : "";
+      html += '<div class="pipeline-stage' + cls + '">';
+      html += esc(p) + (count > 0 ? '<span class="count">(' + count + ')</span>' : '');
+      html += '</div>';
+      if(i < PHASES.length - 1) html += '<span class="pipeline-arrow">&#9654;</span>';
+    });
+    html += '</div>';
+    $("pipeline").innerHTML = html;
+  }
+
+  function renderWorker(w){
+    var html = '<div class="worker">';
+    html += '<div class="worker-info">';
+    if(w.phase){
+      html += '<span class="worker-phase ' + phaseClass(w.phase) + '">' + esc(w.phase) + '</span>';
+    }
+    html += '<span class="worker-status ' + statusClass(w.status) + '">' + esc(w.status) + '</span>';
+    html += '<span class="worker-id" title="' + esc(w.id) + '">' + esc(w.id) + '</span>';
+    if(w.crashCount > 0){
+      html += '<span style="color:var(--red);font-size:0.75rem">crashes: ' + w.crashCount + '</span>';
+    }
+    html += '</div>';
+    html += '<div class="worker-activity">';
+    if(w.activity){
+      html += '<span title="Tokens used">&#x1F4B0; ' + fmtTokens(w.activity.tokensUsed) + '</span>';
+      html += '<span title="Messages">&#x1F4AC; ' + (w.activity.messageCount || 0) + '</span>';
+      html += '<span title="Turns">&#x1F504; ' + (w.activity.turnCount || 0) + '</span>';
+      if(w.activity.lastActivityAt){
+        html += '<span title="Last active">' + relTime(w.activity.lastActivityAt) + '</span>';
+      }
+    }
+    if(w.startedAt){
+      html += '<span title="Started">started ' + relTime(w.startedAt) + '</span>';
+    }
+    html += '</div></div>';
+    return html;
+  }
+
+  function renderGroups(data){
+    var repos = Object.keys(data.groups);
+    if(repos.length === 0){
+      $("groups").innerHTML = '<div class="empty"><div class="empty-icon">&#x1F6B0;</div>' +
+        '<div class="empty-text">No active workers</div></div>';
+      return;
+    }
+    var html = "";
+    repos.sort().forEach(function(repo){
+      html += '<div class="repo-group">';
+      html += '<div class="repo-header">' + esc(repo) + '</div>';
+      var issues = data.groups[repo];
+      var nums = Object.keys(issues).sort(function(a,b){ return Number(a) - Number(b); });
+      nums.forEach(function(num){
+        var issue = issues[num];
+        html += '<div class="issue">';
+        html += '<div class="issue-header">';
+        html += '<span class="issue-number">#' + esc(num) + '</span>';
+        if(issue.issueTitle){
+          html += '<span class="issue-title">' + esc(issue.issueTitle) + '</span>';
+        }
+        if(issue.issueStatus){
+          html += '<span class="issue-status ' + issueStatusClass(issue.issueStatus) + '">';
+          html += esc(issue.issueStatus) + '</span>';
+        }
+        html += '</div>';
+        issue.workers.forEach(function(w){
+          html += renderWorker(w);
+        });
+        html += '</div>';
+      });
+      html += '</div>';
+    });
+    $("groups").innerHTML = html;
+  }
+
+  function renderEvents(data){
+    var events = data.recentEvents || [];
+    if(events.length === 0){
+      $("events-section").innerHTML = "";
+      return;
+    }
+    var html = '<div class="events-title' + (eventsOpen ? " open" : "") + '" id="events-toggle">';
+    html += 'Recent Events (' + events.length + ')</div>';
+    html += '<div class="events-list' + (eventsOpen ? " open" : "") + '" id="events-list">';
+    events.forEach(function(e){
+      html += '<div class="event-row">';
+      html += '<span class="event-time">' + relTime(e.timestamp) + '</span>';
+      html += '<span class="event-type">' + esc(e.event) + '</span>';
+      html += '<span class="event-detail">' + esc(e.workerId || "") + '</span>';
+      html += '</div>';
+    });
+    html += '</div>';
+    $("events-section").innerHTML = html;
+    var toggle = $("events-toggle");
+    if(toggle){
+      toggle.addEventListener("click", function(){
+        eventsOpen = !eventsOpen;
+        var list = $("events-list");
+        toggle.className = "events-title" + (eventsOpen ? " open" : "");
+        if(list) list.className = "events-list" + (eventsOpen ? " open" : "");
+      });
+    }
+  }
+
+  function render(data){
+    renderSummary(data);
+    renderPipeline(data);
+    renderGroups(data);
+    renderEvents(data);
+    $("updated").textContent = "Updated " + new Date(data.generatedAt).toLocaleTimeString();
+    $("error").className = "error-banner";
+  }
+
+  function showError(msg){
+    var el = $("error");
+    el.textContent = "Failed to fetch dashboard data: " + msg;
+    el.className = "error-banner visible";
+  }
+
+  function fetchData(){
+    var indicator = $("indicator");
+    indicator.className = "refresh-indicator fetching";
+    fetch("/dashboard")
+      .then(function(res){
+        if(!res.ok) throw new Error("HTTP " + res.status);
+        return res.json();
+      })
+      .then(function(data){
+        render(data);
+        indicator.className = "refresh-indicator";
+      })
+      .catch(function(err){
+        showError(err.message);
+        indicator.className = "refresh-indicator";
+      });
+  }
+
+  function tick(){
+    countdown--;
+    if(countdown <= 0){
+      countdown = REFRESH_INTERVAL;
+      fetchData();
+    }
+    $("countdown").textContent = String(countdown);
+  }
+
+  // Initial fetch
+  fetchData();
+  timer = setInterval(tick, 1000);
+})();
+</script>
+</body>
+</html>`;
+}

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -17,6 +17,7 @@ import {
   WorkerMode,
   type WorkerModeLiteral,
 } from "../state/types";
+import { getDashboardHtml } from "./dashboard-ui";
 import type { FeedbackLogger } from "./feedback";
 import type { TokenManager } from "./github-apps";
 import { modeToRole } from "./github-apps";
@@ -745,6 +746,13 @@ export function startServer(opts: ServerOptions): {
             },
             groups,
             recentEvents: recentEvents.slice().reverse(),
+          });
+        }
+
+        if (method === "GET" && url.pathname === "/dashboard/ui") {
+          return new Response(getDashboardHtml(), {
+            status: 200,
+            headers: { "content-type": "text/html; charset=utf-8" },
           });
         }
 


### PR DESCRIPTION
Closes #515

## Summary

Single-page HTML dashboard served at `GET /dashboard/ui` by the Legion daemon. Fetches the existing `GET /dashboard` JSON API and renders worker status, pipeline visualization, token usage, and recent events.

### Features
- **Auto-refresh**: Polls `/dashboard` every 30 seconds with countdown indicator
- **Pipeline visualization**: Shows worker distribution across lifecycle phases (architect → plan → implement → test → review → merge)
- **Worker detail cards**: Status, phase, token usage, message/turn counts, crash count, last activity time
- **Issue grouping**: Workers grouped by repo and issue number with title and status
- **Recent events**: Collapsible event log showing worker dispatches and status changes
- **Responsive**: Mobile-friendly layout using CSS grid with breakpoints at 600px
- **No framework**: Vanilla JS/CSS, all inline in a single HTML response
- **Error handling**: Shows error banner on fetch failure, continues auto-refresh cycle

### Files Changed
- `packages/daemon/src/daemon/dashboard-ui.ts` — new file: `getDashboardHtml()` returns the complete HTML page
- `packages/daemon/src/daemon/server.ts` — new route: `GET /dashboard/ui` serves the HTML
- `packages/daemon/src/daemon/__tests__/server.test.ts` — 2 new tests for content-type and HTML content
- `packages/daemon/src/daemon/AGENTS.md` — documented new endpoint