### PR TITLE
fix(skills): add artifact checklist to review workflow

### DIFF
--- a/.legion/retro.json
+++ b/.legion/retro.json
@@ -1,0 +1,7 @@
+{
+  "skipped": true,
+  "reason": "no significant learnings — single-file skill addition with no complications",
+  "schemaVersion": 1,
+  "phase": "retro",
+  "completed": "2026-04-14T04:52:28.052Z"
+}

--- a/.opencode/skills/legion-worker/workflows/review.md
+++ b/.opencode/skills/legion-worker/workflows/review.md
@@ -139,6 +139,25 @@ The `.legion/` directory contains **structured handoff data** committed intentio
 
 **Do NOT flag `.legion/` files for removal or suggest gitignoring them.** They are part of the PR deliverable.
 
+### 1.9. Artifact Check
+
+Before running the review, check for unintended files in the PR that should not be merged:
+
+```bash
+# List all files changed in the PR relative to main
+jj diff --stat --from main
+```
+
+Flag as **P1 (must fix before merge)** if any of these appear in the diff:
+- Compiled binaries (`*.exe`, `*.bin`, Go binaries in package directories)
+- `.opencode/` or `.claude/` session/config directories
+- `node_modules/`, `vendor/`, or other dependency directories
+- Changelog fragments or release notes not part of the issue scope
+- Unrelated files modified by accident (e.g., from a dirty rebase)
+
+**Exception:** `.legion/` files are intentional handoff data — see section 1.5 above. Do NOT flag these.
+
+
 ### 2. Run Review
 
 Invoke `/ce:review` with the branch name.


### PR DESCRIPTION
## Summary
Adds step 1.9 (Artifact Check) to the review workflow — reviewers check `jj diff --stat --from main` for unintended files before running the review.

**Addresses Pattern 9** (agent artifacts in PRs — 4 occurrences, 3 issues) from transcript analysis.

## What it checks
P1 flags for: compiled binaries, .opencode/.claude/ directories, node_modules/vendor, unrelated changelog fragments, accidental file modifications from dirty rebases.

Exception: .legion/ files are intentional (existing section 1.5 already documents this).

## Placement
Step 1.9, right before "Run Review" (step 2). Natural pre-review checkpoint.