### PR TITLE
fix(skills): add circuit breaker for repetitive tool calls

### DIFF
--- a/.opencode/skills/legion-worker/SKILL.md
+++ b/.opencode/skills/legion-worker/SKILL.md
@@ -47,6 +47,7 @@ Use the **backend** from your prompt to choose GitHub CLI or Linear MCP commands
    tmux has-session -t <name> 2>/dev/null && echo "running" || echo "done"
    ```
    Never run `bun run serve`, `pulumi up`, long test suites, or similar commands directly in bash.
+9. **Circuit breaker on repetitive tool calls** — if you've called the same tool more than 10 times consecutively with similar input, STOP and reassess your approach. You are likely in a loop. Steps: (a) describe what you're trying to achieve, (b) identify why the repeated calls aren't working, (c) try a fundamentally different approach. Transcript analysis found 3 catastrophic loop incidents (4,490 wasted tool calls) where workers repeated the same failing action hundreds of times.
 
 ## Skill Discipline
 


### PR DESCRIPTION
## Summary
Adds rule 9 to the worker SKILL.md core principles: if you've called the same tool >10 times consecutively with similar input, STOP and reassess.

**Addresses Pattern 10** (catastrophic skill-load loops — 3 issues, 4,490 wasted tool calls) from transcript analysis.

## What it adds
One principle: detect when you're looping (>10 same tool calls), stop, describe the goal, identify why it's failing, try a different approach.

## Evidence
Issues #328, #329, #330 each entered 1000+ iteration loops calling the same tool with the same failing input. #329 alone consumed 1,499 tool calls over 868 minutes with zero productive work.