### PR TITLE
fix(envoy): make tsnet non-fatal — fall back to legacy port on auth failure

### DIFF
--- a/packages/envoy/cmd/listener/main.go
+++ b/packages/envoy/cmd/listener/main.go
@@ -486,9 +486,14 @@ func main() {
 		tsMux := http.NewServeMux()
 		tsMux.Handle("/v1/", readinessGate(func() bool { return deps.Load() != nil }, v1))
 		if _, err := tsServer.Serve(tsMux, fatal); err != nil {
-			log.Fatal(err)
+			log.Printf("WARNING: tsnet failed to start (non-fatal, continuing without Tailscale): %v", err)
+			tsServer.Close()
+			tsServer = nil
+			// Fall back: serve /v1/* on the legacy port since tsnet is unavailable
+			mux.Handle("/v1/", readinessGate(func() bool { return deps.Load() != nil }, v1))
+		} else {
+			log.Printf("envoy-listener tsnet serving /v1/* on %s:443", tsServer.Hostname())
 		}
-		log.Printf("envoy-listener tsnet serving /v1/* on %s:443", tsServer.Hostname())
 	}
 	// Phase 5: Connect to NATS (main goroutine — log.Fatal is safe here).
 	client, err := bus.Connect(cfg.NATSURLs, bus.WithReplicas(cfg.NATSReplicas))


### PR DESCRIPTION
## Problem

When tsnet is enabled but the auth key is invalid (e.g., `dummy-disabled` placeholder), the listener crashes with `log.Fatal` on `tsServer.Serve()` failure. This prevents the Fargate service from starting and serving webhooks.

## Fix

tsnet failure is now non-fatal. When `Serve()` fails:
1. Logs a warning with the error
2. Closes and nils the tsnet server
3. Falls back to serving `/v1/*` on the legacy HTTP port (same as when tsnet is disabled)
4. Continues running — webhooks work regardless of tsnet status

## Impact

The Fargate deployment on AWS had `ENVOY_TSNET_ENABLED=true` with a dummy auth key, causing crash loops and 502 on `webhooks.trajectorylabs.com`. This fix lets the container start and serve webhooks while tsnet is not yet properly configured.