### PR TITLE
fix: upgrade plugin agent models to cross-model + controller abort rule

### DIFF
--- a/.opencode/skills/legion-controller/SKILL.md
+++ b/.opencode/skills/legion-controller/SKILL.md
@@ -447,6 +447,8 @@ The controller MUST NOT:
 - Use `--admin` to bypass branch protection — **EVER**. If a merge is blocked by branch protection rules, escalate to Sami. Only Sami may authorize admin merge overrides. This is a security/governance rule.
 - Run `jj git push` directly (dispatch a worker)
 - Run tests (dispatch a tester)
+- Abort or kill a worker without first messaging it on Envoy and confirming it is stuck. You MUST NOT assume a worker is stuck based on title, token count, or time elapsed alone — ASK the worker via `envoy_send` and wait for a response (or 2-minute timeout) before taking action.
+- Redispatch a worker for the same issue/mode without confirming the existing worker is dead or unresponsive.
 
 The controller dispatches workers. Workers do the work. If you are about to touch code, branches, or PRs directly — stop and dispatch the appropriate worker instead.
 

--- a/packages/opencode-plugin/src/agents/index.ts
+++ b/packages/opencode-plugin/src/agents/index.ts
@@ -14,16 +14,16 @@ import type { AgentDefinition } from "./types";
 export type { AgentDefinition } from "./types";
 
 const DEFAULT_MODELS: Record<string, string> = {
-  orchestrator: "anthropic/claude-sonnet-4-6",
-  executor: "anthropic/claude-sonnet-4-6",
-  oracle: "anthropic/claude-opus-4-6",
-  explorer: "anthropic/claude-sonnet-4-6",
+  orchestrator: "anthropic/claude-opus-4-6",
+  executor: "openai/gpt-5.4",
+  oracle: "openai/gpt-5.4",
+  explorer: "anthropic/claude-haiku-4-5",
   librarian: "anthropic/claude-sonnet-4-6",
-  metis: "anthropic/claude-sonnet-4-6",
-  momus: "anthropic/claude-sonnet-4-6",
-  multimodal: "anthropic/claude-sonnet-4-6",
-  conductor: "anthropic/claude-sonnet-4-6",
-  "simplicity-reviewer": "anthropic/claude-sonnet-4-6",
+  metis: "openai/gpt-5.4",
+  momus: "openai/gpt-5.4",
+  multimodal: "openai/gpt-5.4",
+  conductor: "anthropic/claude-opus-4-6",
+  "simplicity-reviewer": "openai/gpt-5.4",
 };
 
 function getModel(config: PluginConfig | undefined, agentName: string): string {


### PR DESCRIPTION
Two changes:

**#540 — Cross-model agent defaults:**
- Opus: orchestrator, conductor (heavy thinking)
- GPT-5.4: executor, oracle, metis, momus, multimodal, simplicity-reviewer (cross-model critics)
- Haiku: explorer (fast/cheap search)
- Sonnet: librarian (standard work)

**#542 — Controller abort rule:**
Controllers must message workers via Envoy and confirm they're stuck before aborting or redispatching. No assumptions based on title, token count, or elapsed time.

Closes #540, closes #542. Plugin bumped to 0.16.2.