### PR TITLE
fix(daemon): use file:// path for opencode-legion plugin (interim until npm publish)

### DIFF
--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -196,7 +196,7 @@ function buildServeEnv(config: DaemonConfig): Record<string, string> {
     LEGION_SHORT_ID: legionId.slice(0, 8),
     LEGION_DAEMON_PORT: String(config.daemonPort),
     OPENCODE_CONFIG_CONTENT: JSON.stringify({
-      plugin: ["@sjawhar/opencode-legion@latest"],
+      plugin: [`file://${path.resolve(process.cwd(), "../opencode-plugin/dist/index.js")}`],
     }),
   };
   if (config.envoyUrl) {


### PR DESCRIPTION
Interim fix — the npm package @sjawhar/opencode-legion does not exist yet. Uses file:// path to the built plugin in the monorepo until npm publishing CI is set up.

Once @sjawhar/opencode-legion is published to npm, revert this and use the npm reference.

One-line change in packages/daemon/src/daemon/index.ts.