### PR TITLE
sjawhar-legion-523: keep repo clones fresh — fetch before dispatch, update on close

### DIFF
--- a/.legion/implement.json
+++ b/.legion/implement.json
@@ -1,20 +1,20 @@
 {
   "filesChanged": [
-    "packages/daemon/src/cli/index.ts",
-    "packages/daemon/src/cli/__tests__/index.test.ts",
+    "packages/daemon/src/daemon/repo-manager.ts",
     "packages/daemon/src/daemon/server.ts",
-    "packages/daemon/src/daemon/__tests__/server.test.ts",
-    "docs/solutions/daemon/session-adoption-api-pattern.md"
+    "packages/daemon/src/daemon/index.ts",
+    "packages/daemon/src/daemon/AGENTS.md",
+    "packages/daemon/src/daemon/__tests__/repo-manager.test.ts",
+    "packages/daemon/src/daemon/__tests__/server.test.ts"
   ],
   "trickyParts": [
-    "Distinguishing legion-specific 'adopt' references from generic English uses of 'adopt' in docs and Pulumi comments"
+    "Blocking fetch for implement mode runs before ensureWorkspace — if the clone doesn't exist yet (fresh first dispatch), the fetch fails gracefully and clone proceeds normally",
+    "Post-close fetch collects unique RepoRefs during the first cleanup pass to avoid duplicate fetches for repos with multiple workers"
   ],
-  "deviations": [
-    "No plan phase existed — implemented directly from issue spec. Historical plan docs (docs/plans/) left unchanged since they describe what the code looked like at plan time."
-  ],
+  "deviations": [],
   "openQuestions": [],
   "subPlanningNeeded": false,
   "schemaVersion": 1,
   "phase": "implement",
-  "completed": "2026-04-14T00:33:00.284Z"
+  "completed": "2026-04-14T00:40:29.806Z"
 }

--- a/.legion/retro.json
+++ b/.legion/retro.json
@@ -1,7 +1,7 @@
 {
-  "skipped": true,
-  "reason": "no significant learnings",
+  "skipped": false,
+  "docsCreated": ["docs/solutions/daemon/graduated-fetch-urgency-pattern.md"],
   "schemaVersion": 1,
   "phase": "retro",
-  "completed": "2026-04-14T00:48:22.492Z"
+  "completed": "2026-04-14T00:57:49.335Z"
 }

--- a/.legion/review.json
+++ b/.legion/review.json
@@ -6,13 +6,18 @@
   "keyFindings": [
     {
       "severity": "P3",
-      "file": "docs/solutions/daemon/session-adoption-api-pattern.md",
-      "description": "Filename still says 'adoption' while content was updated to 'enlistment'. Consider renaming to session-enlistment-api-pattern.md for consistency."
+      "file": "packages/daemon/src/daemon/server.ts",
+      "description": "startBackgroundFetch name misleading when used with await for blocking pre-dispatch path — cosmetic only"
+    },
+    {
+      "severity": "P3",
+      "file": "packages/daemon/src/daemon/repo-manager.ts",
+      "description": "fetchAllTrackedRepos uses sequential fetching — reasonable design choice for jj safety but could be parallelized for large repo counts"
     }
   ],
   "learningsInjected": [],
   "learningsHelpful": [],
   "schemaVersion": 1,
   "phase": "review",
-  "completed": "2026-04-14T00:43:23.710Z"
+  "completed": "2026-04-14T00:50:37.612Z"
 }

--- a/docs/solutions/daemon/graduated-fetch-urgency-pattern.md
+++ b/docs/solutions/daemon/graduated-fetch-urgency-pattern.md
@@ -1,0 +1,139 @@
+---
+title: "Graduated fetch urgency — match blocking behavior to cost of staleness"
+category: daemon
+tags:
+  - repo-management
+  - dispatch
+  - blocking-vs-nonblocking
+  - dependency-injection
+  - error-handling
+  - testing
+  - cleanup
+date: 2026-04-14
+status: active
+module: daemon
+related_issues:
+  - "523"
+symptoms:
+  - "worker starts with stale code after dispatch"
+  - "implement worker runs jj git fetch that takes too long"
+  - "daemon startup slow due to repo fetching"
+  - "duplicate fetches after multi-worker cleanup"
+---
+
+# Graduated Fetch Urgency — Match Blocking Behavior to Cost of Staleness
+
+## Context
+
+The daemon maintains a default clone per repo via `ensureRepoClone`. Workers are
+created from this clone, so a stale clone means workers start with outdated code
+and waste time fetching during startup. Issue #523 added `jj git fetch` at three
+points in the lifecycle, each with a different urgency.
+
+## Pattern: Graduated Blocking by Consequence
+
+Not every fetch has the same urgency. Match the async strategy to the cost of delay:
+
+| Context | Strategy | Rationale |
+|---------|----------|-----------|
+| Implement dispatch | **Blocking** (`await`) | Implementer needs latest code; stale clone causes real rework |
+| Other mode dispatch | **Non-blocking** (fire-and-forget) | Nice-to-have freshness, shouldn't delay dispatch response |
+| Issue close (Done) | **Non-blocking** | Merge just landed — opportunistic warmth for next dispatch |
+| Daemon startup | **Non-blocking** | Warm cache, don't delay startup |
+
+### Implementation detail: one function, two calling conventions
+
+`startBackgroundFetch` is called with `await` when blocking is needed and with
+`.catch()` when fire-and-forget is needed. The name is slightly misleading for the
+blocking path, but the alternative (two functions or a boolean parameter) adds code
+for no behavioral change. Pragmatic choice.
+
+```typescript
+// Blocking (implement mode) — in server.ts dispatch handler
+if (mode === WorkerMode.IMPLEMENT) {
+  await startBackgroundFetch(opts.paths, repoRef, opts.repoManagerDeps);
+}
+
+// Non-blocking (other modes) — same function, different call site
+startBackgroundFetch(opts.paths, repoRef, opts.repoManagerDeps).catch((err) => {
+  console.error(`Background fetch failed: ${err.message}`);
+});
+```
+
+## Pattern: Structured Error Collection for Batch Operations
+
+`fetchAllTrackedRepos` walks `reposDir/{host}/{owner}/{repo}` and fetches every
+clone. Rather than throwing on the first failure, it collects errors and continues:
+
+```typescript
+return { fetched: string[], errors: Array<{ repo: string; error: string }> };
+```
+
+This lets callers log partial failures without aborting. Essential for daemon startup
+where one failing repo shouldn't prevent warming others.
+
+## Pattern: Dedup via Map Before Batch Operation
+
+When Done issues are cleaned up, multiple workers may reference the same repo. The
+cleanup collects unique `RepoRef` values in a `Map<string, RepoRef>` keyed by
+`{host}/{owner}/{repo}` before firing post-close fetches:
+
+```typescript
+const cleanedRepoRefs = new Map<string, RepoRef>();
+// During first pass (per worker):
+cleanedRepoRefs.set(repoKey, repoRef);
+// After cleanup: iterate unique repos only
+for (const [repoKey, repoRef] of cleanedRepoRefs) { ... }
+```
+
+Without this, N workers for the same repo would trigger N redundant fetches.
+
+## Gotcha: Fresh Clone Edge Case
+
+On first-ever dispatch for a repo, the blocking pre-dispatch fetch runs before
+the clone exists. It fails gracefully and the clone proceeds normally via
+`ensureRepoClone`. This is why **all fetch operations must be non-fatal** — it's
+not just about network failures; the clone might not exist yet.
+
+## Testing Patterns
+
+### Virtual filesystem via record
+
+For testing directory-walking code like `fetchAllTrackedRepos`, mock the filesystem
+as a `Record<path, entries>` rather than touching real FS:
+
+```typescript
+const dirTree: Record<string, string[]> = {
+  "/repos": ["github.com"],
+  "/repos/github.com": ["acme"],
+  "/repos/github.com/acme": ["widgets"],
+};
+const deps = { listDir: async (p) => dirTree[p] ?? [] };
+```
+
+### Command recording with defensive spread
+
+When recording `jj` commands for test assertions, always spread/clone the args
+array to prevent mutation leakage from later operations:
+
+```typescript
+const commands: string[][] = [];
+runJj: async (args) => {
+  commands.push([...args]);  // Spread prevents mutation
+  return { exitCode: 0, stdout: "", stderr: "" };
+},
+```
+
+### Background operation timing in tests
+
+For non-blocking (fire-and-forget) operations, tests use `setTimeout` to let
+background work complete before asserting:
+
+```typescript
+await new Promise((resolve) => setTimeout(resolve, 50));
+const fetchCmd = jjCommands.find((c) => c[0] === "git" && c[1] === "fetch");
+expect(fetchCmd).toBeDefined();
+```
+
+This is pragmatic — the alternative (exposing a flush mechanism) would leak test
+concerns into production code.

--- a/docs/solutions/index.json
+++ b/docs/solutions/index.json
@@ -21,7 +21,6 @@
       "task-index-patterns.md"
     ],
     "packages/daemon/src/daemon": [
-      "daemon/workspace-validation-retro.md",
       "daemon/session-liveness-detection-pattern.md",
       "daemon/optional-dep-fallback-and-early-return-guard.md",
       "daemon/targeted-delta-filtering-pattern.md",
@@ -30,7 +29,8 @@
       "daemon/pre-cleanup-branch-push-verification.md",
       "best-practices/jj-bookmark-template-syntax-gotchas.md",
       "daemon/dead-worker-workspace-reclamation.md",
-      "daemon/inline-html-dashboard-pattern.md"
+      "daemon/inline-html-dashboard-pattern.md",
+      "daemon/graduated-fetch-urgency-pattern.md"
     ],
     "packages/daemon/src/__tests__": [
       "testing/mock-envoy-server-pattern.md",
@@ -138,7 +138,10 @@
       "daemon/pre-cleanup-branch-push-verification.md"
     ],
     "tag:directory-resolution": ["daemon/worker-directory-fix.md"],
-    "tag:dispatch": ["integration-patterns/controller-worker-protocol.md"],
+    "tag:dispatch": [
+      "integration-patterns/controller-worker-protocol.md",
+      "daemon/graduated-fetch-urgency-pattern.md"
+    ],
     "tag:dispose": ["daemon/opencode-serve-lifecycle.md"],
     "tag:draft-status": ["integration-issues/github-graphql-pr-draft-status.md"],
     "tag:error-handling": ["integration-issues/linear-mcp-label-resolution.md"],
@@ -404,6 +407,8 @@
     "tag:html": ["daemon/inline-html-dashboard-pattern.md"],
     "tag:template-literal": ["daemon/inline-html-dashboard-pattern.md"],
     "tag:zero-dependency": ["daemon/inline-html-dashboard-pattern.md"],
-    "tag:mvp": ["daemon/inline-html-dashboard-pattern.md"]
+    "tag:mvp": ["daemon/inline-html-dashboard-pattern.md"],
+    "tag:repo-management": ["daemon/graduated-fetch-urgency-pattern.md"],
+    "tag:blocking-vs-nonblocking": ["daemon/graduated-fetch-urgency-pattern.md"]
   }
 }

--- a/packages/daemon/src/daemon/AGENTS.md
+++ b/packages/daemon/src/daemon/AGENTS.md
@@ -37,6 +37,7 @@ HTTP server + shared `opencode serve` instance. One long-lived serve process han
 | `config.ts` | `DaemonConfig` interface, `loadConfig()` reads env vars. Defaults: daemon port 13370, shared serve port 13381 (`baseWorkerPort`), check interval 60s. **Controller mode:** `LEGION_CONTROLLER_SESSION_ID` env var (optional, must start with `ses_` if set, hard fails on invalid format). |
 | `state-file.ts` | `readStateFile()` / `writeStateFile()` — atomic JSON persistence to `~/.legion/{legionId}/workers.json`. Includes `controller?: ControllerState` field for controller lifecycle. Legacy `controller-controller` worker entries are stripped on read. |
 | `ports.ts` | `isPortFree()` utility only. `PortAllocator` removed — all workers share one port. |
+| `repo-manager.ts` | Repo clone management: `ensureRepoClone()`, `ensureWorkspace()`, `startBackgroundFetch()`, `fetchAllTrackedRepos()`, `cleanupWorkspace()`, `verifyBranchPushed()`. |
 
 ## Key Patterns
 
@@ -46,3 +47,4 @@ HTTP server + shared `opencode serve` instance. One long-lived serve process han
 - **State persistence** — worker map persisted to disk, sessions re-created on daemon restart using deterministic IDs.
 - **Session IDs** — deterministic UUIDv5 from `computeSessionId(legionId, issueId, mode)`, enables idempotent session creation.
 - **Controller lifecycle** — runs as session on shared serve. For external mode, daemon stores session ID without spawning.
+- **Repo clone freshness** — implement dispatches do a blocking `jj git fetch` before workspace creation. Other modes fetch non-blocking after workspace creation. Done issue cleanup triggers a background fetch. Daemon startup warms all tracked clones via `fetchAllTrackedRepos()`.

--- a/packages/daemon/src/daemon/__tests__/repo-manager.test.ts
+++ b/packages/daemon/src/daemon/__tests__/repo-manager.test.ts
@@ -4,6 +4,7 @@ import {
   cleanupWorkspace,
   ensureRepoClone,
   ensureWorkspace,
+  fetchAllTrackedRepos,
   parseIssueRepo,
   type RepoManagerDeps,
   resolveWorkspacePath,
@@ -591,5 +592,124 @@ describe("startBackgroundFetch", () => {
     await expect(
       startBackgroundFetch(paths, { host: "github.com", owner: "acme", repo: "widgets" }, deps)
     ).rejects.toThrow("Permission denied");
+  });
+});
+
+describe("fetchAllTrackedRepos", () => {
+  it("fetches all repos found under reposDir", async () => {
+    const commands: string[][] = [];
+    const dirTree: Record<string, string[]> = {
+      // reposDir
+      "/home/test/.local/share/legion/repos": ["github.com"],
+      "/home/test/.local/share/legion/repos/github.com": ["acme", "other"],
+      "/home/test/.local/share/legion/repos/github.com/acme": ["widgets"],
+      "/home/test/.local/share/legion/repos/github.com/other": ["app"],
+    };
+    const deps: RepoManagerDeps = {
+      runJj: async (args) => {
+        commands.push(args);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      exists: async () => true,
+      rmDir: async () => {},
+      symlink: async () => {},
+      listDir: async (p) => dirTree[p] ?? [],
+    };
+    const paths = resolveLegionPaths({}, "/home/test");
+
+    const result = await fetchAllTrackedRepos(paths, deps);
+
+    expect(result.fetched).toEqual(["github.com/acme/widgets", "github.com/other/app"]);
+    expect(result.errors).toEqual([]);
+    expect(commands).toHaveLength(2);
+    expect(commands[0]).toContain("git");
+    expect(commands[0]).toContain("fetch");
+    expect(commands[0]).toContain("-R");
+    expect(commands[0]).toContain("/home/test/.local/share/legion/repos/github.com/acme/widgets");
+    expect(commands[1]).toContain("/home/test/.local/share/legion/repos/github.com/other/app");
+  });
+
+  it("collects errors without aborting", async () => {
+    const dirTree: Record<string, string[]> = {
+      "/home/test/.local/share/legion/repos": ["github.com"],
+      "/home/test/.local/share/legion/repos/github.com": ["acme"],
+      "/home/test/.local/share/legion/repos/github.com/acme": ["widgets", "other"],
+    };
+    const deps: RepoManagerDeps = {
+      runJj: async (args) => {
+        if (args.some((a) => a.includes("widgets"))) {
+          return { exitCode: 1, stdout: "", stderr: "auth failed" };
+        }
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      exists: async () => true,
+      rmDir: async () => {},
+      symlink: async () => {},
+      listDir: async (p) => dirTree[p] ?? [],
+    };
+    const paths = resolveLegionPaths({}, "/home/test");
+
+    const result = await fetchAllTrackedRepos(paths, deps);
+
+    expect(result.fetched).toEqual(["github.com/acme/other"]);
+    expect(result.errors).toEqual([{ repo: "github.com/acme/widgets", error: "auth failed" }]);
+  });
+
+  it("returns empty results when reposDir has no hosts", async () => {
+    const deps: RepoManagerDeps = {
+      runJj: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+      exists: async () => true,
+      rmDir: async () => {},
+      symlink: async () => {},
+      listDir: async () => [],
+    };
+    const paths = resolveLegionPaths({}, "/home/test");
+
+    const result = await fetchAllTrackedRepos(paths, deps);
+
+    expect(result.fetched).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("returns empty results when listDir is not provided", async () => {
+    const deps: RepoManagerDeps = {
+      runJj: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+      exists: async () => true,
+      rmDir: async () => {},
+      symlink: async () => {},
+      // listDir intentionally omitted
+    };
+    const paths = resolveLegionPaths({}, "/home/test");
+
+    const result = await fetchAllTrackedRepos(paths, deps);
+
+    expect(result.fetched).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("skips repos where clone path does not exist", async () => {
+    const commands: string[][] = [];
+    const dirTree: Record<string, string[]> = {
+      "/home/test/.local/share/legion/repos": ["github.com"],
+      "/home/test/.local/share/legion/repos/github.com": ["acme"],
+      "/home/test/.local/share/legion/repos/github.com/acme": ["widgets"],
+    };
+    const deps: RepoManagerDeps = {
+      runJj: async (args) => {
+        commands.push(args);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      exists: async () => false,
+      rmDir: async () => {},
+      symlink: async () => {},
+      listDir: async (p) => dirTree[p] ?? [],
+    };
+    const paths = resolveLegionPaths({}, "/home/test");
+
+    const result = await fetchAllTrackedRepos(paths, deps);
+
+    expect(result.fetched).toEqual([]);
+    expect(result.errors).toEqual([]);
+    expect(commands).toEqual([]);
   });
 });

--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -470,8 +470,9 @@ describe("daemon server", () => {
     expect(createSessionCalls[0].workspace).toBe(
       "/tmp/legion-data/workspaces/123e4567-e89b-12d3-a456-426614174000/acme-widgets-77"
     );
-    // Blocking calls: clone + workspace add. Background fetch follows.
-    expect(runJjCalls.slice(0, 2)).toEqual([
+    // For implement mode: blocking pre-dispatch fetch fires first, then clone + workspace add.
+    expect(runJjCalls.slice(0, 3)).toEqual([
+      ["git", "fetch", "-R", "/tmp/legion-data/repos/github.com/acme/widgets"],
       [
         "git",
         "clone",
@@ -489,13 +490,6 @@ describe("daemon server", () => {
         "-R",
         "/tmp/legion-data/repos/github.com/acme/widgets",
       ],
-    ]);
-    // Background fetch fires after workspace creation (non-blocking)
-    expect(runJjCalls[2]).toEqual([
-      "git",
-      "fetch",
-      "-R",
-      "/tmp/legion-data/repos/github.com/acme/widgets",
     ]);
   });
 
@@ -773,6 +767,102 @@ describe("daemon server", () => {
     const body = await response.json();
     expect(body).toHaveProperty("id", "acme-widgets-99-implement");
     expect(body).toHaveProperty("sessionId");
+  });
+
+  it("runs blocking fetch before workspace creation for implement mode", async () => {
+    const jjCommands: string[][] = [];
+    const paths: LegionPaths = {
+      dataDir: "/tmp/legion-data",
+      stateDir: "/tmp/legion-state",
+      reposDir: "/tmp/legion-data/repos",
+      workspacesDir: "/tmp/legion-data/workspaces",
+      legionsFile: "/tmp/legion-state/legions.json",
+      forLegion: (projectId: string) => ({
+        legionStateDir: `/tmp/legion-state/legions/${projectId}`,
+        workersFile: `/tmp/legion-state/legions/${projectId}/workers.json`,
+        feedbackFile: `/tmp/legion-state/legions/${projectId}/feedback.jsonl`,
+        logDir: `/tmp/legion-state/legions/${projectId}/logs`,
+        workspacesDir: `/tmp/legion-data/workspaces/${projectId}`,
+      }),
+      repoClonePath: (host: string, owner: string, repo: string) =>
+        `/tmp/legion-data/repos/${host}/${owner}/${repo}`,
+    };
+    const repoManagerDeps: RepoManagerDeps = {
+      runJj: async (args) => {
+        jjCommands.push([...args]);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      exists: async () => true,
+      rmDir: async () => {},
+      symlink: async () => {},
+    };
+    await startTestServer({ paths, repoManagerDeps });
+
+    const response = await requestJson("/workers", {
+      method: "POST",
+      body: JSON.stringify({
+        issueId: "acme-widgets-99",
+        mode: "implement",
+        repo: "acme/widgets",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    // For implement mode, the fetch should happen BEFORE workspace creation.
+    // Since clone exists, ensureRepoClone doesn't call runJj, so the first
+    // jj command should be "git fetch" (the blocking pre-dispatch fetch).
+    const fetchCmd = jjCommands.find((c) => c[0] === "git" && c[1] === "fetch");
+    expect(fetchCmd).toBeDefined();
+    expect(fetchCmd).toContain("-R");
+  });
+
+  it("uses non-blocking fetch for non-implement modes", async () => {
+    const jjCommands: string[][] = [];
+    const paths: LegionPaths = {
+      dataDir: "/tmp/legion-data",
+      stateDir: "/tmp/legion-state",
+      reposDir: "/tmp/legion-data/repos",
+      workspacesDir: "/tmp/legion-data/workspaces",
+      legionsFile: "/tmp/legion-state/legions.json",
+      forLegion: (projectId: string) => ({
+        legionStateDir: `/tmp/legion-state/legions/${projectId}`,
+        workersFile: `/tmp/legion-state/legions/${projectId}/workers.json`,
+        feedbackFile: `/tmp/legion-state/legions/${projectId}/feedback.jsonl`,
+        logDir: `/tmp/legion-state/legions/${projectId}/logs`,
+        workspacesDir: `/tmp/legion-data/workspaces/${projectId}`,
+      }),
+      repoClonePath: (host: string, owner: string, repo: string) =>
+        `/tmp/legion-data/repos/${host}/${owner}/${repo}`,
+    };
+    const repoManagerDeps: RepoManagerDeps = {
+      runJj: async (args) => {
+        jjCommands.push([...args]);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      exists: async () => true,
+      rmDir: async () => {},
+      symlink: async () => {},
+    };
+    await startTestServer({ paths, repoManagerDeps });
+
+    const response = await requestJson("/workers", {
+      method: "POST",
+      body: JSON.stringify({
+        issueId: "acme-widgets-99",
+        mode: "plan",
+        repo: "acme/widgets",
+        force: true,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    // For plan mode, the fetch is non-blocking (background).
+    // A fetch command should still eventually be issued, but we mainly verify
+    // that the response succeeds and a fetch was queued.
+    // Wait a tick for the background fetch to fire
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const fetchCmd = jjCommands.find((c) => c[0] === "git" && c[1] === "fetch");
+    expect(fetchCmd).toBeDefined();
   });
 
   it("returns 500 when repo clone fails", async () => {
@@ -1914,6 +2004,66 @@ describe("daemon server", () => {
       expect(workers[0]?.id).toBe("acme-widgets-46-implement");
       // Session should NOT have been deleted
       expect(deleteSessionCalls).toEqual([]);
+    });
+
+    it("fires background fetch on repo clone after Done issue cleanup", async () => {
+      const jjCommands: string[][] = [];
+      const rmDirCalls: string[] = [];
+      await startTestServer({
+        paths,
+        repoManagerDeps: makeRepoManagerDeps({
+          runJj: async (args) => {
+            jjCommands.push([...args]);
+            // bookmark list returns synced bookmark for cleanup to proceed
+            if (args.includes("bookmark")) {
+              return {
+                exitCode: 0,
+                stdout: ["acme-widgets-47 local", "acme-widgets-47 remote:origin ahead:0"].join(
+                  "\n"
+                ),
+                stderr: "",
+              };
+            }
+            return { exitCode: 0, stdout: "", stderr: "" };
+          },
+          rmDir: async (p) => {
+            rmDirCalls.push(p);
+          },
+        }),
+      });
+
+      await createRepoWorker("acme-widgets-47");
+
+      // Collect state with issue as Done — triggers cleanup + fetch
+      await requestJson("/state/collect", {
+        method: "POST",
+        body: JSON.stringify({
+          backend: "github",
+          issues: [
+            {
+              id: "PVTI_fetch_on_close",
+              content: {
+                number: 47,
+                repository: "acme/widgets",
+                url: "https://github.com/acme/widgets/issues/47",
+                type: "Issue",
+              },
+              status: "Done",
+              labels: [],
+            },
+          ],
+        }),
+      });
+      // Wait for async cleanup + background fetch to complete
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Verify workspace was cleaned up
+      expect(rmDirCalls.length).toBeGreaterThan(0);
+      // Verify a "git fetch" was fired on the repo clone after cleanup
+      // (separate from the pre-dispatch fetch for the implement worker creation)
+      const fetchCommands = jjCommands.filter((c) => c[0] === "git" && c[1] === "fetch");
+      // At least 2 fetches: one for implement dispatch (blocking), one after Done cleanup
+      expect(fetchCommands.length).toBeGreaterThanOrEqual(2);
     });
 
     it("directory scan uses real fs listDir when repoManagerDeps.listDir is not injected", async () => {

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -18,6 +18,7 @@ import {
   writeLegionEntry,
 } from "./legions-registry";
 import { isPortFree } from "./ports";
+import { fetchAllTrackedRepos } from "./repo-manager";
 import { readProcessRssBytes } from "./rss-monitor";
 import { createAdapter } from "./runtime";
 import type { RuntimeAdapter, RuntimeStartOptions } from "./runtime/types";
@@ -400,6 +401,24 @@ export async function startDaemon(
       );
     }
   }
+
+  // Warm up all tracked repo clones — non-blocking, best-effort.
+  // Runs in the background so it doesn't delay daemon startup.
+  fetchAllTrackedRepos(config.paths).then(
+    ({ fetched, errors }) => {
+      if (fetched.length > 0) {
+        console.log(`[startup] Fetched ${fetched.length} repo clone(s): ${fetched.join(", ")}`);
+      }
+      for (const { repo, error } of errors) {
+        console.warn(`[startup] Repo fetch failed for ${repo}: ${error}`);
+      }
+    },
+    (err) => {
+      console.warn(
+        `[startup] fetchAllTrackedRepos failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  );
 
   if (hasIndexRoot) {
     const startedIndexBuildAt = Date.now();

--- a/packages/daemon/src/daemon/repo-manager.ts
+++ b/packages/daemon/src/daemon/repo-manager.ts
@@ -178,6 +178,58 @@ export async function startBackgroundFetch(
 }
 
 /**
+ * Fetch all tracked repo clones under `paths.reposDir`.
+ *
+ * Walks the directory tree `reposDir/{host}/{owner}/{repo}` and fires
+ * `jj git fetch` on each clone. Failures are collected but do not abort the
+ * overall run — callers get a summary of successes and errors.
+ */
+export async function fetchAllTrackedRepos(
+  paths: LegionPaths,
+  deps: RepoManagerDeps = defaultDeps
+): Promise<{ fetched: string[]; errors: Array<{ repo: string; error: string }> }> {
+  const listDir = deps.listDir ?? defaultDeps.listDir;
+  if (!listDir) {
+    return { fetched: [], errors: [] };
+  }
+
+  const fetched: string[] = [];
+  const errors: Array<{ repo: string; error: string }> = [];
+
+  const hosts = await listDir(paths.reposDir);
+  for (const host of hosts) {
+    const hostPath = path.join(paths.reposDir, host);
+    const owners = await listDir(hostPath);
+    for (const owner of owners) {
+      const ownerPath = path.join(hostPath, owner);
+      const repos = await listDir(ownerPath);
+      for (const repo of repos) {
+        const clonePath = path.join(ownerPath, repo);
+        if (!(await deps.exists(clonePath))) {
+          continue;
+        }
+        const label = `${host}/${owner}/${repo}`;
+        try {
+          const result = await deps.runJj(["git", "fetch", "-R", clonePath]);
+          if (result.exitCode !== 0) {
+            errors.push({ repo: label, error: result.stderr });
+          } else {
+            fetched.push(label);
+          }
+        } catch (err) {
+          errors.push({
+            repo: label,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    }
+  }
+
+  return { fetched, errors };
+}
+
+/**
  * Check whether a bookmark (branch) for the given issue has been pushed to origin.
  *
  * Returns `{ safe: true }` when either:

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -28,6 +28,7 @@ import {
   ensureWorkspace,
   parseIssueRepo,
   type RepoManagerDeps,
+  type RepoRef,
   removeDir,
   startBackgroundFetch,
   verifyBranchPushed,
@@ -451,6 +452,7 @@ export function startServer(opts: ServerOptions): {
     const cleanedIssueIds = new Set<string>();
     const failedWorkspaceIssueIds = new Set<string>();
     const cleanedWorkspaceIssueIds = new Set<string>();
+    const cleanedRepoRefs = new Map<string, RepoRef>();
     let cleanedWorkers = 0;
 
     // First pass: attempt workspace cleanup (once per issue)
@@ -474,6 +476,8 @@ export function startServer(opts: ServerOptions): {
               opts.repoManagerDeps
             );
             cleanedWorkspaceIssueIds.add(issueId);
+            const repoKey = `${repoRef.host}/${repoRef.owner}/${repoRef.repo}`;
+            cleanedRepoRefs.set(repoKey, repoRef);
           } catch (error) {
             console.warn(
               `[auto-cleanup] workspace cleanup failed for ${issueId}: ${error instanceof Error ? error.message : String(error)}`
@@ -525,6 +529,18 @@ export function startServer(opts: ServerOptions): {
       console.log(
         `[auto-cleanup] Cleaned ${cleanedWorkers} workers for ${cleanedIssueIds.size} Done issues`
       );
+    }
+
+    // Fetch repo clones for Done issues — the merge just landed, so bring the
+    // default clone up to date for future dispatches. Non-blocking, best-effort.
+    if (opts.paths && cleanedRepoRefs.size > 0) {
+      for (const [repoKey, repoRef] of cleanedRepoRefs) {
+        startBackgroundFetch(opts.paths, repoRef, opts.repoManagerDeps).catch((err) => {
+          console.warn(
+            `[auto-cleanup] Post-close fetch failed for ${repoKey}: ${err instanceof Error ? err.message : String(err)}`
+          );
+        });
+      }
     }
 
     // Directory scan fallback: remove workspaces for issues no longer on the board
@@ -909,6 +925,18 @@ export function startServer(opts: ServerOptions): {
               if (!repoRef) {
                 return badRequest("invalid_repo: expected owner/repo");
               }
+              // For implement mode: blocking fetch BEFORE workspace creation so the
+              // workspace is created from a fresh clone. For other modes: non-blocking
+              // fetch after workspace creation (existing behavior).
+              if (mode === WorkerMode.IMPLEMENT) {
+                try {
+                  await startBackgroundFetch(opts.paths, repoRef, opts.repoManagerDeps);
+                } catch (err) {
+                  console.warn(
+                    `[dispatch] Pre-dispatch fetch failed for ${repoRef.owner}/${repoRef.repo}: ${err instanceof Error ? err.message : String(err)} — proceeding with potentially stale clone`
+                  );
+                }
+              }
               try {
                 resolvedWorkspace = await ensureWorkspace(
                   opts.paths,
@@ -920,13 +948,15 @@ export function startServer(opts: ServerOptions): {
               } catch (error) {
                 return serverError(`Failed to resolve workspace: ${(error as Error).message}`);
               }
-              // Fire background fetch (non-blocking) — pre-warms the clone for the
-              // worker's own `jj git fetch` during startup.
-              startBackgroundFetch(opts.paths, repoRef, opts.repoManagerDeps).catch((err) => {
-                console.error(
-                  `[dispatch] Background fetch failed for ${repoRef.owner}/${repoRef.repo}: ${err instanceof Error ? err.message : String(err)}`
-                );
-              });
+              if (mode !== WorkerMode.IMPLEMENT) {
+                // Non-implement modes: fire background fetch (non-blocking) — pre-warms
+                // the clone for the worker's own `jj git fetch` during startup.
+                startBackgroundFetch(opts.paths, repoRef, opts.repoManagerDeps).catch((err) => {
+                  console.error(
+                    `[dispatch] Background fetch failed for ${repoRef.owner}/${repoRef.repo}: ${err instanceof Error ? err.message : String(err)}`
+                  );
+                });
+              }
             } else if (typeof workspace === "string") {
               if (!isAbsolute(workspace)) {
                 return badRequest("workspace must be an absolute path");


### PR DESCRIPTION
Closes #523

## Summary

Keep default repo clones fresh so workers start with up-to-date code instead of fetching from scratch.

**Three changes in repo-manager.ts / server.ts / index.ts:**

1. **Blocking fetch before implementer dispatch** — `POST /workers` with `mode=implement` now runs a blocking `jj git fetch` on the default clone *before* `ensureWorkspace()` creates the jj workspace. Other modes retain the existing non-blocking background fetch after workspace creation. If the pre-dispatch fetch fails, it logs a warning and proceeds (non-fatal).

2. **Background fetch on issue close** — `cleanupDoneIssueWorkers()` now fires a non-blocking `startBackgroundFetch()` for each unique repo after workspace cleanup. Since Done means a merge just landed, this brings the clone up to date for future dispatches.

3. **Warm all clones on daemon startup** — new `fetchAllTrackedRepos()` function walks `reposDir/{host}/{owner}/{repo}` and fetches every clone. Called non-blocking during `startDaemon()` so it doesn't delay startup.

## Testing

- 5 new unit tests for `fetchAllTrackedRepos` (multi-repo, error collection, empty, no listDir, nonexistent)
- 3 new server tests (blocking fetch for implement, non-blocking for plan, post-close fetch)
- Updated existing test expectations for changed jj command ordering
- All 212 daemon tests pass, biome clean