### PR TITLE
sjawhar-legion-522: rename legion adopt to legion enlist

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,21 +1,20 @@
 {
   "filesChanged": [
-    "packages/daemon/src/daemon/dashboard-ui.ts",
+    "packages/daemon/src/cli/index.ts",
+    "packages/daemon/src/cli/__tests__/index.test.ts",
     "packages/daemon/src/daemon/server.ts",
     "packages/daemon/src/daemon/__tests__/server.test.ts",
-    "packages/daemon/src/daemon/AGENTS.md"
+    "docs/solutions/daemon/session-adoption-api-pattern.md"
   ],
   "trickyParts": [
-    "Keeping the HTML/CSS/JS self-contained in a single TypeScript string template while maintaining readability and proper escaping"
+    "Distinguishing legion-specific 'adopt' references from generic English uses of 'adopt' in docs and Pulumi comments"
   ],
   "deviations": [
-    "No plan phase existed for this issue — implemented directly from issue spec and dispatch prompt. The issue mentioned broader features (reports, visual artifacts, feedback) but dispatch scoped to MVP: single HTML page with worker status, pipeline, tokens, auto-refresh."
+    "No plan phase existed — implemented directly from issue spec. Historical plan docs (docs/plans/) left unchanged since they describe what the code looked like at plan time."
   ],
-  "openQuestions": [
-    "Future iterations could add: interactive feedback (approve/reject plans), report viewing, visual artifact rendering, WebSocket for real-time updates instead of polling"
-  ],
+  "openQuestions": [],
   "subPlanningNeeded": false,
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-13T22:33:20.858Z"
+  "completed": "2026-04-14T00:33:00.284Z"
 }

--- a/.legion/retro.json
+++ b/.legion/retro.json
@@ -1,9 +1,7 @@
 {
-  "skipped": false,
-  "docsCreated": [
-    "docs/solutions/daemon/inline-html-dashboard-pattern.md"
-  ],
+  "skipped": true,
+  "reason": "no significant learnings",
   "schemaVersion": 1,
   "phase": "retro",
-  "completed": "2026-04-13T22:50:45.412Z"
+  "completed": "2026-04-14T00:48:22.492Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -1,23 +1,18 @@
 {
   "critical": 0,
   "important": 0,
-  "minor": 2,
+  "minor": 1,
   "verdict": "approved",
   "keyFindings": [
     {
       "severity": "P3",
-      "file": "packages/daemon/src/daemon/dashboard-ui.ts",
-      "description": "statusClass()/phaseClass()/issueStatusClass() insert values into CSS class names without escaping — low risk since values are server-controlled enums"
-    },
-    {
-      "severity": "P3",
-      "file": "packages/daemon/src/daemon/dashboard-ui.ts",
-      "description": "timer variable assigned but never read (dead store) — cosmetic only"
+      "file": "docs/solutions/daemon/session-adoption-api-pattern.md",
+      "description": "Filename still says 'adoption' while content was updated to 'enlistment'. Consider renaming to session-enlistment-api-pattern.md for consistency."
     }
   ],
   "learningsInjected": [],
   "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-13T22:41:32.032Z"
+  "completed": "2026-04-14T00:43:23.710Z"
 }

--- a/docs/solutions/daemon/session-adoption-api-pattern.md
+++ b/docs/solutions/daemon/session-adoption-api-pattern.md
@@ -1,29 +1,30 @@
 ---
-title: "Session Adoption API Pattern"
+title: "Session Enlistment API Pattern"
 category: daemon
 tags:
   - session-management
   - api-extension
   - guard-pattern
   - external-registry
-  - cli-adoption
+  - cli-enlistment
 date: 2026-04-11
 status: active
 module: daemon
 related_issues:
   - "#98"
+  - "#522"
 symptoms:
   - "How to add optional fields to POST /workers"
-  - "How to prevent duplicate session adoption"
+  - "How to prevent duplicate session enlistment"
   - "How to scan OC registry for session info"
-  - "session_already_adopted 409 error"
+  - "session_already_enlisted 409 error"
 ---
 
-# Session Adoption API Pattern
+# Session Enlistment API Pattern
 
 ## Problem
 
-Standalone OpenCode sessions need to be adopted as Legion workers without restarting them.
+Standalone OpenCode sessions need to be enlisted as Legion workers without restarting them.
 This requires extending `POST /workers` with an optional `sessionId` field while preserving
 all existing behavior when the field is absent.
 
@@ -63,7 +64,7 @@ immediately before `workers.set()` — not at the top of the handler.
 if (typeof providedSessionId === "string") {
   for (const [, existingEntry] of workers) {
     if (existingEntry.status !== "dead" && existingEntry.sessionId === providedSessionId) {
-      return jsonResponse({ error: "session_already_adopted", id: existingEntry.id }, 409);
+      return jsonResponse({ error: "session_already_enlisted", id: existingEntry.id }, 409);
     }
   }
 }
@@ -76,7 +77,7 @@ right before `set()` minimizes the window where a concurrent request could slip 
 In single-threaded Bun this is mostly academic, but the pattern is correct for any runtime.
 
 **Why only non-dead workers:** Dead workers are tombstones — their session IDs should be
-recyclable for new adoption.
+recyclable for new enlistment.
 
 ### 3. Conditional Override for Computed Values
 
@@ -90,9 +91,9 @@ const sessionId =
 This preserves the existing deterministic computation when `sessionId` is absent.
 The `typeof` check doubles as a null guard — no need for a separate `if`.
 
-## Pattern: CLI Adoption via Existing Endpoint
+## Pattern: CLI Enlistment via Existing Endpoint
 
-Adoption reuses `POST /workers` with `force: true` rather than a new endpoint:
+Enlistment reuses `POST /workers` with `force: true` rather than a new endpoint:
 
 ```typescript
 const body = {
@@ -105,7 +106,7 @@ const body = {
 };
 ```
 
-**Why `force: true`:** Adopted sessions weren't started by Legion, so phase gates
+**Why `force: true`:** Enlisted sessions weren't started by Legion, so phase gates
 don't apply. The session may be mid-task — we just want to register it.
 
 **Why include `prompt`:** Even though the session is already running, the prompt tells
@@ -146,10 +147,10 @@ for (const file of files) {
 - **`normalizedIssueId` is declared downstream** — when inserting validation blocks
   in `POST /workers`, check you're not accidentally referencing a variable that hasn't
   been declared yet. See `server-side-dispatch-validation.md`.
-- **`createSession()` 409 is idempotent** — when an adopted session already exists in
+- **`createSession()` 409 is idempotent** — when an enlisted session already exists in
   SQLite, `createSession()` returns 409 `DuplicateIDError`, which `serve-manager.ts`
   treats as success. No special handling needed for this case.
-- **SIGHUP PID is transient** — the PID from the OC registry is used once at adopt-time
+- **SIGHUP PID is transient** — the PID from the OC registry is used once at enlist-time
   to send SIGHUP. Do NOT persist it in `WorkerEntry` or `workers.json`.
 - **`SESSION_ID_PATTERN` lives in `types.ts`** — it's shared between daemon (server.ts)
   and CLI (cli/index.ts), so it belongs in the shared types module, not in either consumer.

--- a/packages/daemon/src/cli/__tests__/index.test.ts
+++ b/packages/daemon/src/cli/__tests__/index.test.ts
@@ -28,16 +28,16 @@ mock.module("node:child_process", () => ({
 
 import { resolveLegionPaths } from "../../daemon/paths";
 import {
-  adoptCommand,
   attachCommand,
   CliError,
-  cmdAdopt,
   cmdDispatch,
+  cmdEnlist,
   cmdPrompt,
   cmdResetCrashes,
   cmdStart,
   discoverConfigPath,
   dispatchCommand,
+  enlistCommand,
   getDaemonPort,
   legionsCommand,
   loadLegionsCache,
@@ -556,32 +556,32 @@ describe("cmdStart config wiring", () => {
   });
 });
 
-describe("adoptCommand", () => {
+describe("enlistCommand", () => {
   it("has correct meta", async () => {
-    const meta = await Promise.resolve(adoptCommand.meta);
-    expect(meta?.name).toBe("adopt");
+    const meta = await Promise.resolve(enlistCommand.meta);
+    expect(meta?.name).toBe("enlist");
   });
 
   it("requires team and session as positional args", async () => {
-    const args = await resolveArgs(adoptCommand);
+    const args = await resolveArgs(enlistCommand);
     expect(args.team).toEqual(expect.objectContaining({ type: "positional", required: true }));
     expect(args.session).toEqual(expect.objectContaining({ type: "positional", required: true }));
   });
 
   it("requires --mode and --issue flags", async () => {
-    const args = await resolveArgs(adoptCommand);
+    const args = await resolveArgs(enlistCommand);
     expect(args.mode).toEqual(expect.objectContaining({ type: "string", required: true }));
     expect(args.issue).toEqual(expect.objectContaining({ type: "string", required: true }));
   });
 
   it("has optional --workspace flag", async () => {
-    const args = await resolveArgs(adoptCommand);
+    const args = await resolveArgs(enlistCommand);
     expect(args.workspace).toEqual(expect.objectContaining({ type: "string" }));
     expect((args.workspace as StringArg).required).toBeFalsy();
   });
 });
 
-describe("cmdAdopt behavior", () => {
+describe("cmdEnlist behavior", () => {
   const originalFetch = globalThis.fetch;
   let capturedCalls: Array<{ url: string; body: Record<string, unknown> }>;
 
@@ -618,7 +618,7 @@ describe("cmdAdopt behavior", () => {
 
   it("sends sessionId, force=true, and prompt in POST body", async () => {
     const testSession = "ses_31617365bffeUEa4wPBVIL2LBI";
-    await cmdAdopt("sjawhar/5", testSession, {
+    await cmdEnlist("sjawhar/5", testSession, {
       mode: "implement",
       issue: "eng-42",
       workspace: "/tmp/test-workspace",
@@ -638,7 +638,7 @@ describe("cmdAdopt behavior", () => {
     );
   });
 
-  it("throws CliError for session_already_adopted 409", () => {
+  it("throws CliError for session_already_enlisted 409", () => {
     const mock409 = async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
       if (url.includes("/health")) {
@@ -646,7 +646,7 @@ describe("cmdAdopt behavior", () => {
       }
       if (url.includes("/workers") && init?.method === "POST") {
         return new Response(
-          JSON.stringify({ error: "session_already_adopted", id: "eng-42-implement" }),
+          JSON.stringify({ error: "session_already_enlisted", id: "eng-42-implement" }),
           { status: 409 }
         );
       }
@@ -657,7 +657,7 @@ describe("cmdAdopt behavior", () => {
     });
 
     return expect(
-      cmdAdopt("sjawhar/5", "ses_31617365bffeUEa4wPBVIL2LBI", {
+      cmdEnlist("sjawhar/5", "ses_31617365bffeUEa4wPBVIL2LBI", {
         mode: "implement",
         issue: "eng-42",
         workspace: "/tmp/work",
@@ -668,7 +668,7 @@ describe("cmdAdopt behavior", () => {
 
   it("throws CliError for invalid session ID format", () => {
     return expect(
-      cmdAdopt("sjawhar/5", "not-a-session-id", {
+      cmdEnlist("sjawhar/5", "not-a-session-id", {
         mode: "implement",
         issue: "eng-42",
         workspace: "/tmp/work",

--- a/packages/daemon/src/cli/index.ts
+++ b/packages/daemon/src/cli/index.ts
@@ -713,14 +713,14 @@ export async function scanOcRegistry(
   return null;
 }
 
-interface AdoptOptions {
+interface EnlistOptions {
   mode: string;
   issue: string;
   workspace?: string;
   daemonPort?: number;
 }
 
-export async function cmdAdopt(team: string, session: string, opts: AdoptOptions): Promise<void> {
+export async function cmdEnlist(team: string, session: string, opts: EnlistOptions): Promise<void> {
   if (!SESSION_ID_PATTERN.test(session)) {
     throw new CliError(
       `Invalid session ID format: ${session}\nExpected: ses_ + 12 hex + 14 Base62`
@@ -792,7 +792,7 @@ export async function cmdAdopt(team: string, session: string, opts: AdoptOptions
   }
 
   if (response.status === 409) {
-    if (responseBody.error === "session_already_adopted") {
+    if (responseBody.error === "session_already_enlisted") {
       throw new CliError(`Session ${session} is already tracked by worker ${responseBody.id}`);
     }
     console.log(`Worker already running: ${responseBody.id}`);
@@ -806,21 +806,21 @@ export async function cmdAdopt(team: string, session: string, opts: AdoptOptions
   }
 
   if (!response.ok) {
-    throw new CliError(`Failed to adopt: ${JSON.stringify(responseBody)}`);
+    throw new CliError(`Failed to enlist: ${JSON.stringify(responseBody)}`);
   }
 
   const workerId = responseBody.id as string;
   const workerPort = responseBody.port as number;
-  const adoptedSessionId = responseBody.sessionId as string;
+  const enlistedSessionId = responseBody.sessionId as string;
 
-  console.log(`Session adopted: ${workerId}`);
+  console.log(`Session enlisted: ${workerId}`);
   console.log(`  port: ${workerPort}`);
-  console.log(`  session: ${adoptedSessionId}`);
+  console.log(`  session: ${enlistedSessionId}`);
 
   if (responseBody.promptDelivered === true) {
     console.log(`Prompt sent: /legion-worker ${opts.mode} mode for ${opts.issue}`);
   } else if (responseBody.promptDelivered === false) {
-    console.warn("Session adopted but prompt delivery failed. Send manually:");
+    console.warn("Session enlisted but prompt delivery failed. Send manually:");
     console.warn(
       `  legion prompt ${opts.issue} "/legion-worker ${opts.mode} mode for ${opts.issue}"`
     );
@@ -1120,10 +1120,10 @@ export const attachCommand = defineCommand({
   },
 });
 
-export const adoptCommand = defineCommand({
+export const enlistCommand = defineCommand({
   meta: {
-    name: "adopt",
-    description: "Adopt an existing OpenCode session as a Legion worker",
+    name: "enlist",
+    description: "Enlist an existing OpenCode session as a Legion worker",
   },
   args: {
     team: {
@@ -1156,7 +1156,7 @@ export const adoptCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      await cmdAdopt(args.team, args.session, {
+      await cmdEnlist(args.team, args.session, {
         mode: args.mode as string,
         issue: args.issue as string,
         workspace: args.workspace as string | undefined,
@@ -1703,7 +1703,7 @@ export const mainCommand = defineCommand({
     stop: stopCommand,
     status: statusCommand,
     attach: attachCommand,
-    adopt: adoptCommand,
+    enlist: enlistCommand,
     advance: advanceCommand,
     dispatch: dispatchCommand,
     prompt: promptCommand,

--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -336,7 +336,7 @@ describe("daemon server", () => {
     expect(body.error).toBe("invalid_session_id");
   });
 
-  it("returns 409 session_already_adopted when sessionId is tracked by live worker", async () => {
+  it("returns 409 session_already_enlisted when sessionId is tracked by live worker", async () => {
     await startTestServer();
     const first = await requestJson("/workers", {
       method: "POST",
@@ -360,11 +360,11 @@ describe("daemon server", () => {
     });
     expect(response.status).toBe(409);
     const body = (await response.json()) as Record<string, unknown>;
-    expect(body.error).toBe("session_already_adopted");
+    expect(body.error).toBe("session_already_enlisted");
     expect(body.id).toBe("eng-42-implement");
   });
 
-  it("allows adoption when existing worker with same sessionId is dead", async () => {
+  it("allows enlistment when existing worker with same sessionId is dead", async () => {
     await startTestServer();
     const first = await requestJson("/workers", {
       method: "POST",

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -1027,7 +1027,7 @@ export function startServer(opts: ServerOptions): {
                 ) {
                   return jsonResponse(
                     {
-                      error: "session_already_adopted",
+                      error: "session_already_enlisted",
                       id: existingEntry.id,
                       sessionId: providedSessionId,
                     },


### PR DESCRIPTION
Closes #522

## Summary

Renames `legion adopt` CLI command to `legion enlist` across the codebase:

- **CLI**: `adoptCommand` → `enlistCommand`, `cmdAdopt` → `cmdEnlist`, `AdoptOptions` → `EnlistOptions`
- **Server**: error code `session_already_adopted` → `session_already_enlisted`
- **Tests**: updated all test names, imports, assertions, and mock error codes
- **Docs**: updated `docs/solutions/daemon/session-adoption-api-pattern.md` to reflect "enlist" terminology

No behavior change — pure rename. All 977 tests pass, biome clean.