### PR TITLE
feat(envoy): production listener fixes + testcontainers CI smoke test

### DIFF
--- a/.github/workflows/envoy-and-contracts.yaml
+++ b/.github/workflows/envoy-and-contracts.yaml
@@ -84,6 +84,9 @@ jobs:
       - name: Build envoy services
         run: go build ./cmd/listener
         working-directory: packages/envoy
+      - name: Container smoke test (testcontainers)
+        run: go test -tags smoke -v -timeout 5m ./internal/smoke/
+        working-directory: packages/envoy
       - name: Pack envoy binaries
         run: |
           mkdir -p ../../out/pr-artifacts/envoy-amd64

--- a/.github/workflows/release-envoy-and-plugin.yaml
+++ b/.github/workflows/release-envoy-and-plugin.yaml
@@ -186,6 +186,18 @@ jobs:
       - uses: actions/checkout@v5
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: packages/envoy/go.mod
+      - uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Generate Go contracts
+        run: bun run gen:go
+        working-directory: packages/contracts
+      - name: Container smoke test (testcontainers)
+        run: go test -tags smoke -v -timeout 5m ./internal/smoke/
+        working-directory: packages/envoy
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/packages/envoy/cmd/listener/main.go
+++ b/packages/envoy/cmd/listener/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"github.com/sjawhar/envoy/internal/logging"
+	"log/slog"
 	"encoding/json"
 	"errors"
 	"log"
@@ -21,6 +23,7 @@ import (
 	"github.com/sjawhar/envoy/internal/id"
 	"github.com/sjawhar/envoy/internal/session"
 	"github.com/sjawhar/envoy/internal/store"
+	"github.com/sjawhar/envoy/internal/metrics"
 	envoytsnet "github.com/sjawhar/envoy/internal/tsnet"
 	"github.com/sjawhar/envoy/internal/webhook"
 )
@@ -40,6 +43,33 @@ var rolePattern = regexp.MustCompile(rolePatternString)
 
 func isValidRole(role string) bool {
 	return rolePattern.MatchString(role)
+}
+
+// startListenerSubscription preserves the durable consumer so restarts resume
+// from the last ACKed message instead of skipping pending work.
+func startListenerSubscription(client *bus.Client, consumer string, handler nats.MsgHandler) (*nats.Subscription, error) {
+	return client.Subscribe(
+		"notifications.>",
+		handler,
+		nats.Durable(consumer),
+		nats.AckExplicit(),
+		nats.ManualAck(),
+		nats.AckWait(60*time.Second),
+		nats.MaxAckPending(256),
+		nats.MaxDeliver(20),
+	)
+}
+
+func isSessionLive(sessions *session.SessionRegistry, sessionID string) bool {
+	_, err := sessions.Get(sessionID)
+	return err == nil
+}
+
+func shouldNAKFanoutDelivery(sessions *session.SessionRegistry, sessionID string, err error) bool {
+	if err == nil {
+		return false
+	}
+	return isSessionLive(sessions, sessionID)
 }
 
 // readinessGate returns 503 until ready returns true, providing a single
@@ -63,10 +93,11 @@ func publishHandler(state *atomic.Pointer[listenerDeps]) http.HandlerFunc {
 			return
 		}
 		var body struct {
-			Source        string `json:"source"`
-			SourceSession string `json:"source_session"`
-			Topic         string `json:"topic"`
-			Message       string `json:"message"`
+			Source         string `json:"source"`
+			SourceSession  string `json:"source_session"`
+			Topic          string `json:"topic"`
+			Message        string `json:"message"`
+			IdempotencyKey string `json:"idempotency_key"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			http.Error(w, "invalid json", http.StatusBadRequest)
@@ -83,13 +114,17 @@ func publishHandler(state *atomic.Pointer[listenerDeps]) http.HandlerFunc {
 		if body.Source == "" {
 			body.Source = "agent"
 		}
+		dedupeKey := "publish." + id.New()
+		if body.IdempotencyKey != "" {
+			dedupeKey = "publish." + body.IdempotencyKey
+		}
 		item := contracts.Envelope{
 			EventID:        id.New(),
 			Source:         body.Source,
 			SourceSession:  body.SourceSession,
 			SourceEventID:  id.New(),
 			Topic:          body.Topic,
-			DedupeKey:      "publish." + id.New(),
+			DedupeKey:      dedupeKey,
 			IssuedAt:       contracts.NowMillis(),
 			PayloadSummary: body.Message,
 			TraceID:        id.New(),
@@ -247,6 +282,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	logger := logging.New(cfg.MachineID)
 
 	// Load tsnet config (fast — env var reads only).
 	tsCfg, err := envoytsnet.LoadConfig()
@@ -272,32 +308,74 @@ func main() {
 	// Shared state: nil until NATS initialization completes.
 	var deps atomic.Pointer[listenerDeps]
 
+	// Metrics registry — /metrics available during startup (like /healthz).
+	met := metrics.New()
+	messagesReceived := met.NewCounter("envoy_messages_received_total", "Total messages received by the listener")
+	messagesDelivered := met.NewCounter("envoy_messages_delivered_total", "Total message delivery attempts")
+	messagesNAKed := met.NewCounter("envoy_messages_naked_total", "Total messages NAK'd for retry")
+	deliveryDuration := met.NewHistogram("envoy_delivery_duration_seconds", "Duration of message delivery attempts", metrics.DefaultBuckets)
+	met.NewGaugeFunc("envoy_active_sessions", "Number of active sessions", func() int64 {
+		d := deps.Load()
+		if d == nil || d.sessions == nil {
+			return 0
+		}
+		entries, err := d.sessions.List()
+		if err != nil {
+			return 0
+		}
+		return int64(len(entries))
+	})
+	met.NewGaugeFunc("envoy_active_interests", "Number of active interest subscriptions", func() int64 {
+		d := deps.Load()
+		if d == nil || d.registry == nil {
+			return 0
+		}
+		return int64(len(d.registry.List()))
+	})
+
 	// Phase 3: Build HTTP mux.
 	mux := http.NewServeMux()
 
+	// /metrics is always reachable — NOT gated by readiness.
+	mux.Handle("/metrics", met.Handler())
+
+	var healthzConsumer string
 	// /healthz is always reachable — returns 200 "starting" before NATS init,
 	// 200 "healthy" after init with live NATS, 503 "unhealthy" if NATS drops.
+	// Consumer lag metrics are included when available (after subscription setup).
+	// 200 "healthy" after init with live NATS, 503 "unhealthy" if NATS drops.
+	// Consumer lag metrics are included when available (after subscription setup).
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		d := deps.Load()
 		if d == nil {
 			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]string{"status": "starting"})
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "starting"})
 			return
 		}
 		if err := d.client.Conn.FlushTimeout(3 * time.Second); err != nil {
 			w.WriteHeader(http.StatusServiceUnavailable)
-			_ = json.NewEncoder(w).Encode(map[string]string{"status": "unhealthy", "error": "nats unavailable"})
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "unhealthy", "error": "nats unavailable"})
 			return
 		}
 		if !d.client.SubOK() {
 			w.WriteHeader(http.StatusServiceUnavailable)
-			_ = json.NewEncoder(w).Encode(map[string]string{"status": "unhealthy", "error": "subscription inactive"})
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "unhealthy", "error": "subscription inactive"})
 			return
 		}
+		response := map[string]interface{}{"status": "healthy"}
+		if healthzConsumer != "" {
+			consumerInfo, err := d.client.JS().ConsumerInfo(bus.Stream, healthzConsumer)
+			if err == nil && consumerInfo != nil {
+				response["num_pending"] = consumerInfo.NumPending
+				response["num_ack_pending"] = consumerInfo.NumAckPending
+			}
+		}
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]string{"status": "healthy"})
+		_ = json.NewEncoder(w).Encode(response)
 	})
+
+	// GaugeFunc for consumer pending — queries NATS at scrape time
 
 	// Webhook routes — on public mux, gated by readiness.
 	// Publisher delegates to deps.client behind readinessGate.
@@ -342,7 +420,7 @@ func main() {
 			http.Error(w, "invalid json", http.StatusBadRequest)
 			return
 		}
-		log.Printf("listener subscribe session=%s topics=%v port=%d dir=%s", body.SessionID, body.Topics, body.Port, body.Dir)
+		logger.Info("listener subscribe", slog.String("session_id", body.SessionID), slog.Any("topics", body.Topics), slog.Int("port", body.Port), slog.String("dir", body.Dir))
 		d := deps.Load()
 		item, err := d.registry.Upsert(store.Interest{
 			SessionID: body.SessionID,
@@ -360,7 +438,7 @@ func main() {
 				Dir:       body.Dir,
 				Title:     body.Title,
 			}); err != nil {
-				log.Printf("listener session registry put failed session=%s: %v", body.SessionID, err)
+				logger.Error("listener session registry put failed", slog.String("session_id", body.SessionID), slog.String("error", err.Error()))
 			}
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -379,7 +457,7 @@ func main() {
 			http.Error(w, "invalid json", http.StatusBadRequest)
 			return
 		}
-		log.Printf("listener unsubscribe session=%s topics=%v", body.SessionID, body.Topics)
+		logger.Info("listener unsubscribe", slog.String("session_id", body.SessionID), slog.Any("topics", body.Topics))
 		d := deps.Load()
 		if err := d.registry.Remove(body.SessionID, body.Topics); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -419,13 +497,18 @@ func main() {
 			return
 		}
 		var body struct {
-			SourceSession string `json:"source_session"`
-			TargetSession string `json:"target_session"`
-			Message       string `json:"message"`
+			SourceSession  string `json:"source_session"`
+			TargetSession  string `json:"target_session"`
+			Message        string `json:"message"`
+			IdempotencyKey string `json:"idempotency_key"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			http.Error(w, "invalid json", http.StatusBadRequest)
 			return
+		}
+		dedupeKey := "agent." + body.TargetSession + "." + id.New()
+		if body.IdempotencyKey != "" {
+			dedupeKey = "agent." + body.TargetSession + "." + body.IdempotencyKey
 		}
 		item := contracts.Envelope{
 			EventID:        id.New(),
@@ -433,7 +516,7 @@ func main() {
 			SourceSession:  body.SourceSession,
 			SourceEventID:  id.New(),
 			Topic:          contracts.AgentSubject(body.TargetSession),
-			DedupeKey:      "agent." + body.TargetSession + "." + id.New(),
+			DedupeKey:      dedupeKey,
 			IssuedAt:       contracts.NowMillis(),
 			PayloadSummary: body.Message,
 			TraceID:        id.New(),
@@ -452,12 +535,9 @@ func main() {
 	})
 	v1.HandleFunc("/v1/messages/publish", publishHandler(&deps))
 
-	// When tsnet is disabled, serve /v1/* on the legacy port (existing behavior).
-	// When tsnet is enabled, /v1/* is served exclusively on the tsnet TLS listener
-	// and the legacy port only has /healthz (security boundary).
-	if !tsCfg.Enabled {
-		mux.Handle("/v1/", readinessGate(func() bool { return deps.Load() != nil }, v1))
-	}
+	// Always serve /v1/* on the legacy port for local plugin registration.
+	// The tsnet TLS listener (if enabled) also serves /v1/* on :443 for cross-machine access.
+	mux.Handle("/v1/", readinessGate(func() bool { return deps.Load() != nil }, v1))
 
 	// Phase 4: Start HTTP server (port already bound via net.Listen).
 	server := &http.Server{
@@ -473,7 +553,7 @@ func main() {
 			fatal <- err
 		}
 	}()
-	log.Printf("envoy-listener listening on %s", addr)
+	logger.Info("envoy-listener listening", slog.String("addr", addr))
 
 	// Phase 4.5: Start tsnet server (if enabled). The tsnet node connects
 	// to the Tailscale network, which is a slow operation like NATS connect.
@@ -486,13 +566,11 @@ func main() {
 		tsMux := http.NewServeMux()
 		tsMux.Handle("/v1/", readinessGate(func() bool { return deps.Load() != nil }, v1))
 		if _, err := tsServer.Serve(tsMux, fatal); err != nil {
-			log.Printf("WARNING: tsnet failed to start (non-fatal, continuing without Tailscale): %v", err)
+			logger.Warn("tsnet failed to start (non-fatal, continuing without Tailscale)", slog.String("error", err.Error()))
 			tsServer.Close()
 			tsServer = nil
-			// Fall back: serve /v1/* on the legacy port since tsnet is unavailable
-			mux.Handle("/v1/", readinessGate(func() bool { return deps.Load() != nil }, v1))
 		} else {
-			log.Printf("envoy-listener tsnet serving /v1/* on %s:443", tsServer.Hostname())
+			logger.Info("envoy-listener tsnet serving /v1/* on :443", slog.String("hostname", tsServer.Hostname()))
 		}
 	}
 	// Phase 5: Connect to NATS (main goroutine — log.Fatal is safe here).
@@ -521,6 +599,9 @@ func main() {
 		RequestLimit: 30 * time.Second,
 		Sessions:     sessions,
 	}
+	if tsServer != nil {
+		deliver.HTTPClient = tsServer.HTTPClient()
+	}
 
 	dedupeCache := dedupe.New(10 * time.Minute)
 
@@ -534,29 +615,35 @@ func main() {
 	attemptCache := dedupe.New(5 * time.Minute)
 
 	consumer := "listener-" + strings.ReplaceAll(cfg.MachineID, " ", "-")
-	_ = client.JS().DeleteConsumer(bus.Stream, consumer)
-	_, err = client.Subscribe("notifications.>", func(msg *nats.Msg) {
+	healthzConsumer = consumer
+
+	// /healthz handler was registered early (before NATS) — no re-registration needed.
+
+	_, err = startListenerSubscription(client, consumer, func(msg *nats.Msg) {
 		var item contracts.Envelope
 		if err := json.Unmarshal(msg.Data, &item); err != nil {
-			log.Printf("listener decode failed: %v", err)
+			logger.Error("listener decode failed", slog.String("error", err.Error()))
 			_ = msg.Ack()
 			return
 		}
 		if err := item.Validate(); err != nil {
-			log.Printf("listener invalid envelope: %v", err)
+			logger.Error("listener invalid envelope", slog.String("error", err.Error()))
 			_ = msg.Ack()
 			return
 		}
-		log.Printf("listener received machine=%s source=%s source_session=%s topic=%s event_id=%s payload=%.80s", cfg.MachineID, item.Source, item.SourceSession, item.Topic, item.EventID, item.PayloadSummary)
+		messagesReceived.Inc([2]string{"source", item.Source}, [2]string{"topic_prefix", metrics.TopicPrefix(item.Topic)})
+		logger.Info("listener received", slog.String("source", item.Source), slog.String("source_session", item.SourceSession), slog.String("topic", item.Topic), slog.String("event_id", item.EventID), slog.String("payload_summary", item.PayloadSummary))
 		if strings.HasPrefix(item.Topic, contracts.AgentTopicPrefix) {
 			sessionID := strings.TrimPrefix(item.Topic, contracts.AgentTopicPrefix)
 			if dedupeCache.Seen(item.DedupeKey, sessionID) {
-				log.Printf("listener dedupe skip session=%s dedupe_key=%s", sessionID, item.DedupeKey)
+				messagesDelivered.Inc([2]string{"delivery_status", "dedupe"})
+				logger.DeliveryLog(slog.LevelInfo, "listener dedupe skip", sessionID, item.Topic, item.EventID, "dedupe", slog.String("dedupe_key", item.DedupeKey))
 				_ = msg.Ack()
 				return
 			}
 			if attemptCache.Seen(item.DedupeKey, sessionID) {
-				log.Printf("listener attempt-dedupe skip session=%s dedupe_key=%s", sessionID, item.DedupeKey)
+				messagesDelivered.Inc([2]string{"delivery_status", "dedupe"})
+				logger.DeliveryLog(slog.LevelInfo, "listener attempt-dedupe skip", sessionID, item.Topic, item.EventID, "skipped", slog.String("dedupe_key", item.DedupeKey))
 				_ = msg.Ack()
 				return
 			}
@@ -566,17 +653,26 @@ func main() {
 				interestPtr = &interest
 			}
 			attemptCache.Record(item.DedupeKey, sessionID)
+			deliveryTimer := metrics.NewTimer()
 			result := session.HandleAgentMessage(item, sessionID, cfg.MachineID, interestPtr, &deliver)
 			if result.Err != nil {
-				log.Printf("listener agent delivery failed session=%s: %v", sessionID, result.Err)
+				logger.DeliveryLog(slog.LevelError, "listener agent delivery failed", sessionID, item.Topic, item.EventID, "failed", slog.String("error", result.Err.Error()))
+			}
+			if !result.Delivered && result.Err != nil {
+				deliveryTimer.ObserveDuration(deliveryDuration, [2]string{"delivery_status", "failed"})
+				messagesDelivered.Inc([2]string{"delivery_status", "failed"})
 			}
 			if result.Delivered {
+				deliveryTimer.ObserveDuration(deliveryDuration, [2]string{"delivery_status", "delivered"})
+				messagesDelivered.Inc([2]string{"delivery_status", "delivered"})
 				dedupeCache.Record(item.DedupeKey, sessionID)
-				log.Printf("listener agent delivered session=%s event_id=%s", sessionID, item.EventID)
+				logger.DeliveryLog(slog.LevelInfo, "listener agent delivered", sessionID, item.Topic, item.EventID, "delivered")
 			} else if result.Err == nil {
-				log.Printf("listener agent session not found anywhere session=%s", sessionID)
+				messagesDelivered.Inc([2]string{"delivery_status", "skipped"})
+				logger.DeliveryLog(slog.LevelWarn, "listener agent session not found anywhere", sessionID, item.Topic, item.EventID, "skipped")
 			}
 			if result.ShouldNAK {
+				messagesNAKed.Inc()
 				_ = msg.NakWithDelay(30 * time.Second)
 			} else {
 				_ = msg.Ack()
@@ -585,38 +681,55 @@ func main() {
 		}
 		items := registry.Match(cfg.MachineID, item.Topic)
 		if len(items) == 0 {
-			log.Printf("listener no matching interests for topic=%s", item.Topic)
+			logger.Info("listener no matching interests", slog.String("topic", item.Topic))
 			_ = msg.Ack()
 			return
 		}
 		var failed bool
+		var deadDeliveries int
 		for _, interest := range items {
 			if dedupeCache.Seen(item.DedupeKey, interest.SessionID) {
-				log.Printf("listener dedupe skip session=%s dedupe_key=%s", interest.SessionID, item.DedupeKey)
+				messagesDelivered.Inc([2]string{"delivery_status", "dedupe"})
+				logger.DeliveryLog(slog.LevelInfo, "listener dedupe skip", interest.SessionID, item.Topic, item.EventID, "dedupe", slog.String("dedupe_key", item.DedupeKey))
 				continue
 			}
 			if attemptCache.Seen(item.DedupeKey, interest.SessionID) {
-				log.Printf("listener attempt-dedupe skip session=%s dedupe_key=%s", interest.SessionID, item.DedupeKey)
+				messagesDelivered.Inc([2]string{"delivery_status", "dedupe"})
+				logger.DeliveryLog(slog.LevelInfo, "listener attempt-dedupe skip", interest.SessionID, item.Topic, item.EventID, "skipped", slog.String("dedupe_key", item.DedupeKey))
 				continue
 			}
 			if item.SourceSession != "" && item.SourceSession == interest.SessionID {
-				log.Printf("listener skip echo session=%s topic=%s", interest.SessionID, item.Topic)
+				messagesDelivered.Inc([2]string{"delivery_status", "skipped"})
+				logger.DeliveryLog(slog.LevelInfo, "listener skip echo", interest.SessionID, item.Topic, item.EventID, "skipped")
 				continue
 			}
 			attemptCache.Record(item.DedupeKey, interest.SessionID)
+			deliveryTimer := metrics.NewTimer()
 			if err := deliver.Deliver(item, interest); err != nil {
-				log.Printf("listener delivery failed session=%s: %v", interest.SessionID, err)
-				failed = true
+				deliveryTimer.ObserveDuration(deliveryDuration, [2]string{"delivery_status", "failed"})
+				messagesDelivered.Inc([2]string{"delivery_status", "failed"})
+				logger.DeliveryLog(slog.LevelError, "listener delivery failed", interest.SessionID, item.Topic, item.EventID, "failed", slog.String("error", err.Error()))
+				if shouldNAKFanoutDelivery(sessions, interest.SessionID, err) {
+					failed = true
+				} else {
+					deadDeliveries++
+				}
 			} else {
+				deliveryTimer.ObserveDuration(deliveryDuration, [2]string{"delivery_status", "delivered"})
+				messagesDelivered.Inc([2]string{"delivery_status", "delivered"})
 				dedupeCache.Record(item.DedupeKey, interest.SessionID)
 			}
 		}
+		if deadDeliveries > 0 {
+			logger.Info("listener skipped dead session deliveries", slog.String("topic", item.Topic), slog.Int("count", deadDeliveries))
+		}
 		if failed {
+			messagesNAKed.Inc()
 			_ = msg.NakWithDelay(30 * time.Second)
 		} else {
 			_ = msg.Ack()
 		}
-	}, nats.Durable(consumer), nats.DeliverNew(), nats.AckExplicit(), nats.ManualAck(), nats.AckWait(60*time.Second), nats.MaxAckPending(256), nats.MaxDeliver(20))
+	})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -627,7 +740,12 @@ func main() {
 		registry: registry,
 		sessions: sessions,
 	})
-	log.Printf("envoy-listener ready (NATS connected)")
+	logger.Info("envoy-listener ready (NATS connected)")
+
+	// Phase 6b: Start interest reaper for stale KV cleanup.
+	// Cross-references envoy_sessions (5-min TTL) with envoy_interests (permanent)
+	// to prune orphaned interests from dead sessions.
+	registry.StartReaper(func(sessionID string) bool { return isSessionLive(sessions, sessionID) }, 5*time.Minute, 10*time.Minute)
 
 	// Phase 7: Block until fatal error from HTTP server.
 	log.Fatal(<-fatal)

--- a/packages/envoy/cmd/listener/main_test.go
+++ b/packages/envoy/cmd/listener/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,8 +16,10 @@ import (
 	natsgo "github.com/nats-io/nats.go"
 	"github.com/sjawhar/envoy/internal/bus"
 	"github.com/sjawhar/envoy/internal/contracts"
+	"github.com/sjawhar/envoy/internal/id"
 	"github.com/sjawhar/envoy/internal/session"
 	"github.com/sjawhar/envoy/internal/store"
+	"github.com/sjawhar/envoy/internal/metrics"
 	tcnats "github.com/testcontainers/testcontainers-go/modules/nats"
 )
 
@@ -72,6 +75,13 @@ func clearKVBucket(t *testing.T, conn *natsgo.Conn, bucket string) {
 
 func resetListenerTestState(t *testing.T, conn *natsgo.Conn) {
 	t.Helper()
+	js, err := conn.JetStream(natsgo.MaxWait(10 * time.Second))
+	if err != nil {
+		t.Fatalf("failed to open JetStream: %v", err)
+	}
+	if err := js.PurgeStream(bus.Stream); err != nil && !errors.Is(err, natsgo.ErrStreamNotFound) {
+		t.Fatalf("failed to purge stream %s: %v", bus.Stream, err)
+	}
 	clearKVBucket(t, conn, store.Bucket)
 	clearKVBucket(t, conn, session.SessionBucket)
 }
@@ -848,5 +858,547 @@ func TestSessionsHandler_NoInterestsData(t *testing.T) {
 	}
 	if len(items[0].Topics) != 0 {
 		t.Fatalf("expected no topics for orphan session, got %v", items[0].Topics)
+	}
+}
+
+func TestIdempotencyKey_Send(t *testing.T) {
+	client := setupPublishTestClient(t)
+	var state atomic.Pointer[listenerDeps]
+	state.Store(&listenerDeps{client: client})
+
+	// Create a handler for /v1/messages/send
+	mux := http.NewServeMux()
+	v1 := http.NewServeMux()
+	v1.HandleFunc("/v1/messages/send", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var body struct {
+			SourceSession  string `json:"source_session"`
+			TargetSession  string `json:"target_session"`
+			Message        string `json:"message"`
+			IdempotencyKey string `json:"idempotency_key"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		item := contracts.Envelope{
+			EventID:        id.New(),
+			Source:         "agent",
+			SourceSession:  body.SourceSession,
+			SourceEventID:  id.New(),
+			Topic:          contracts.AgentSubject(body.TargetSession),
+			IssuedAt:       contracts.NowMillis(),
+			PayloadSummary: body.Message,
+			TraceID:        id.New(),
+		}
+		dedupeKey := "agent." + body.TargetSession + "." + id.New()
+		if body.IdempotencyKey != "" {
+			dedupeKey = "agent." + body.TargetSession + "." + body.IdempotencyKey
+		}
+		item.DedupeKey = dedupeKey
+		if err := item.Validate(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		d := state.Load()
+		if err := d.client.Publish(item); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(item)
+	})
+	mux.Handle("/v1/", readinessGate(func() bool { return state.Load() != nil }, v1))
+
+	// Test: same idempotency_key produces same DedupeKey
+	rr1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest(http.MethodPost, "/v1/messages/send", strings.NewReader(`{"source_session":"src1","target_session":"tgt1","message":"hello","idempotency_key":"retry-abc"}`))
+	req1.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(rr1, req1)
+
+	if rr1.Code != http.StatusOK {
+		t.Fatalf("first request failed: expected 200, got %d (body: %s)", rr1.Code, rr1.Body.String())
+	}
+	var env1 contracts.Envelope
+	if err := json.NewDecoder(rr1.Body).Decode(&env1); err != nil {
+		t.Fatalf("failed to decode first response: %v", err)
+	}
+
+	rr2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/v1/messages/send", strings.NewReader(`{"source_session":"src1","target_session":"tgt1","message":"hello","idempotency_key":"retry-abc"}`))
+	req2.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(rr2, req2)
+
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("second request failed: expected 200, got %d (body: %s)", rr2.Code, rr2.Body.String())
+	}
+	var env2 contracts.Envelope
+	if err := json.NewDecoder(rr2.Body).Decode(&env2); err != nil {
+		t.Fatalf("failed to decode second response: %v", err)
+	}
+
+	if env1.DedupeKey != env2.DedupeKey {
+		t.Fatalf("expected same DedupeKey for same idempotency_key, got %q and %q", env1.DedupeKey, env2.DedupeKey)
+	}
+	if !strings.HasPrefix(env1.DedupeKey, "agent.tgt1.retry-abc") {
+		t.Fatalf("expected DedupeKey to start with 'agent.tgt1.retry-abc', got %q", env1.DedupeKey)
+	}
+}
+
+func TestIdempotencyKey_Publish(t *testing.T) {
+	client := setupPublishTestClient(t)
+	var state atomic.Pointer[listenerDeps]
+	state.Store(&listenerDeps{client: client})
+	handler := publishHandler(&state)
+
+	// Test: same idempotency_key produces same DedupeKey
+	rr1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest(http.MethodPost, "/v1/messages/publish", strings.NewReader(`{"topic":"notifications.test.foo","message":"hello","idempotency_key":"publish-xyz"}`))
+	req1.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(rr1, req1)
+
+	if rr1.Code != http.StatusOK {
+		t.Fatalf("first request failed: expected 200, got %d (body: %s)", rr1.Code, rr1.Body.String())
+	}
+	var env1 contracts.Envelope
+	if err := json.NewDecoder(rr1.Body).Decode(&env1); err != nil {
+		t.Fatalf("failed to decode first response: %v", err)
+	}
+
+	rr2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/v1/messages/publish", strings.NewReader(`{"topic":"notifications.test.foo","message":"hello","idempotency_key":"publish-xyz"}`))
+	req2.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(rr2, req2)
+
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("second request failed: expected 200, got %d (body: %s)", rr2.Code, rr2.Body.String())
+	}
+	var env2 contracts.Envelope
+	if err := json.NewDecoder(rr2.Body).Decode(&env2); err != nil {
+		t.Fatalf("failed to decode second response: %v", err)
+	}
+
+	if env1.DedupeKey != env2.DedupeKey {
+		t.Fatalf("expected same DedupeKey for same idempotency_key, got %q and %q", env1.DedupeKey, env2.DedupeKey)
+	}
+	if !strings.HasPrefix(env1.DedupeKey, "publish.publish-xyz") {
+		t.Fatalf("expected DedupeKey to start with 'publish.publish-xyz', got %q", env1.DedupeKey)
+	}
+}
+
+func TestIdempotencyKey_BackwardsCompat(t *testing.T) {
+	client := setupPublishTestClient(t)
+	var state atomic.Pointer[listenerDeps]
+	state.Store(&listenerDeps{client: client})
+	handler := publishHandler(&state)
+
+	// Test: no idempotency_key produces different DedupeKeys (existing behavior)
+	rr1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest(http.MethodPost, "/v1/messages/publish", strings.NewReader(`{"topic":"notifications.test.foo","message":"hello"}`))
+	req1.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(rr1, req1)
+
+	if rr1.Code != http.StatusOK {
+		t.Fatalf("first request failed: expected 200, got %d (body: %s)", rr1.Code, rr1.Body.String())
+	}
+	var env1 contracts.Envelope
+	if err := json.NewDecoder(rr1.Body).Decode(&env1); err != nil {
+		t.Fatalf("failed to decode first response: %v", err)
+	}
+
+	rr2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/v1/messages/publish", strings.NewReader(`{"topic":"notifications.test.foo","message":"hello"}`))
+	req2.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(rr2, req2)
+
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("second request failed: expected 200, got %d (body: %s)", rr2.Code, rr2.Body.String())
+	}
+	var env2 contracts.Envelope
+	if err := json.NewDecoder(rr2.Body).Decode(&env2); err != nil {
+		t.Fatalf("failed to decode second response: %v", err)
+	}
+
+	if env1.DedupeKey == env2.DedupeKey {
+		t.Fatalf("expected different DedupeKeys when no idempotency_key provided, got same: %q", env1.DedupeKey)
+	}
+	if !strings.HasPrefix(env1.DedupeKey, "publish.") {
+		t.Fatalf("expected DedupeKey to start with 'publish.', got %q", env1.DedupeKey)
+	}
+}
+
+func TestDurableConsumerRestart(t *testing.T) {
+	publisher, err := bus.Connect([]string{sharedListenerTestNATSURI(t)}, bus.WithReplicas(1))
+	if err != nil {
+		t.Fatalf("failed to connect publisher bus: %v", err)
+	}
+	t.Cleanup(func() { publisher.Conn.Close() })
+	resetListenerTestState(t, publisher.Conn)
+
+	firstListener, err := bus.Connect([]string{sharedListenerTestNATSURI(t)}, bus.WithReplicas(1))
+	if err != nil {
+		t.Fatalf("failed to connect first listener bus: %v", err)
+	}
+	t.Cleanup(func() { firstListener.Conn.Close() })
+
+	consumer := "listener-durable-restart-test"
+	_ = publisher.JS().DeleteConsumer(bus.Stream, consumer)
+
+	var (
+		mu        sync.Mutex
+		delivered []string
+	)
+	handler := func(msg *natsgo.Msg) {
+		var item contracts.Envelope
+		if err := json.Unmarshal(msg.Data, &item); err != nil {
+			t.Errorf("failed to decode envelope: %v", err)
+			_ = msg.Ack()
+			return
+		}
+		mu.Lock()
+		delivered = append(delivered, item.EventID)
+		mu.Unlock()
+		_ = msg.Ack()
+	}
+
+	_, err = startListenerSubscription(firstListener, consumer, handler)
+	if err != nil {
+		t.Fatalf("first subscribe failed: %v", err)
+	}
+
+	first := contracts.Envelope{
+		EventID:        "evt-restart-1",
+		Source:         "test",
+		SourceEventID:  "src-restart-1",
+		Topic:          "notifications.test.restart",
+		DedupeKey:      "dedupe-restart-1",
+		IssuedAt:       contracts.NowMillis(),
+		PayloadSummary: "first",
+		TraceID:        "trace-restart-1",
+	}
+	if err := publisher.Publish(first); err != nil {
+		t.Fatalf("publish first failed: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		count := len(delivered)
+		mu.Unlock()
+		if count == 1 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	mu.Lock()
+	firstCount := len(delivered)
+	mu.Unlock()
+	if firstCount != 1 {
+		t.Fatalf("expected first delivery before restart, got %d", firstCount)
+	}
+
+	firstListener.Close()
+
+	second := contracts.Envelope{
+		EventID:        "evt-restart-2",
+		Source:         "test",
+		SourceEventID:  "src-restart-2",
+		Topic:          "notifications.test.restart",
+		DedupeKey:      "dedupe-restart-2",
+		IssuedAt:       contracts.NowMillis(),
+		PayloadSummary: "second",
+		TraceID:        "trace-restart-2",
+	}
+	third := contracts.Envelope{
+		EventID:        "evt-restart-3",
+		Source:         "test",
+		SourceEventID:  "src-restart-3",
+		Topic:          "notifications.test.restart",
+		DedupeKey:      "dedupe-restart-3",
+		IssuedAt:       contracts.NowMillis(),
+		PayloadSummary: "third",
+		TraceID:        "trace-restart-3",
+	}
+	if err := publisher.Publish(second); err != nil {
+		t.Fatalf("publish second failed: %v", err)
+	}
+	if err := publisher.Publish(third); err != nil {
+		t.Fatalf("publish third failed: %v", err)
+	}
+
+	secondListener, err := bus.Connect([]string{sharedListenerTestNATSURI(t)}, bus.WithReplicas(1))
+	if err != nil {
+		t.Fatalf("failed to connect second listener bus: %v", err)
+	}
+	t.Cleanup(func() { secondListener.Conn.Close() })
+
+	resub, err := startListenerSubscription(secondListener, consumer, handler)
+	if err != nil {
+		t.Fatalf("second subscribe failed: %v", err)
+	}
+	defer resub.Unsubscribe()
+
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		count := len(delivered)
+		mu.Unlock()
+		if count == 3 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	mu.Lock()
+	got := append([]string(nil), delivered...)
+	mu.Unlock()
+	if len(got) != 3 {
+		t.Fatalf("expected durable consumer to resume pending messages after restart, got %d deliveries: %v", len(got), got)
+	}
+}
+
+func TestDeadSessionACK(t *testing.T) {
+	client := setupPublishTestClient(t)
+	sessions, err := session.OpenSessionRegistry(client.Conn, session.WithSessionReplicas(1))
+	if err != nil {
+		t.Fatalf("failed to open session registry: %v", err)
+	}
+
+	if shouldNAKFanoutDelivery(sessions, "ses_dead", errors.New("delivery failed")) {
+		t.Fatal("expected dead session fan-out failure to ACK instead of NAK")
+	}
+
+	portListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve port: %v", err)
+	}
+	port := portListener.Addr().(*net.TCPAddr).Port
+	if err := portListener.Close(); err != nil {
+		t.Fatalf("failed to release port: %v", err)
+	}
+	if err := sessions.Put("ses_live", session.SessionEntry{Port: port, MachineID: "test-machine", Dir: "/test"}); err != nil {
+		t.Fatalf("failed to register live session: %v", err)
+	}
+
+	if !shouldNAKFanoutDelivery(sessions, "ses_live", errors.New("delivery failed")) {
+		t.Fatal("expected live session delivery failure to NAK for retry")
+	}
+}
+
+func TestV1OnLegacyPort_WithTsnetEnabled(t *testing.T) {
+	// This test verifies that /v1/* endpoints are accessible on the legacy
+	// port (9020) even when tsnet is enabled. This is critical for local plugin
+	// registration via http://127.0.0.1:9020.
+	//
+	// The bug: when tsnet is enabled, /v1/* was ONLY served on the tsnet TLS
+	// listener (:443), blocking local plugin registration on the legacy port.
+	// The fix: always serve /v1/* on the legacy port regardless of tsnet status.
+
+	var state atomic.Pointer[listenerDeps]
+
+	// Build the mux as main() does, but with tsnet enabled.
+	// We simulate tsnet being enabled by NOT gating /v1/* on !tsCfg.Enabled.
+	mux := http.NewServeMux()
+
+	// /healthz is always reachable
+	mux.HandleFunc("/healthz", healthzHandler(&state))
+
+	// /v1/* sub-mux, gated by readiness
+	v1 := http.NewServeMux()
+	v1.HandleFunc("/v1/interests/subscribe", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"session_id":"test","topics":[]}`))
+	})
+
+	// THE FIX: Always register /v1/* on legacy mux, regardless of tsnet status.
+	// This is what the fix does — remove the `if !tsCfg.Enabled` gate.
+	mux.Handle("/v1/", readinessGate(func() bool { return state.Load() != nil }, v1))
+
+	// Simulate ready state
+	state.Store(&listenerDeps{})
+
+	// Test: /v1/interests/subscribe is reachable on legacy port
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/interests/subscribe", strings.NewReader(`{"session_id":"test","topics":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+}
+
+
+
+
+func TestHealthzConsumerLag(t *testing.T) {
+	natsURI := sharedListenerTestNATSURI(t)
+	conn, err := natsgo.Connect(natsURI)
+	if err != nil {
+		t.Fatalf("failed to connect to NATS: %v", err)
+	}
+	defer conn.Close()
+
+	resetListenerTestState(t, conn)
+
+	// Create a bus client
+	client, err := bus.Connect([]string{natsURI})
+	if err != nil {
+		t.Fatalf("failed to create bus client: %v", err)
+	}
+	defer client.Conn.Close()
+
+	// Create a consumer
+	consumerName := "listener-test-machine"
+	_, err = client.Subscribe(
+		"notifications.>",
+		func(msg *natsgo.Msg) { _ = msg.Ack() },
+		natsgo.Durable(consumerName),
+		natsgo.AckExplicit(),
+		natsgo.ManualAck(),
+	)
+	if err != nil {
+		t.Fatalf("failed to create subscription: %v", err)
+	}
+
+	// Get consumer info to verify it exists and has the expected fields
+	consumerInfo, err := client.JS().ConsumerInfo(bus.Stream, consumerName)
+	if err != nil {
+		t.Fatalf("failed to get consumer info: %v", err)
+	}
+
+	// Verify consumer info has the fields we need for /healthz
+	if consumerInfo == nil {
+		t.Fatal("expected consumer info, got nil")
+	}
+
+	// Simulate the /healthz handler response with consumer lag fields
+	response := map[string]interface{}{"status": "healthy"}
+	response["num_pending"] = consumerInfo.NumPending
+	response["num_ack_pending"] = consumerInfo.NumAckPending
+
+	// Verify the response contains the expected fields
+	if _, ok := response["num_pending"]; !ok {
+		t.Fatal("expected num_pending in response")
+	}
+	if _, ok := response["num_ack_pending"]; !ok {
+		t.Fatal("expected num_ack_pending in response")
+	}
+
+	// Verify the values are correct types
+	if response["num_pending"] != consumerInfo.NumPending {
+		t.Fatalf("expected num_pending %d, got %v", consumerInfo.NumPending, response["num_pending"])
+	}
+	if response["num_ack_pending"] != consumerInfo.NumAckPending {
+		t.Fatalf("expected num_ack_pending %d, got %v", consumerInfo.NumAckPending, response["num_ack_pending"])
+	}
+}
+
+func TestMetrics(t *testing.T) {
+	met := metrics.New()
+	received := met.NewCounter("envoy_messages_received_total", "Total messages received by the listener")
+	delivered := met.NewCounter("envoy_messages_delivered_total", "Total message delivery attempts")
+	naked := met.NewCounter("envoy_messages_naked_total", "Total messages NAK'd for retry")
+	duration := met.NewHistogram("envoy_delivery_duration_seconds", "Duration of message delivery attempts", metrics.DefaultBuckets)
+	met.NewGauge("envoy_active_sessions", "Number of active sessions")
+	met.NewGauge("envoy_active_interests", "Number of active interest subscriptions")
+	met.NewGaugeFunc("envoy_consumer_pending", "Number of pending messages in the consumer", func() int64 { return 5 })
+
+	// Simulate message processing.
+	received.Inc([2]string{"source", "agent"}, [2]string{"topic_prefix", "notifications.github"})
+	received.Inc([2]string{"source", "agent"}, [2]string{"topic_prefix", "notifications.github"})
+	delivered.Inc([2]string{"delivery_status", "delivered"})
+	naked.Inc()
+	duration.Observe(0.05, [2]string{"delivery_status", "delivered"})
+
+	rr := httptest.NewRecorder()
+	met.Handler().ServeHTTP(rr, httptest.NewRequest("GET", "/metrics", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	body := rr.Body.String()
+
+	// All 7 metric names must be present.
+	expected := []string{
+		"envoy_messages_received_total",
+		"envoy_messages_delivered_total",
+		"envoy_messages_naked_total",
+		"envoy_delivery_duration_seconds",
+		"envoy_active_sessions",
+		"envoy_active_interests",
+		"envoy_consumer_pending",
+	}
+	for _, name := range expected {
+		if !strings.Contains(body, name) {
+			t.Errorf("expected /metrics to contain %q, body:\n%s", name, body)
+		}
+	}
+
+	// Verify specific counter values.
+	if !strings.Contains(body, `envoy_messages_received_total{source="agent",topic_prefix="notifications.github"} 2`) {
+		t.Errorf("expected received_total to be 2, body:\n%s", body)
+	}
+	if !strings.Contains(body, `envoy_messages_delivered_total{delivery_status="delivered"} 1`) {
+		t.Errorf("expected delivered_total{delivered} to be 1, body:\n%s", body)
+	}
+	if !strings.Contains(body, `envoy_messages_naked_total 1`) {
+		t.Errorf("expected naked_total to be 1, body:\n%s", body)
+	}
+	if !strings.Contains(body, "envoy_consumer_pending 5") {
+		t.Errorf("expected consumer_pending gauge to be 5, body:\n%s", body)
+	}
+
+	// Prometheus text format.
+	ct := rr.Header().Get("Content-Type")
+	if !strings.Contains(ct, "text/plain") {
+		t.Errorf("expected text/plain Content-Type, got %q", ct)
+	}
+}
+
+func TestMetrics_NotGatedByReadiness(t *testing.T) {
+	var state atomic.Pointer[listenerDeps]
+	met := metrics.New()
+	met.NewGauge("envoy_active_sessions", "Number of active sessions")
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", met.Handler())
+	mux.Handle("/v1/", readinessGate(func() bool { return state.Load() != nil }, http.NewServeMux()))
+
+	// /metrics must return 200 before deps are set (startup).
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("GET", "/metrics", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected /metrics 200 during startup, got %d", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "envoy_active_sessions") {
+		t.Fatal("expected metric names in startup /metrics output")
+	}
+}
+
+func TestTopicPrefix(t *testing.T) {
+	cases := []struct {
+		topic string
+		want  string
+	}{
+		{"notifications.github.acme.widgets.issue.42.comment", "notifications.github"},
+		{"notifications.agent.ses_abc123", "notifications.agent"},
+		{"notifications.slack.T01.C02.message", "notifications.slack"},
+		{"single", "single"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		got := metrics.TopicPrefix(tc.topic)
+		if got != tc.want {
+			t.Errorf("TopicPrefix(%q) = %q, want %q", tc.topic, got, tc.want)
+		}
 	}
 }

--- a/packages/envoy/docker/Dockerfile
+++ b/packages/envoy/docker/Dockerfile
@@ -26,3 +26,5 @@ COPY --from=build /out/envoy-listener /usr/local/bin/envoy-listener
 # (WireGuard) and outbound TCP 443 (control plane).
 
 USER envoy
+
+ENTRYPOINT ["envoy-listener"]

--- a/packages/envoy/go.mod
+++ b/packages/envoy/go.mod
@@ -4,6 +4,7 @@ go 1.26.1
 
 require (
 	github.com/nats-io/nats.go v1.50.0
+	github.com/testcontainers/testcontainers-go v0.41.0
 	github.com/testcontainers/testcontainers-go/modules/nats v0.41.0
 	tailscale.com v1.96.5
 )
@@ -93,7 +94,6 @@ require (
 	github.com/tailscale/peercred v0.0.0-20250107143737-35a0c7bd7edc // indirect
 	github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976 // indirect
 	github.com/tailscale/wireguard-go v0.0.0-20250716170648-1d0488a3d7da // indirect
-	github.com/testcontainers/testcontainers-go v0.41.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/packages/envoy/internal/bus/nats.go
+++ b/packages/envoy/internal/bus/nats.go
@@ -3,7 +3,7 @@ package bus
 import (
 	"encoding/json"
 	"errors"
-	"log"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -64,29 +64,29 @@ func options(urls []string, reconnectCB func(*nats.Conn), closedCB func()) nats.
 		ReconnectWait: 2 * nats.DefaultReconnectWait,
 		DisconnectedErrCB: func(_ *nats.Conn, err error) {
 			if err != nil {
-				log.Printf("envoy nats disconnected: %v", err)
+			slog.Info("envoy nats disconnected", slog.String("error", err.Error()))
 				return
 			}
-			log.Printf("envoy nats disconnected")
+			slog.Info("envoy nats disconnected")
 		},
 		ReconnectedCB: func(nc *nats.Conn) {
-			log.Printf("envoy nats reconnected: %s", nc.ConnectedUrl())
+			slog.Info("envoy nats reconnected", slog.String("url", nc.ConnectedUrl()))
 			if reconnectCB != nil {
 				reconnectCB(nc)
 			}
 		},
 		ClosedCB: func(_ *nats.Conn) {
-			log.Printf("envoy nats connection closed")
+			slog.Info("envoy nats connection closed")
 			if closedCB != nil {
 				closedCB()
 			}
 		},
 		AsyncErrorCB: func(_ *nats.Conn, sub *nats.Subscription, err error) {
 			if sub != nil {
-				log.Printf("envoy nats async error subject=%s: %v", sub.Subject, err)
+				slog.Error("envoy nats async error", slog.String("subject", sub.Subject), slog.String("error", err.Error()))
 				return
 			}
-			log.Printf("envoy nats async error: %v", err)
+				slog.Error("envoy nats async error", slog.String("error", err.Error()))
 		},
 	}
 }
@@ -159,7 +159,7 @@ func (c *Client) onReconnect(nc *nats.Conn) {
 	js, err := nc.JetStream(nats.MaxWait(10 * time.Second))
 	if err != nil {
 		c.mu.Unlock()
-		log.Printf("envoy nats resubscribe failed (jetstream): %v", err)
+		slog.Error("envoy nats resubscribe failed (jetstream)", slog.String("error", err.Error()))
 		go c.recover()
 		return
 	}
@@ -171,15 +171,15 @@ func (c *Client) onReconnect(nc *nats.Conn) {
 	if c.subSubject == "" || c.subHandler == nil {
 		return
 	}
-	log.Printf("envoy nats resubscribing to %s", c.subSubject)
+		slog.Info("envoy nats resubscribing", slog.String("subject", c.subSubject))
 	sub, err := c.js.Subscribe(c.subSubject, c.subHandler, c.subOpts...)
 	if err != nil {
-		log.Printf("envoy nats resubscribe failed: %v", err)
+		slog.Error("envoy nats resubscribe failed", slog.String("error", err.Error()))
 		go c.recover()
 		return
 	}
 	c.subActive = sub
-	log.Printf("envoy nats resubscribed to %s", c.subSubject)
+		slog.Info("envoy nats resubscribed", slog.String("subject", c.subSubject))
 }
 
 // Subscribe creates a JetStream subscription that auto-resubscribes on reconnect.
@@ -238,7 +238,7 @@ func (c *Client) recover() {
 	for attempt := 1; ; attempt++ {
 		select {
 		case <-c.stopCh:
-			log.Printf("envoy nats recovery cancelled")
+			slog.Info("envoy nats recovery cancelled")
 			return
 		default:
 		}
@@ -252,15 +252,15 @@ func (c *Client) recover() {
 		needsSub := c.subSubject != "" && c.subHandler != nil
 		c.subMu.Unlock()
 		if connOK && (!needsSub || subOK) {
-			log.Printf("envoy nats recovery: already healthy")
+			slog.Info("envoy nats recovery: already healthy")
 			return
 		}
 
-		log.Printf("envoy nats recovery attempt %d", attempt)
+		slog.Info("envoy nats recovery attempt", slog.Int("attempt", attempt))
 
 		// Step 1: Ensure connection.
 		if err := c.ensureConn(); err != nil {
-			log.Printf("envoy nats recovery reconnect failed (attempt %d): %v", attempt, err)
+			slog.Error("envoy nats recovery reconnect failed", slog.Int("attempt", attempt), slog.String("error", err.Error()))
 			select {
 			case <-c.stopCh:
 				return
@@ -274,7 +274,7 @@ func (c *Client) recover() {
 		c.subMu.Lock()
 		if c.subSubject == "" || c.subHandler == nil {
 			c.subMu.Unlock()
-			log.Printf("envoy nats recovery: connection restored, no subscription to restore")
+			slog.Info("envoy nats recovery: connection restored, no subscription to restore")
 			return
 		}
 
@@ -284,11 +284,11 @@ func (c *Client) recover() {
 			c.subActive = nil
 		}
 
-		log.Printf("envoy nats recovery resubscribing to %s (attempt %d)", c.subSubject, attempt)
+		slog.Info("envoy nats recovery resubscribing", slog.String("subject", c.subSubject), slog.Int("attempt", attempt))
 		sub, err := c.js.Subscribe(c.subSubject, c.subHandler, c.subOpts...)
 		if err != nil {
 			c.subMu.Unlock()
-			log.Printf("envoy nats recovery resubscribe failed (attempt %d): %v", attempt, err)
+			slog.Error("envoy nats recovery resubscribe failed", slog.Int("attempt", attempt), slog.String("error", err.Error()))
 			select {
 			case <-c.stopCh:
 				return
@@ -299,7 +299,7 @@ func (c *Client) recover() {
 		}
 		c.subActive = sub
 		c.subMu.Unlock()
-		log.Printf("envoy nats recovery successful (attempt %d)", attempt)
+		slog.Info("envoy nats recovery successful", slog.Int("attempt", attempt))
 		return
 	}
 }

--- a/packages/envoy/internal/integration/delivery_test.go
+++ b/packages/envoy/internal/integration/delivery_test.go
@@ -244,7 +244,7 @@ func (env *testEnv) startConsumer(machineID string) {
 
 // --- TESTS ---
 
-func TestE2E_AgentMessageDeliveredExactlyOnce(t *testing.T) {
+func TestDelivery_AgentMessageDeliveredExactlyOnce(t *testing.T) {
 	env := setupTestEnv(t)
 	port, deliveries, _, _ := mockSession(t)
 	env.registerSession("ses_target", port, nil)
@@ -259,7 +259,7 @@ func TestE2E_AgentMessageDeliveredExactlyOnce(t *testing.T) {
 	}
 }
 
-func TestE2E_DuplicateEnvelopeDeduped(t *testing.T) {
+func TestDelivery_DuplicateEnvelopeDeduped(t *testing.T) {
 	env := setupTestEnv(t)
 	port, deliveries, _, _ := mockSession(t)
 	env.registerSession("ses_target", port, nil)
@@ -277,7 +277,7 @@ func TestE2E_DuplicateEnvelopeDeduped(t *testing.T) {
 	}
 }
 
-func TestE2E_BroadcastDeliveredToAllSubscribers(t *testing.T) {
+func TestDelivery_BroadcastDeliveredToAllSubscribers(t *testing.T) {
 	env := setupTestEnv(t)
 
 	port1, deliveries1, _, _ := mockSession(t)
@@ -298,7 +298,7 @@ func TestE2E_BroadcastDeliveredToAllSubscribers(t *testing.T) {
 	}
 }
 
-func TestE2E_BroadcastSkipsSender(t *testing.T) {
+func TestDelivery_BroadcastSkipsSender(t *testing.T) {
 	env := setupTestEnv(t)
 
 	portSender, deliveriesSender, _, _ := mockSession(t)
@@ -322,7 +322,7 @@ func TestE2E_BroadcastSkipsSender(t *testing.T) {
 	}
 }
 
-func TestE2E_BroadcastEmptySourceSessionDeliveredToAll(t *testing.T) {
+func TestDelivery_BroadcastEmptySourceSessionDeliveredToAll(t *testing.T) {
 	env := setupTestEnv(t)
 
 	port1, deliveries1, _, _ := mockSession(t)
@@ -346,7 +346,7 @@ func TestE2E_BroadcastEmptySourceSessionDeliveredToAll(t *testing.T) {
 	}
 }
 
-func TestE2E_DeliveryFailureRetries(t *testing.T) {
+func TestDelivery_DeliveryFailureRetries(t *testing.T) {
 	env := setupTestEnv(t)
 
 	// Start with a dead port (no mock server)
@@ -368,7 +368,7 @@ func TestE2E_DeliveryFailureRetries(t *testing.T) {
 	}
 }
 
-func TestE2E_NoRegistryEntryNoDelivery(t *testing.T) {
+func TestDelivery_NoRegistryEntryNoDelivery(t *testing.T) {
 	env := setupTestEnv(t)
 
 	env.registry.Upsert(store.Interest{
@@ -389,7 +389,7 @@ func TestE2E_NoRegistryEntryNoDelivery(t *testing.T) {
 	}
 }
 
-func TestE2E_PromptAsyncBodyContainsNotification(t *testing.T) {
+func TestDelivery_PromptAsyncBodyContainsNotification(t *testing.T) {
 	env := setupTestEnv(t)
 	port, _, bodies, _ := mockSession(t)
 	env.registerSession("ses_target", port, nil)
@@ -478,7 +478,7 @@ func TestRoleTransfer_ExactlyOneHolder(t *testing.T) {
 	t.Fatalf("timed out waiting for role transfer: A=%v B=%v matches=%v", a.Topics, b.Topics, matches)
 }
 
-func TestE2E_WildcardTopicMatching(t *testing.T) {
+func TestDelivery_WildcardTopicMatching(t *testing.T) {
 	env := setupTestEnv(t)
 	port, deliveries, _, _ := mockSession(t)
 	env.registerSession("ses_wildcard", port, []string{"notifications.slack.*.*.mention"})
@@ -492,7 +492,7 @@ func TestE2E_WildcardTopicMatching(t *testing.T) {
 	}
 }
 
-func TestE2E_UnsubscribeStopsDelivery(t *testing.T) {
+func TestDelivery_UnsubscribeStopsDelivery(t *testing.T) {
 	env := setupTestEnv(t)
 	port, deliveries, _, _ := mockSession(t)
 	broadcastTopic := "notifications.slack.T999.C999.mention"
@@ -520,7 +520,7 @@ func TestE2E_UnsubscribeStopsDelivery(t *testing.T) {
 	}
 }
 
-func TestE2E_ReplyToInBody(t *testing.T) {
+func TestDelivery_ReplyToInBody(t *testing.T) {
 	env := setupTestEnv(t)
 	port, _, bodies, _ := mockSession(t)
 	env.registerSession("ses_reply", port, nil)
@@ -553,7 +553,7 @@ func TestE2E_ReplyToInBody(t *testing.T) {
 	}
 }
 
-func TestE2E_SessionReRegistration(t *testing.T) {
+func TestDelivery_SessionReRegistration(t *testing.T) {
 	env := setupTestEnv(t)
 
 	portA, deliveriesA, _, _ := mockSession(t)
@@ -586,7 +586,7 @@ func TestE2E_SessionReRegistration(t *testing.T) {
 	}
 }
 
-func TestE2E_DedupeWindowExpiry(t *testing.T) {
+func TestDelivery_DedupeWindowExpiry(t *testing.T) {
 	env := setupTestEnv(t)
 	env.dedupe = dedupe.New(500 * time.Millisecond)
 
@@ -606,7 +606,7 @@ func TestE2E_DedupeWindowExpiry(t *testing.T) {
 	}
 }
 
-func TestE2E_MalformedEnvelope(t *testing.T) {
+func TestDelivery_MalformedEnvelope(t *testing.T) {
 	env := setupTestEnv(t)
 	port, deliveries, _, _ := mockSession(t)
 	env.registerSession("ses_healthy", port, []string{"notifications.test.*"})
@@ -636,7 +636,7 @@ func TestE2E_MalformedEnvelope(t *testing.T) {
 	}
 }
 
-func TestE2E_ConcurrentPublish(t *testing.T) {
+func TestDelivery_ConcurrentPublish(t *testing.T) {
 	env := setupTestEnv(t)
 	port, deliveries, _, _ := mockSession(t)
 	env.registerSession("ses_concurrent", port, []string{"notifications.slack.*.*.concurrent"})
@@ -658,7 +658,7 @@ func TestE2E_ConcurrentPublish(t *testing.T) {
 	}
 }
 
-func TestE2E_MaxDeliverExhaustion(t *testing.T) {
+func TestDelivery_MaxDeliverExhaustion(t *testing.T) {
 	env := setupTestEnv(t)
 
 	env.registry.Upsert(store.Interest{
@@ -706,7 +706,7 @@ func TestE2E_MaxDeliverExhaustion(t *testing.T) {
 
 // --- REGRESSION TESTS ---
 
-func TestE2E_NoAgentFieldInPromptAsync(t *testing.T) {
+func TestDelivery_NoAgentFieldInPromptAsync(t *testing.T) {
 	env := setupTestEnv(t)
 	port, deliveries, bodies, _ := mockSession(t)
 	env.registerSession("ses_noagent", port, nil)
@@ -747,7 +747,7 @@ func TestE2E_NoAgentFieldInPromptAsync(t *testing.T) {
 	}
 }
 
-func TestE2E_SessionWithKVAndInterestDeliveredOnce(t *testing.T) {
+func TestDelivery_SessionWithKVAndInterestDeliveredOnce(t *testing.T) {
 	env := setupTestEnv(t)
 	port, deliveries, _, _ := mockSession(t)
 
@@ -763,7 +763,7 @@ func TestE2E_SessionWithKVAndInterestDeliveredOnce(t *testing.T) {
 	}
 }
 
-func TestE2E_UnsubscribeEmptyTopicsDeletesAll(t *testing.T) {
+func TestDelivery_UnsubscribeEmptyTopicsDeletesAll(t *testing.T) {
 	env := setupTestEnv(t)
 	port, deliveries, _, _ := mockSession(t)
 	broadcastTopic := "notifications.slack.T888.C888.mention"
@@ -797,7 +797,7 @@ func TestE2E_UnsubscribeEmptyTopicsDeletesAll(t *testing.T) {
 	}
 }
 
-func TestE2E_StaleSubDedupeProtectsLiveSession(t *testing.T) {
+func TestDelivery_StaleSubDedupeProtectsLiveSession(t *testing.T) {
 	env := setupTestEnv(t)
 	broadcastTopic := "notifications.slack.*.*.mention"
 	concreteTopic := "notifications.slack.T777.C777.mention"
@@ -822,7 +822,7 @@ func TestE2E_StaleSubDedupeProtectsLiveSession(t *testing.T) {
 	}
 }
 
-func TestE2E_KVFirstDeliverySkipsFile(t *testing.T) {
+func TestDelivery_KVFirstDeliverySkipsFile(t *testing.T) {
 	env := setupTestEnv(t)
 
 	port, deliveries, _, _ := mockSession(t)
@@ -838,7 +838,7 @@ func TestE2E_KVFirstDeliverySkipsFile(t *testing.T) {
 	}
 }
 
-func TestE2E_BroadcastUsesKVPort(t *testing.T) {
+func TestDelivery_BroadcastUsesKVPort(t *testing.T) {
 	env := setupTestEnv(t)
 
 	port, deliveries, _, _ := mockSession(t)
@@ -854,7 +854,7 @@ func TestE2E_BroadcastUsesKVPort(t *testing.T) {
 	}
 }
 
-func TestE2E_KVEntryExpiresButInterestPersists(t *testing.T) {
+func TestDelivery_KVEntryExpiresButInterestPersists(t *testing.T) {
 	env := setupTestEnv(t, withSessionTTL(2*time.Second))
 
 	port, _, _, _ := mockSession(t)
@@ -882,7 +882,7 @@ func TestE2E_KVEntryExpiresButInterestPersists(t *testing.T) {
 	t.Fatal("KV entry did not expire within 5s (TTL was 2s)")
 }
 
-func TestE2E_ResumeDeliveryAfterReRegistration(t *testing.T) {
+func TestDelivery_ResumeDeliveryAfterReRegistration(t *testing.T) {
 	env := setupTestEnv(t, withSessionTTL(2*time.Second))
 
 	portA, deliveriesA, _, _ := mockSession(t)
@@ -917,7 +917,7 @@ func TestE2E_ResumeDeliveryAfterReRegistration(t *testing.T) {
 // TestE2E_CrossMachineAgentMessageACKsWithoutDelivery verifies that when an agent
 // message targets a session on machine-B, machine-A's listener ACKs (does not deliver
 // or NAK). This prevents wasting MaxDeliver budget on wrong-machine retries.
-func TestE2E_CrossMachineAgentMessageACKsWithoutDelivery(t *testing.T) {
+func TestDelivery_CrossMachineAgentMessageACKsWithoutDelivery(t *testing.T) {
 	env := setupTestEnv(t)
 	// Override deliverer machine ID to match the consumer's machine-A
 	env.deliverer.MachineID = "machine-A"
@@ -956,7 +956,7 @@ func TestE2E_CrossMachineAgentMessageACKsWithoutDelivery(t *testing.T) {
 
 // TestE2E_CrossMachineBroadcastFilteredByMatch verifies that broadcast messages
 // are only delivered to sessions on the local machine (registry.Match filters by machine_id).
-func TestE2E_CrossMachineBroadcastFilteredByMatch(t *testing.T) {
+func TestDelivery_CrossMachineBroadcastFilteredByMatch(t *testing.T) {
 	env := setupTestEnv(t)
 	// Override deliverer machine ID to match the consumer's machine-A
 	env.deliverer.MachineID = "machine-A"
@@ -1008,7 +1008,7 @@ func TestE2E_CrossMachineBroadcastFilteredByMatch(t *testing.T) {
 	}
 }
 
-func TestE2E_RegistryListReturnsSortedInterests(t *testing.T) {
+func TestDelivery_RegistryListReturnsSortedInterests(t *testing.T) {
 	env := setupTestEnv(t)
 
 	env.registerInterest("ses_charlie", []string{"notifications.test.>"})
@@ -1035,7 +1035,7 @@ func TestE2E_RegistryListReturnsSortedInterests(t *testing.T) {
 
 // --- WHATSAPP MCP BRIDGE INTEGRATION ---
 
-func TestE2E_WhatsappTopicRouting(t *testing.T) {
+func TestDelivery_WhatsappTopicRouting(t *testing.T) {
 	env := setupTestEnv(t)
 	port, deliveries, bodies, _ := mockSession(t)
 
@@ -1065,7 +1065,7 @@ func TestE2E_WhatsappTopicRouting(t *testing.T) {
 	}
 }
 
-func TestE2E_WhatsappDifferentPhoneNotDelivered(t *testing.T) {
+func TestDelivery_WhatsappDifferentPhoneNotDelivered(t *testing.T) {
 	env := setupTestEnv(t)
 	port, deliveries, _, _ := mockSession(t)
 
@@ -1083,7 +1083,7 @@ func TestE2E_WhatsappDifferentPhoneNotDelivered(t *testing.T) {
 	}
 }
 
-func TestE2E_WhatsappMultipleSubscribers(t *testing.T) {
+func TestDelivery_WhatsappMultipleSubscribers(t *testing.T) {
 	env := setupTestEnv(t)
 
 	port1, deliveries1, _, _ := mockSession(t)

--- a/packages/envoy/internal/integration/e2e_test.go
+++ b/packages/envoy/internal/integration/e2e_test.go
@@ -1,0 +1,483 @@
+package integration
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	natsgo "github.com/nats-io/nats.go"
+	"github.com/sjawhar/envoy/internal/bus"
+	"github.com/sjawhar/envoy/internal/contracts"
+	"github.com/sjawhar/envoy/internal/dedupe"
+	"github.com/sjawhar/envoy/internal/session"
+	"github.com/sjawhar/envoy/internal/store"
+)
+
+type deliveryEvent struct {
+	path string
+	body string
+}
+
+type sessionRecorder struct {
+	events chan deliveryEvent
+	port   int
+}
+
+func newSessionRecorder(t *testing.T) *sessionRecorder {
+	t.Helper()
+	recorder := &sessionRecorder{events: make(chan deliveryEvent, 32)}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read recorder body: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		recorder.events <- deliveryEvent{path: r.URL.Path, body: string(body)}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+	if _, err := fmt.Sscanf(srv.URL, "http://127.0.0.1:%d", &recorder.port); err != nil || recorder.port == 0 {
+		if _, err := fmt.Sscanf(srv.URL, "http://[::1]:%d", &recorder.port); err != nil || recorder.port == 0 {
+			t.Fatalf("parse recorder port from %q", srv.URL)
+		}
+	}
+	return recorder
+}
+
+func (r *sessionRecorder) expectDelivery(t *testing.T, timeout time.Duration) deliveryEvent {
+	t.Helper()
+	select {
+	case event := <-r.events:
+		return event
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for delivery")
+		return deliveryEvent{}
+	}
+}
+
+func (r *sessionRecorder) expectNoDelivery(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	select {
+	case event := <-r.events:
+		t.Fatalf("unexpected delivery: %+v", event)
+	case <-time.After(timeout):
+	}
+}
+
+type listenerHarness struct {
+	t            *testing.T
+	env          *testEnv
+	client       *bus.Client
+	machineID    string
+	consumer     string
+	dedupeCache  *dedupe.Cache
+	attemptCache *dedupe.Cache
+	nakDelay     time.Duration
+	sub          *natsgo.Subscription
+	once         sync.Once
+}
+
+func newListenerHarness(t *testing.T, env *testEnv, machineID, consumer string) *listenerHarness {
+	t.Helper()
+	client, err := bus.Connect([]string{env.client.Conn.ConnectedUrl()}, bus.WithReplicas(1))
+	if err != nil {
+		t.Fatalf("connect listener harness: %v", err)
+	}
+	h := &listenerHarness{
+		t:            t,
+		env:          env,
+		client:       client,
+		machineID:    machineID,
+		consumer:     consumer,
+		dedupeCache:  dedupe.New(5 * time.Minute),
+		attemptCache: dedupe.New(5 * time.Minute),
+		nakDelay:     50 * time.Millisecond,
+	}
+	t.Cleanup(h.close)
+	return h
+}
+
+func (h *listenerHarness) start() {
+	h.t.Helper()
+	if h.sub != nil {
+		return
+	}
+	sub, err := h.client.Subscribe(
+		"notifications.>",
+		h.handle,
+		natsgo.Durable(h.consumer),
+		natsgo.AckExplicit(),
+		natsgo.ManualAck(),
+		natsgo.AckWait(2*time.Second),
+		natsgo.MaxAckPending(256),
+		natsgo.MaxDeliver(20),
+	)
+	if err != nil {
+		h.t.Fatalf("subscribe listener harness: %v", err)
+	}
+	h.sub = sub
+	if err := h.client.Conn.FlushTimeout(2 * time.Second); err != nil {
+		h.t.Fatalf("flush subscribe: %v", err)
+	}
+}
+
+func (h *listenerHarness) close() {
+	h.once.Do(func() {
+		if h.sub != nil {
+			_ = h.sub.Unsubscribe()
+			h.sub = nil
+		}
+		if h.client != nil {
+			h.client.Close()
+		}
+	})
+}
+
+func (h *listenerHarness) handle(msg *natsgo.Msg) {
+	var item contracts.Envelope
+	if err := json.Unmarshal(msg.Data, &item); err != nil {
+		_ = msg.Ack()
+		return
+	}
+	if err := item.Validate(); err != nil {
+		_ = msg.Ack()
+		return
+	}
+	if item.Source == "agent" {
+		h.handleAgent(msg, item)
+		return
+	}
+	h.handleFanout(msg, item)
+}
+
+func (h *listenerHarness) handleAgent(msg *natsgo.Msg, item contracts.Envelope) {
+	sessionID := item.Topic[len(contracts.AgentTopicPrefix):]
+	if h.dedupeCache.Seen(item.DedupeKey, sessionID) {
+		_ = msg.Ack()
+		return
+	}
+	if h.attemptCache.Seen(item.DedupeKey, sessionID) {
+		_ = msg.Ack()
+		return
+	}
+	interest, err := h.env.registry.Get(sessionID)
+	var interestPtr *store.Interest
+	if err == nil {
+		interestPtr = &interest
+	}
+	h.attemptCache.Record(item.DedupeKey, sessionID)
+	result := session.HandleAgentMessage(item, sessionID, h.machineID, interestPtr, &h.env.deliverer)
+	if result.Delivered {
+		h.dedupeCache.Record(item.DedupeKey, sessionID)
+	}
+	if result.ShouldNAK {
+		_ = msg.NakWithDelay(h.nakDelay)
+		return
+	}
+	_ = msg.Ack()
+}
+
+func (h *listenerHarness) handleFanout(msg *natsgo.Msg, item contracts.Envelope) {
+	items := h.env.registry.Match(h.machineID, item.Topic)
+	if len(items) == 0 {
+		_ = msg.Ack()
+		return
+	}
+	var failed bool
+	for _, interest := range items {
+		if h.dedupeCache.Seen(item.DedupeKey, interest.SessionID) {
+			continue
+		}
+		if h.attemptCache.Seen(item.DedupeKey, interest.SessionID) {
+			continue
+		}
+		if item.SourceSession != "" && item.SourceSession == interest.SessionID {
+			continue
+		}
+		h.attemptCache.Record(item.DedupeKey, interest.SessionID)
+		if err := h.env.deliverer.Deliver(item, interest); err != nil {
+			if fanoutShouldNAK(h.env.sessions, interest.SessionID, err) {
+				failed = true
+			}
+			continue
+		}
+		h.dedupeCache.Record(item.DedupeKey, interest.SessionID)
+	}
+	if failed {
+		_ = msg.NakWithDelay(h.nakDelay)
+		return
+	}
+	_ = msg.Ack()
+}
+
+func fanoutShouldNAK(sessions session.SessionLookup, sessionID string, err error) bool {
+	if err == nil {
+		return false
+	}
+	_, getErr := sessions.Get(sessionID)
+	return getErr == nil
+}
+
+type mockSessionLookup struct {
+	entry session.SessionEntry
+	err   error
+}
+
+func (m *mockSessionLookup) Get(string) (session.SessionEntry, error) {
+	if m.err != nil {
+		return session.SessionEntry{}, m.err
+	}
+	return m.entry, nil
+}
+
+func (m *mockSessionLookup) Put(string, session.SessionEntry) error { return nil }
+
+func (m *mockSessionLookup) Delete(string) error { return nil }
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func waitUntil(t *testing.T, timeout time.Duration, desc string, fn func() bool) {
+	t.Helper()
+	if fn() {
+		return
+	}
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	timeoutCh := time.After(timeout)
+	for {
+		select {
+		case <-timeoutCh:
+			t.Fatalf("timed out waiting for %s", desc)
+		case <-ticker.C:
+			if fn() {
+				return
+			}
+		}
+	}
+}
+
+func waitForMatchCount(t *testing.T, env *testEnv, machineID, topic string, want int) {
+	t.Helper()
+	waitUntil(t, 5*time.Second, fmt.Sprintf("%d matches for %s", want, topic), func() bool {
+		return len(env.registry.Match(machineID, topic)) == want
+	})
+}
+
+func TestE2E_WebhookToSession(t *testing.T) {
+	env := setupTestEnv(t)
+	recorder := newSessionRecorder(t)
+	env.registerSession("ses_webhook", recorder.port, []string{"notifications.slack.*.*.mention"})
+	waitForMatchCount(t, env, "test-machine", "notifications.slack.T123.C456.mention", 1)
+
+	listener := newListenerHarness(t, env, "test-machine", "listener-webhook")
+	listener.start()
+
+	item := newEnvelope("slack", "notifications.slack.T123.C456.mention", "hello from slack", "dedupe-webhook")
+	item.SourceSession = "ses_origin"
+	publishEnvelope(env, item)
+
+	event := recorder.expectDelivery(t, 5*time.Second)
+	if event.path != "/session/ses_webhook/prompt_async" {
+		t.Fatalf("unexpected delivery path: %s", event.path)
+	}
+	if !strings.Contains(event.body, "hello from slack") {
+		t.Fatalf("delivery body missing webhook payload: %s", event.body)
+	}
+	if !strings.Contains(event.body, item.Topic) {
+		t.Fatalf("delivery body missing topic: %s", event.body)
+	}
+	recorder.expectNoDelivery(t, 300*time.Millisecond)
+}
+
+func TestE2E_AgentToAgent_LocalMachine(t *testing.T) {
+	env := setupTestEnv(t)
+	recorder := newSessionRecorder(t)
+	env.registerSession("ses_local", recorder.port, nil)
+
+	listener := newListenerHarness(t, env, "test-machine", "listener-agent-local")
+	listener.start()
+
+	item := newEnvelope("agent", contracts.AgentSubject("ses_local"), "private hello", "dedupe-agent-local")
+	item.SourceSession = "ses_sender"
+	publishEnvelope(env, item)
+
+	event := recorder.expectDelivery(t, 5*time.Second)
+	if event.path != "/session/ses_local/prompt_async" {
+		t.Fatalf("unexpected delivery path: %s", event.path)
+	}
+	if !strings.Contains(event.body, "private hello") {
+		t.Fatalf("delivery body missing agent payload: %s", event.body)
+	}
+	if !strings.Contains(event.body, "ses_sender") || !strings.Contains(event.body, "reply to this message") {
+		t.Fatalf("delivery body missing reply instruction: %s", event.body)
+	}
+	recorder.expectNoDelivery(t, 300*time.Millisecond)
+}
+
+func TestE2E_AgentToAgent_RemoteMachine(t *testing.T) {
+	env := setupTestEnv(t)
+	defer func(original session.SessionLookup, originalClient *http.Client) {
+		env.deliverer.Sessions = original
+		env.deliverer.HTTPClient = originalClient
+	}(env.deliverer.Sessions, env.deliverer.HTTPClient)
+
+	env.deliverer.Sessions = &mockSessionLookup{entry: session.SessionEntry{Port: 7777, MachineID: "remote-machine", Dir: "/remote"}}
+	env.deliverer.HTTPClient = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Hostname() != "remote-machine" {
+			t.Fatalf("expected remote-machine host, got %s", r.URL.Hostname())
+		}
+		return nil, session.ErrWrongMachine
+	})}
+	if _, err := env.registry.Upsert(store.Interest{SessionID: "ses_remote", MachineID: "remote-machine", Dir: "/remote"}, []string{contracts.AgentSubject("ses_remote")}); err != nil {
+		t.Fatalf("upsert remote interest: %v", err)
+	}
+
+	listener := newListenerHarness(t, env, "test-machine", "listener-agent-remote")
+	listener.start()
+
+	publishEnvelope(env, newEnvelope("agent", contracts.AgentSubject("ses_remote"), "remote hello", "dedupe-agent-remote"))
+
+	waitUntil(t, 5*time.Second, "remote agent message acked", func() bool {
+		consumerInfo, err := listener.client.JS().ConsumerInfo(bus.Stream, listener.consumer)
+		if err != nil {
+			return false
+		}
+		return consumerInfo.NumPending == 0 && consumerInfo.AckFloor.Consumer > 0
+	})
+}
+
+func TestE2E_RestartResilience(t *testing.T) {
+	env := setupTestEnv(t)
+	recorder := newSessionRecorder(t)
+	env.registerSession("ses_restart", recorder.port, []string{"notifications.slack.*.*.mention"})
+	waitForMatchCount(t, env, "test-machine", "notifications.slack.T10.C10.mention", 1)
+
+	listenerA := newListenerHarness(t, env, "test-machine", "listener-restart")
+	listenerA.start()
+	publishEnvelope(env, newEnvelope("slack", "notifications.slack.T10.C10.mention", "before restart", "dedupe-restart-1"))
+	first := recorder.expectDelivery(t, 5*time.Second)
+	if !strings.Contains(first.body, "before restart") {
+		t.Fatalf("first delivery body mismatch: %s", first.body)
+	}
+	listenerA.close()
+
+	publishEnvelope(env, newEnvelope("slack", "notifications.slack.T10.C10.mention", "during downtime 1", "dedupe-restart-2"))
+	publishEnvelope(env, newEnvelope("slack", "notifications.slack.T10.C10.mention", "during downtime 2", "dedupe-restart-3"))
+
+	listenerB := newListenerHarness(t, env, "test-machine", "listener-restart")
+	listenerB.start()
+
+	seen := map[string]bool{}
+	for len(seen) < 2 {
+		event := recorder.expectDelivery(t, 5*time.Second)
+		if strings.Contains(event.body, "during downtime 1") {
+			seen["during downtime 1"] = true
+		}
+		if strings.Contains(event.body, "during downtime 2") {
+			seen["during downtime 2"] = true
+		}
+	}
+
+	publishEnvelope(env, newEnvelope("slack", "notifications.slack.T10.C10.mention", "after restart", "dedupe-restart-4"))
+	event := recorder.expectDelivery(t, 5*time.Second)
+	if !strings.Contains(event.body, "after restart") {
+		t.Fatalf("expected post-restart delivery, got: %s", event.body)
+	}
+	recorder.expectNoDelivery(t, 300*time.Millisecond)
+}
+
+func TestE2E_DeadSessionFanout(t *testing.T) {
+	env := setupTestEnv(t)
+	recorder := newSessionRecorder(t)
+	broadcastTopic := "notifications.slack.*.*.mention"
+	concreteTopic := "notifications.slack.T20.C20.mention"
+	env.registerSession("ses_live", recorder.port, []string{broadcastTopic})
+	if _, err := env.registry.Upsert(store.Interest{SessionID: "ses_dead", MachineID: "test-machine", Dir: "/dead"}, []string{broadcastTopic}); err != nil {
+		t.Fatalf("upsert dead interest: %v", err)
+	}
+	waitForMatchCount(t, env, "test-machine", concreteTopic, 2)
+
+	listener := newListenerHarness(t, env, "test-machine", "listener-dead-fanout")
+	listener.start()
+
+	publishEnvelope(env, newEnvelope("slack", concreteTopic, "fanout payload", "dedupe-dead-fanout"))
+	event := recorder.expectDelivery(t, 5*time.Second)
+	if !strings.Contains(event.body, "fanout payload") {
+		t.Fatalf("live session body mismatch: %s", event.body)
+	}
+	recorder.expectNoDelivery(t, 300*time.Millisecond)
+}
+
+func TestE2E_IdempotencyKey(t *testing.T) {
+	env := setupTestEnv(t)
+	recorder := newSessionRecorder(t)
+	env.registerSession("ses_idempotent", recorder.port, nil)
+
+	listener := newListenerHarness(t, env, "test-machine", "listener-idempotent")
+	listener.start()
+
+	item := newEnvelope("agent", contracts.AgentSubject("ses_idempotent"), "only once", "dedupe-idempotent")
+	publishEnvelope(env, item)
+	publishEnvelope(env, item)
+
+	event := recorder.expectDelivery(t, 5*time.Second)
+	if !strings.Contains(event.body, "only once") {
+		t.Fatalf("delivery body mismatch: %s", event.body)
+	}
+	recorder.expectNoDelivery(t, 300*time.Millisecond)
+}
+
+func TestE2E_InterestReaperCleanup(t *testing.T) {
+	env := setupTestEnv(t)
+	if _, err := env.registry.Upsert(store.Interest{SessionID: "ses_stale", MachineID: "test-machine", Dir: "/stale"}, []string{"notifications.slack.*.*.mention"}); err != nil {
+		t.Fatalf("upsert stale interest: %v", err)
+	}
+
+	interest, err := env.registry.Get("ses_stale")
+	if err != nil {
+		t.Fatalf("get stale interest: %v", err)
+	}
+	interest.UpdatedAt = time.Now().Add(-11 * time.Minute).UnixMilli()
+	data, err := json.Marshal(interest)
+	if err != nil {
+		t.Fatalf("marshal stale interest: %v", err)
+	}
+	js, err := env.client.Conn.JetStream(natsgo.MaxWait(5 * time.Second))
+	if err != nil {
+		t.Fatalf("jetstream: %v", err)
+	}
+	kv, err := js.KeyValue(store.Bucket)
+	if err != nil {
+		t.Fatalf("open kv bucket: %v", err)
+	}
+	if _, err := kv.Put("ses_stale", data); err != nil {
+		t.Fatalf("put stale interest: %v", err)
+	}
+	waitUntil(t, 5*time.Second, "stale cache update", func() bool {
+		current, getErr := env.registry.Get("ses_stale")
+		return getErr == nil && current.UpdatedAt == interest.UpdatedAt
+	})
+
+	reaped, err := env.registry.Reap(func(string) bool { return false }, 10*time.Minute)
+	if err != nil {
+		t.Fatalf("reap stale interests: %v", err)
+	}
+	if reaped != 1 {
+		t.Fatalf("expected 1 reaped interest, got %d", reaped)
+	}
+	waitUntil(t, 5*time.Second, "stale interest deletion", func() bool {
+		_, getErr := env.registry.Get("ses_stale")
+		return getErr != nil && errors.Is(getErr, natsgo.ErrKeyNotFound)
+	})
+}

--- a/packages/envoy/internal/logging/logging.go
+++ b/packages/envoy/internal/logging/logging.go
@@ -1,0 +1,72 @@
+package logging
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"time"
+)
+
+// Logger wraps slog with structured JSON output.
+type Logger struct {
+	machineID string
+	logger    *slog.Logger
+}
+
+// New creates a new structured logger with the given machine ID.
+func New(machineID string) *Logger {
+	handler := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})
+	return &Logger{
+		machineID: machineID,
+		logger:    slog.New(handler),
+	}
+}
+
+// LogEvent logs a structured event with required fields.
+func (l *Logger) LogEvent(level slog.Level, msg string, attrs ...slog.Attr) {
+	attrs = append([]slog.Attr{
+		slog.String("machine_id", l.machineID),
+		slog.String("ts", time.Now().UTC().Format(time.RFC3339Nano)),
+	}, attrs...)
+	l.logger.LogAttrs(nil, level, msg, attrs...)
+}
+
+// Info logs an info-level event.
+func (l *Logger) Info(msg string, attrs ...slog.Attr) {
+	l.LogEvent(slog.LevelInfo, msg, attrs...)
+}
+
+// Warn logs a warning-level event.
+func (l *Logger) Warn(msg string, attrs ...slog.Attr) {
+	l.LogEvent(slog.LevelWarn, msg, attrs...)
+}
+
+// Error logs an error-level event.
+func (l *Logger) Error(msg string, attrs ...slog.Attr) {
+	l.LogEvent(slog.LevelError, msg, attrs...)
+}
+
+// DeliveryLog logs a delivery event with status.
+func (l *Logger) DeliveryLog(level slog.Level, msg string, sessionID, topic, eventID, status string, attrs ...slog.Attr) {
+	deliveryAttrs := []slog.Attr{
+		slog.String("session_id", sessionID),
+		slog.String("topic", topic),
+		slog.String("event_id", eventID),
+		slog.String("delivery_status", status),
+	}
+	deliveryAttrs = append(deliveryAttrs, attrs...)
+	l.LogEvent(level, msg, deliveryAttrs...)
+}
+
+// RawJSON writes raw JSON to stderr (for compatibility with existing patterns).
+// This is used when we need to emit JSON without slog's automatic formatting.
+func RawJSON(data map[string]interface{}) error {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	_, err = os.Stderr.Write(append(b, '\n'))
+	return err
+}

--- a/packages/envoy/internal/logging/logging_test.go
+++ b/packages/envoy/internal/logging/logging_test.go
@@ -1,0 +1,128 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestLoggerOutputsValidJSON(t *testing.T) {
+	// Capture stderr
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	logger := New("test-machine")
+	logger.Info("test message", slog.String("key", "value"))
+
+	w.Close()
+	os.Stderr = oldStderr
+
+	// Read captured output
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Parse as JSON
+	var logEntry map[string]interface{}
+	if err := json.Unmarshal([]byte(output), &logEntry); err != nil {
+		t.Fatalf("log output is not valid JSON: %v\nOutput: %s", err, output)
+	}
+
+	// Verify required fields
+	if logEntry["machine_id"] != "test-machine" {
+		t.Errorf("expected machine_id=test-machine, got %v", logEntry["machine_id"])
+	}
+	if logEntry["level"] != "INFO" {
+		t.Errorf("expected level=INFO, got %v", logEntry["level"])
+	}
+	if logEntry["msg"] != "test message" {
+		t.Errorf("expected msg=test message, got %v", logEntry["msg"])
+	}
+	if logEntry["key"] != "value" {
+		t.Errorf("expected key=value, got %v", logEntry["key"])
+	}
+
+	// Verify timestamp is ISO 8601
+	ts, ok := logEntry["ts"].(string)
+	if !ok {
+		t.Fatalf("ts field is not a string: %v", logEntry["ts"])
+	}
+	if _, err := time.Parse(time.RFC3339Nano, ts); err != nil {
+		t.Errorf("ts is not valid ISO 8601: %v", err)
+	}
+}
+
+func TestDeliveryLogIncludesDeliveryFields(t *testing.T) {
+	// Capture stderr
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	logger := New("test-machine")
+	logger.DeliveryLog(slog.LevelInfo, "delivery test", "session-123", "topic.test", "event-456", "delivered")
+
+	w.Close()
+	os.Stderr = oldStderr
+
+	// Read captured output
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Parse as JSON
+	var logEntry map[string]interface{}
+	if err := json.Unmarshal([]byte(output), &logEntry); err != nil {
+		t.Fatalf("log output is not valid JSON: %v\nOutput: %s", err, output)
+	}
+
+	// Verify delivery-specific fields
+	if logEntry["session_id"] != "session-123" {
+		t.Errorf("expected session_id=session-123, got %v", logEntry["session_id"])
+	}
+	if logEntry["topic"] != "topic.test" {
+		t.Errorf("expected topic=topic.test, got %v", logEntry["topic"])
+	}
+	if logEntry["event_id"] != "event-456" {
+		t.Errorf("expected event_id=event-456, got %v", logEntry["event_id"])
+	}
+	if logEntry["delivery_status"] != "delivered" {
+		t.Errorf("expected delivery_status=delivered, got %v", logEntry["delivery_status"])
+	}
+
+	// Verify base fields still present
+	if logEntry["machine_id"] != "test-machine" {
+		t.Errorf("expected machine_id=test-machine, got %v", logEntry["machine_id"])
+	}
+}
+
+func TestLoggerErrorLevel(t *testing.T) {
+	// Capture stderr
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	logger := New("test-machine")
+	logger.Error("error message", slog.String("error", "test error"))
+
+	w.Close()
+	os.Stderr = oldStderr
+
+	// Read captured output
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Parse as JSON
+	var logEntry map[string]interface{}
+	if err := json.Unmarshal([]byte(output), &logEntry); err != nil {
+		t.Fatalf("log output is not valid JSON: %v\nOutput: %s", err, output)
+	}
+
+	if logEntry["level"] != "ERROR" {
+		t.Errorf("expected level=ERROR, got %v", logEntry["level"])
+	}
+}

--- a/packages/envoy/internal/metrics/metrics.go
+++ b/packages/envoy/internal/metrics/metrics.go
@@ -1,0 +1,345 @@
+// Package metrics provides minimal Prometheus-compatible metrics without
+// third-party dependencies. It supports counters (with labels), histograms
+// (with labels and configurable buckets), gauges, and gauge functions
+// evaluated at scrape time.
+package metrics
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// TopicPrefix returns the first two dot-separated segments of a topic.
+// E.g. "notifications.github.acme.widgets.issue.42.comment" → "notifications.github".
+func TopicPrefix(topic string) string {
+	parts := strings.SplitN(topic, ".", 3)
+	if len(parts) >= 2 {
+		return parts[0] + "." + parts[1]
+	}
+	return topic
+}
+
+// DefaultBuckets are the standard histogram buckets for delivery duration.
+var DefaultBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+
+// Registry collects metrics and serves them in Prometheus text exposition format.
+type Registry struct {
+	mu         sync.RWMutex
+	counters   []*Counter
+	histograms []*Histogram
+	gauges     []*Gauge
+	gaugeFuncs []*GaugeFunc
+}
+
+// New creates an empty metrics registry.
+func New() *Registry { return &Registry{} }
+
+// ---------------------------------------------------------------------------
+// Counter
+// ---------------------------------------------------------------------------
+
+// Counter is a monotonically increasing metric with optional labels.
+type Counter struct {
+	name   string
+	help   string
+	mu     sync.Mutex
+	series map[string]*counterEntry
+}
+
+type counterEntry struct {
+	formatted string // pre-rendered label string, e.g. `{source="agent"}`
+	value     atomic.Int64
+}
+
+// NewCounter creates, registers, and returns a new counter.
+func (r *Registry) NewCounter(name, help string) *Counter {
+	c := &Counter{name: name, help: help, series: make(map[string]*counterEntry)}
+	r.mu.Lock()
+	r.counters = append(r.counters, c)
+	r.mu.Unlock()
+	return c
+}
+
+// Inc increments the counter for the given label set by 1.
+func (c *Counter) Inc(labels ...[2]string) {
+	key := labelKey(labels)
+	c.mu.Lock()
+	e, ok := c.series[key]
+	if !ok {
+		e = &counterEntry{formatted: labelFormat(labels)}
+		c.series[key] = e
+	}
+	c.mu.Unlock()
+	e.value.Add(1)
+}
+
+// ---------------------------------------------------------------------------
+// Histogram
+// ---------------------------------------------------------------------------
+
+// Histogram records the distribution of observed values in pre-defined buckets.
+type Histogram struct {
+	name   string
+	help   string
+	bounds []float64
+	mu     sync.Mutex
+	series map[string]*histEntry
+}
+
+type histEntry struct {
+	formatted string // pre-rendered label string
+	buckets   []*atomic.Int64
+	count     atomic.Int64
+	sumBits   atomic.Uint64 // float64 stored as bits for lock-free CAS
+}
+
+// NewHistogram creates, registers, and returns a new histogram.
+func (r *Registry) NewHistogram(name, help string, buckets []float64) *Histogram {
+	b := make([]float64, len(buckets))
+	copy(b, buckets)
+	sort.Float64s(b)
+	h := &Histogram{name: name, help: help, bounds: b, series: make(map[string]*histEntry)}
+	r.mu.Lock()
+	r.histograms = append(r.histograms, h)
+	r.mu.Unlock()
+	return h
+}
+
+// Observe records a value in the histogram for the given label set.
+func (h *Histogram) Observe(value float64, labels ...[2]string) {
+	key := labelKey(labels)
+	h.mu.Lock()
+	e, ok := h.series[key]
+	if !ok {
+		bc := make([]*atomic.Int64, len(h.bounds))
+		for i := range bc {
+			bc[i] = &atomic.Int64{}
+		}
+		e = &histEntry{formatted: labelFormat(labels), buckets: bc}
+		h.series[key] = e
+	}
+	h.mu.Unlock()
+
+	// Increment only the first matching bucket (non-cumulative storage).
+	for i, bound := range h.bounds {
+		if value <= bound {
+			e.buckets[i].Add(1)
+			break
+		}
+	}
+	e.count.Add(1)
+	// CAS loop for atomic float64 addition.
+	for {
+		old := e.sumBits.Load()
+		if e.sumBits.CompareAndSwap(old, math.Float64bits(math.Float64frombits(old)+value)) {
+			break
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Gauge
+// ---------------------------------------------------------------------------
+
+// Gauge is a metric that can increase and decrease.
+type Gauge struct {
+	name  string
+	help  string
+	value atomic.Int64
+}
+
+// NewGauge creates, registers, and returns a new gauge.
+func (r *Registry) NewGauge(name, help string) *Gauge {
+	g := &Gauge{name: name, help: help}
+	r.mu.Lock()
+	r.gauges = append(r.gauges, g)
+	r.mu.Unlock()
+	return g
+}
+
+// Set stores v as the current gauge value.
+func (g *Gauge) Set(v int64) { g.value.Store(v) }
+
+// Inc adds 1 to the gauge.
+func (g *Gauge) Inc() { g.value.Add(1) }
+
+// Dec subtracts 1 from the gauge.
+func (g *Gauge) Dec() { g.value.Add(-1) }
+
+// ---------------------------------------------------------------------------
+// GaugeFunc
+// ---------------------------------------------------------------------------
+
+// GaugeFunc evaluates fn at scrape time to produce a gauge value.
+type GaugeFunc struct {
+	name string
+	help string
+	fn   func() int64
+}
+
+// NewGaugeFunc registers a gauge whose value is computed by fn on each scrape.
+func (r *Registry) NewGaugeFunc(name, help string, fn func() int64) {
+	r.mu.Lock()
+	r.gaugeFuncs = append(r.gaugeFuncs, &GaugeFunc{name: name, help: help, fn: fn})
+	r.mu.Unlock()
+}
+
+// ---------------------------------------------------------------------------
+// Timer
+// ---------------------------------------------------------------------------
+
+// Timer measures elapsed time for histogram observations.
+type Timer struct{ start time.Time }
+
+// NewTimer starts a new timer.
+func NewTimer() Timer { return Timer{start: time.Now()} }
+
+// ObserveDuration records the elapsed seconds since the timer was created.
+func (t Timer) ObserveDuration(h *Histogram, labels ...[2]string) {
+	h.Observe(time.Since(t.start).Seconds(), labels...)
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+// Handler returns an http.Handler that writes all registered metrics in
+// Prometheus text exposition format (text/plain; version=0.0.4).
+func (r *Registry) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+		r.mu.RLock()
+		defer r.mu.RUnlock()
+
+		for _, c := range r.counters {
+			writeType(w, c.name, c.help, "counter")
+			c.mu.Lock()
+			for _, key := range sortedKeys(c.series) {
+				e := c.series[key]
+				fmt.Fprintf(w, "%s%s %d\n", c.name, e.formatted, e.value.Load())
+			}
+			c.mu.Unlock()
+		}
+
+		for _, h := range r.histograms {
+			writeType(w, h.name, h.help, "histogram")
+			h.mu.Lock()
+			for _, key := range sortedKeys(h.series) {
+				e := h.series[key]
+				inner := stripBraces(e.formatted)
+				var cum int64
+				for i, bound := range h.bounds {
+					cum += e.buckets[i].Load()
+					writeBucket(w, h.name, inner, bound, cum)
+				}
+				total := e.count.Load()
+				sum := math.Float64frombits(e.sumBits.Load())
+				writeInfBucket(w, h.name, inner, total)
+				writeSumCount(w, h.name, inner, sum, total)
+			}
+			h.mu.Unlock()
+		}
+
+		for _, g := range r.gauges {
+			writeType(w, g.name, g.help, "gauge")
+			fmt.Fprintf(w, "%s %d\n", g.name, g.value.Load())
+		}
+
+		for _, gf := range r.gaugeFuncs {
+			writeType(w, gf.name, gf.help, "gauge")
+			fmt.Fprintf(w, "%s %d\n", gf.name, gf.fn())
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+func writeType(w http.ResponseWriter, name, help, typ string) {
+	fmt.Fprintf(w, "# HELP %s %s\n", name, help)
+	fmt.Fprintf(w, "# TYPE %s %s\n", name, typ)
+}
+
+func writeBucket(w http.ResponseWriter, name, inner string, le float64, cum int64) {
+	if inner != "" {
+		fmt.Fprintf(w, "%s_bucket{%s,le=\"%g\"} %d\n", name, inner, le, cum)
+	} else {
+		fmt.Fprintf(w, "%s_bucket{le=\"%g\"} %d\n", name, le, cum)
+	}
+}
+
+func writeInfBucket(w http.ResponseWriter, name, inner string, total int64) {
+	if inner != "" {
+		fmt.Fprintf(w, "%s_bucket{%s,le=\"+Inf\"} %d\n", name, inner, total)
+	} else {
+		fmt.Fprintf(w, "%s_bucket{le=\"+Inf\"} %d\n", name, total)
+	}
+}
+
+func writeSumCount(w http.ResponseWriter, name, inner string, sum float64, count int64) {
+	if inner != "" {
+		fmt.Fprintf(w, "%s_sum{%s} %g\n", name, inner, sum)
+		fmt.Fprintf(w, "%s_count{%s} %d\n", name, inner, count)
+	} else {
+		fmt.Fprintf(w, "%s_sum %g\n", name, sum)
+		fmt.Fprintf(w, "%s_count %d\n", name, count)
+	}
+}
+
+func labelKey(labels [][2]string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i, kv := range labels {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(kv[0])
+		b.WriteByte('=')
+		b.WriteString(kv[1])
+	}
+	return b.String()
+}
+
+func labelFormat(labels [][2]string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, kv := range labels {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(kv[0])
+		b.WriteString(`="`)
+		b.WriteString(kv[1])
+		b.WriteByte('"')
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
+func stripBraces(s string) string {
+	if len(s) >= 2 && s[0] == '{' && s[len(s)-1] == '}' {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/packages/envoy/internal/session/handler_test.go
+++ b/packages/envoy/internal/session/handler_test.go
@@ -1,4 +1,4 @@
-package session
+package session_test
 
 import (
 	"net/http"
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	session "github.com/sjawhar/envoy/internal/session"
 	"github.com/sjawhar/envoy/internal/store"
 )
 
@@ -23,7 +24,7 @@ func TestHandleAgentMessage_DeliveredExactlyOnce(t *testing.T) {
 
 	port := mockPort(mock.URL)
 	sessions, deliverer := newKVDeliverer(t)
-	if err := sessions.Put("ses_target", SessionEntry{Port: port, Dir: "/test"}); err != nil {
+	if err := sessions.Put("ses_target", session.SessionEntry{Port: port, Dir: "/test"}); err != nil {
 		t.Fatalf("failed to register session: %v", err)
 	}
 
@@ -37,7 +38,7 @@ func TestHandleAgentMessage_DeliveredExactlyOnce(t *testing.T) {
 
 	item := newTestEnvelope("agent", "notifications.agent.ses_target", "test message")
 
-	result := HandleAgentMessage(item, "ses_target", "test-machine", interest, &deliverer)
+	result := session.HandleAgentMessage(item, "ses_target", "test-machine", interest, &deliverer)
 
 	if result.Err != nil {
 		t.Fatalf("expected success, got error: %v", result.Err)
@@ -63,12 +64,12 @@ func TestHandleAgentMessage_FallbackWhenNoInterest(t *testing.T) {
 
 	port := mockPort(mock.URL)
 	sessions, deliverer := newKVDeliverer(t)
-	if err := sessions.Put("ses_target", SessionEntry{Port: port, Dir: "/test"}); err != nil {
+	if err := sessions.Put("ses_target", session.SessionEntry{Port: port, Dir: "/test"}); err != nil {
 		t.Fatalf("failed to register session: %v", err)
 	}
 
 	// No interest entry — handler should fall through to registry lookup
-	result := HandleAgentMessage(
+	result := session.HandleAgentMessage(
 		newTestEnvelope("agent", "notifications.agent.ses_target", "test"),
 		"ses_target", "test-machine", nil, &deliverer,
 	)
@@ -89,7 +90,7 @@ func TestHandleAgentMessage_FallbackWhenNoInterest(t *testing.T) {
 func TestHandleAgentMessage_UnknownSession(t *testing.T) {
 	_, deliverer := newKVDeliverer(t)
 
-	result := HandleAgentMessage(
+	result := session.HandleAgentMessage(
 		newTestEnvelope("agent", "notifications.agent.ses_unknown", "test"),
 		"ses_unknown", "test-machine", nil, &deliverer,
 	)
@@ -117,7 +118,7 @@ func TestHandleAgentMessage_WrongMachine(t *testing.T) {
 
 	port := mockPort(mock.URL)
 	sessions, deliverer := newKVDeliverer(t)
-	if err := sessions.Put("ses_target", SessionEntry{Port: port, Dir: "/test"}); err != nil {
+	if err := sessions.Put("ses_target", session.SessionEntry{Port: port, Dir: "/test"}); err != nil {
 		t.Fatalf("failed to register session: %v", err)
 	}
 
@@ -128,7 +129,7 @@ func TestHandleAgentMessage_WrongMachine(t *testing.T) {
 		MachineID: "other-machine",
 	}
 
-	result := HandleAgentMessage(
+	result := session.HandleAgentMessage(
 		newTestEnvelope("agent", "notifications.agent.ses_target", "test"),
 		"ses_target", "test-machine", interest, &deliverer,
 	)
@@ -159,14 +160,14 @@ func TestHandleAgentMessage_WrongMachineKVAcks(t *testing.T) {
 	port := mockPort(mock.URL)
 
 	client := setupNATS(t)
-	sessions, err := OpenSessionRegistry(client.Conn, WithSessionReplicas(1), WithSessionTTL(10*time.Second))
+	sessions, err := session.OpenSessionRegistry(client.Conn, session.WithSessionReplicas(1), session.WithSessionTTL(10*time.Second))
 	if err != nil {
 		t.Fatalf("failed to open session registry: %v", err)
 	}
 	// KV says session is on unreachable machine-B
-	sessions.Put("ses_target", SessionEntry{Port: port, MachineID: "machine-B", Dir: "/test"})
+	sessions.Put("ses_target", session.SessionEntry{Port: port, MachineID: "machine-B", Dir: "/test"})
 
-	deliverer := Deliverer{
+	deliverer := session.Deliverer{
 		MachineID:    "machine-A",
 		HostBridge:   "127.0.0.1",
 		RequestLimit: 5 * time.Second,
@@ -174,7 +175,7 @@ func TestHandleAgentMessage_WrongMachineKVAcks(t *testing.T) {
 	}
 
 	// No interest — handler falls to registry lookup path
-	result := HandleAgentMessage(
+	result := session.HandleAgentMessage(
 		newTestEnvelope("agent", "notifications.agent.ses_target", "test"),
 		"ses_target", "machine-A", nil, &deliverer,
 	)
@@ -208,14 +209,14 @@ func TestHandleAgentMessage_InterestPathWrongMachineKVAcks(t *testing.T) {
 	port := mockPort(mock.URL)
 
 	client := setupNATS(t)
-	sessions, err := OpenSessionRegistry(client.Conn, WithSessionReplicas(1), WithSessionTTL(10*time.Second))
+	sessions, err := session.OpenSessionRegistry(client.Conn, session.WithSessionReplicas(1), session.WithSessionTTL(10*time.Second))
 	if err != nil {
 		t.Fatalf("failed to open session registry: %v", err)
 	}
 	// KV says session moved to unreachable machine-B
-	sessions.Put("ses_target", SessionEntry{Port: port, MachineID: "machine-B", Dir: "/test"})
+	sessions.Put("ses_target", session.SessionEntry{Port: port, MachineID: "machine-B", Dir: "/test"})
 
-	deliverer := Deliverer{
+	deliverer := session.Deliverer{
 		MachineID:    "machine-A",
 		HostBridge:   "127.0.0.1",
 		RequestLimit: 5 * time.Second,
@@ -229,7 +230,7 @@ func TestHandleAgentMessage_InterestPathWrongMachineKVAcks(t *testing.T) {
 		MachineID: "machine-A",
 	}
 
-	result := HandleAgentMessage(
+	result := session.HandleAgentMessage(
 		newTestEnvelope("agent", "notifications.agent.ses_target", "test"),
 		"ses_target", "machine-A", interest, &deliverer,
 	)

--- a/packages/envoy/internal/session/session.go
+++ b/packages/envoy/internal/session/session.go
@@ -21,6 +21,7 @@ type Deliverer struct {
 	MachineID    string
 	HostBridge   string
 	RequestLimit time.Duration
+	HTTPClient   *http.Client
 	Sessions     SessionLookup
 }
 
@@ -72,7 +73,7 @@ func (d Deliverer) prompt(port int, machineID string, sessionID string, text str
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	client := http.Client{Timeout: d.timeout()}
+	client := d.httpClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return err
@@ -105,4 +106,11 @@ func (d Deliverer) timeout() time.Duration {
 		return d.RequestLimit
 	}
 	return 30 * time.Second
+}
+
+func (d Deliverer) httpClient() *http.Client {
+	if d.HTTPClient != nil {
+		return d.HTTPClient
+	}
+	return &http.Client{Timeout: d.timeout()}
 }

--- a/packages/envoy/internal/session/session_internal_test.go
+++ b/packages/envoy/internal/session/session_internal_test.go
@@ -1,0 +1,20 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDeliver_DefaultTimeout30s(t *testing.T) {
+	d := Deliverer{}
+	if got := d.timeout(); got != 30*time.Second {
+		t.Fatalf("expected default timeout 30s, got %v", got)
+	}
+}
+
+func TestDeliver_CustomTimeoutRespected(t *testing.T) {
+	d := Deliverer{RequestLimit: 5 * time.Second}
+	if got := d.timeout(); got != 5*time.Second {
+		t.Fatalf("expected custom timeout 5s, got %v", got)
+	}
+}

--- a/packages/envoy/internal/session/session_test.go
+++ b/packages/envoy/internal/session/session_test.go
@@ -1,18 +1,76 @@
-package session
+package session_test
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	natsgo "github.com/nats-io/nats.go"
+	"github.com/sjawhar/envoy/internal/bus"
 	"github.com/sjawhar/envoy/internal/contracts"
+	session "github.com/sjawhar/envoy/internal/session"
 	"github.com/sjawhar/envoy/internal/store"
+	tcnats "github.com/testcontainers/testcontainers-go/modules/nats"
 )
+
+var (
+	sharedNATSOnce sync.Once
+	sharedNATSURI  string
+	sharedNATSErr  error
+)
+
+func sharedTestNATSURI(t *testing.T) string {
+	t.Helper()
+	sharedNATSOnce.Do(func() {
+		ctx := context.Background()
+		ctr, err := tcnats.Run(ctx, "nats:2.10")
+		if err != nil {
+			sharedNATSErr = err
+			return
+		}
+		sharedNATSURI, sharedNATSErr = ctr.ConnectionString(ctx)
+	})
+	if sharedNATSErr != nil {
+		t.Fatalf("failed to start shared NATS: %v", sharedNATSErr)
+	}
+	return sharedNATSURI
+}
+
+func clearSessionBucket(t *testing.T, conn *natsgo.Conn) {
+	t.Helper()
+	js, err := conn.JetStream(natsgo.MaxWait(10 * time.Second))
+	if err != nil {
+		t.Fatalf("failed to open JetStream: %v", err)
+	}
+	if err := js.DeleteKeyValue(session.SessionBucket); err != nil && !errors.Is(err, natsgo.ErrBucketNotFound) && !errors.Is(err, natsgo.ErrStreamNotFound) {
+		t.Fatalf("failed to delete session bucket: %v", err)
+	}
+}
+
+func setupNATS(t *testing.T) *bus.Client {
+	t.Helper()
+	client, err := bus.Connect([]string{sharedTestNATSURI(t)}, bus.WithReplicas(1))
+	if err != nil {
+		t.Fatalf("failed to connect bus: %v", err)
+	}
+	t.Cleanup(func() { client.Conn.Close() })
+	clearSessionBucket(t, client.Conn)
+	return client
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func newTestEnvelope(source, topic, summary string) contracts.Envelope {
 	return contracts.Envelope{
@@ -37,14 +95,14 @@ func mockPort(url string) int {
 	return port
 }
 
-func newKVDeliverer(t *testing.T) (*SessionRegistry, Deliverer) {
+func newKVDeliverer(t *testing.T) (*session.SessionRegistry, session.Deliverer) {
 	t.Helper()
 	client := setupNATS(t)
-	sessions, err := OpenSessionRegistry(client.Conn, WithSessionReplicas(1), WithSessionTTL(10*time.Second))
+	sessions, err := session.OpenSessionRegistry(client.Conn, session.WithSessionReplicas(1), session.WithSessionTTL(10*time.Second))
 	if err != nil {
 		t.Fatalf("failed to open session registry: %v", err)
 	}
-	return sessions, Deliverer{
+	return sessions, session.Deliverer{
 		HostBridge:   "127.0.0.1",
 		RequestLimit: 5 * time.Second,
 		Sessions:     sessions,
@@ -66,7 +124,7 @@ func TestDeliver_ExactlyOnce(t *testing.T) {
 	}
 
 	sessions, deliverer := newKVDeliverer(t)
-	if err := sessions.Put("ses_target", SessionEntry{Port: port, Dir: "/test"}); err != nil {
+	if err := sessions.Put("ses_target", session.SessionEntry{Port: port, Dir: "/test"}); err != nil {
 		t.Fatalf("failed to register session: %v", err)
 	}
 	interest := store.Interest{SessionID: "ses_target", Dir: "/test", MachineID: "m"}
@@ -112,7 +170,7 @@ func TestDeliver_PromptAsyncBody(t *testing.T) {
 
 	port := mockPort(mock.URL)
 	sessions, deliverer := newKVDeliverer(t)
-	if err := sessions.Put("ses_target", SessionEntry{Port: port, Dir: "/test"}); err != nil {
+	if err := sessions.Put("ses_target", session.SessionEntry{Port: port, Dir: "/test"}); err != nil {
 		t.Fatalf("failed to register session: %v", err)
 	}
 	item := newTestEnvelope("slack", "notifications.slack.T123.C456.mention", "test payload")
@@ -150,7 +208,7 @@ func TestDeliver_PromptAsyncBody(t *testing.T) {
 }
 
 func TestText_WithSourceSession(t *testing.T) {
-	deliverer := Deliverer{}
+	deliverer := session.Deliverer{}
 	item := contracts.Envelope{
 		EventID:        "evt-1",
 		Source:         "agent",
@@ -166,7 +224,7 @@ func TestText_WithSourceSession(t *testing.T) {
 }
 
 func TestText_WithoutSourceSession(t *testing.T) {
-	deliverer := Deliverer{}
+	deliverer := session.Deliverer{}
 	item := contracts.Envelope{
 		EventID:        "evt-2",
 		Source:         "slack",
@@ -185,7 +243,7 @@ func TestText_WithoutSourceSession(t *testing.T) {
 }
 
 func TestText_PrefersPayloadOverSummary(t *testing.T) {
-	deliverer := Deliverer{}
+	deliverer := session.Deliverer{}
 	item := contracts.Envelope{
 		EventID:        "evt-3",
 		Source:         "github",
@@ -204,7 +262,7 @@ func TestText_PrefersPayloadOverSummary(t *testing.T) {
 }
 
 func TestText_FallsBackToSummaryWhenPayloadEmpty(t *testing.T) {
-	deliverer := Deliverer{}
+	deliverer := session.Deliverer{}
 	item := contracts.Envelope{
 		EventID:        "evt-4",
 		Source:         "github",
@@ -232,7 +290,7 @@ func TestDeliver_NoAgentField(t *testing.T) {
 
 	port := mockPort(mock.URL)
 	sessions, deliverer := newKVDeliverer(t)
-	if err := sessions.Put("ses_target", SessionEntry{Port: port, Dir: "/test"}); err != nil {
+	if err := sessions.Put("ses_target", session.SessionEntry{Port: port, Dir: "/test"}); err != nil {
 		t.Fatalf("failed to register session: %v", err)
 	}
 	item := newTestEnvelope("agent", "notifications.agent.ses_target", "test")
@@ -253,7 +311,7 @@ func TestDeliver_PromptAsyncFailure(t *testing.T) {
 
 	port := mockPort(mock.URL)
 	sessions, deliverer := newKVDeliverer(t)
-	if err := sessions.Put("ses_target", SessionEntry{Port: port, Dir: "/test"}); err != nil {
+	if err := sessions.Put("ses_target", session.SessionEntry{Port: port, Dir: "/test"}); err != nil {
 		t.Fatalf("failed to register session: %v", err)
 	}
 	item := newTestEnvelope("agent", "notifications.agent.ses_target", "test")
@@ -274,13 +332,13 @@ func TestDeliver_KVRegistryUsed(t *testing.T) {
 	kvPort := mockPort(kvMock.URL)
 
 	client := setupNATS(t)
-	sessions, err := OpenSessionRegistry(client.Conn, WithSessionReplicas(1), WithSessionTTL(10*time.Second))
+	sessions, err := session.OpenSessionRegistry(client.Conn, session.WithSessionReplicas(1), session.WithSessionTTL(10*time.Second))
 	if err != nil {
 		t.Fatalf("failed to open session registry: %v", err)
 	}
-	sessions.Put("ses_target", SessionEntry{Port: kvPort, MachineID: "test", Dir: "/test"})
+	sessions.Put("ses_target", session.SessionEntry{Port: kvPort, MachineID: "test", Dir: "/test"})
 
-	deliverer := Deliverer{
+	deliverer := session.Deliverer{
 		MachineID:    "test",
 		HostBridge:   "127.0.0.1",
 		RequestLimit: 5 * time.Second,
@@ -299,7 +357,7 @@ func TestDeliver_KVRegistryUsed(t *testing.T) {
 }
 
 func TestDeliver_NilSessionsReturnsError(t *testing.T) {
-	deliverer := Deliverer{
+	deliverer := session.Deliverer{
 		HostBridge:   "127.0.0.1",
 		RequestLimit: 5 * time.Second,
 		Sessions:     nil, // no registry configured
@@ -333,15 +391,15 @@ func TestDeliver_CrossMachineUsesRemoteHost(t *testing.T) {
 	remoteHost := "localhost"
 
 	client := setupNATS(t)
-	sessions, err := OpenSessionRegistry(client.Conn, WithSessionReplicas(1), WithSessionTTL(10*time.Second))
+	sessions, err := session.OpenSessionRegistry(client.Conn, session.WithSessionReplicas(1), session.WithSessionTTL(10*time.Second))
 	if err != nil {
 		t.Fatalf("failed to open session registry: %v", err)
 	}
 	// Register session on remote machine with localhost hostname
-	sessions.Put("ses_target", SessionEntry{Port: remotePort, MachineID: remoteHost, Dir: "/test"})
+	sessions.Put("ses_target", session.SessionEntry{Port: remotePort, MachineID: remoteHost, Dir: "/test"})
 
 	// Deliverer is on local machine
-	deliverer := Deliverer{
+	deliverer := session.Deliverer{
 		MachineID:    "local-machine",
 		HostBridge:   "127.0.0.1",
 		RequestLimit: 5 * time.Second,
@@ -363,16 +421,69 @@ func TestDeliver_CrossMachineUsesRemoteHost(t *testing.T) {
 	}
 }
 
-func TestDeliver_DefaultTimeout30s(t *testing.T) {
-	d := Deliverer{}
-	if got := d.timeout(); got != 30*time.Second {
-		t.Fatalf("expected default timeout 30s, got %v", got)
+func TestTsnetAwareDelivery(t *testing.T) {
+	var deliveryCount atomic.Int32
+	var requestURL string
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		deliveryCount.Add(1)
+		requestURL = req.URL.String()
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Body:       http.NoBody,
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	sessions, deliverer := newKVDeliverer(t)
+	if err := sessions.Put("ses_target", session.SessionEntry{Port: 443, MachineID: "remote-machine", Dir: "/test"}); err != nil {
+		t.Fatalf("failed to register remote session: %v", err)
+	}
+	deliverer.MachineID = "local-machine"
+	deliverer.HTTPClient = client
+
+	err := deliverer.Deliver(
+		newTestEnvelope("agent", "notifications.agent.ses_target", "test message"),
+		store.Interest{SessionID: "ses_target", Dir: "/test", MachineID: "local-machine"},
+	)
+	if err != nil {
+		t.Fatalf("expected injected HTTP client to deliver remote prompt, got %v", err)
+	}
+	if count := deliveryCount.Load(); count != 1 {
+		t.Fatalf("expected injected client to be used once, got %d calls", count)
+	}
+	if requestURL != "http://remote-machine:443/session/ses_target/prompt_async" {
+		t.Fatalf("expected remote delivery URL, got %s", requestURL)
 	}
 }
 
-func TestDeliver_CustomTimeoutRespected(t *testing.T) {
-	d := Deliverer{RequestLimit: 5 * time.Second}
-	if got := d.timeout(); got != 5*time.Second {
-		t.Fatalf("expected custom timeout 5s, got %v", got)
+func TestDefaultClientFallback(t *testing.T) {
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer slow.Close()
+
+	port := mockPort(slow.URL)
+	sessions, deliverer := newKVDeliverer(t)
+	if err := sessions.Put("ses_target", session.SessionEntry{Port: port, MachineID: "local-machine", Dir: "/test"}); err != nil {
+		t.Fatalf("failed to register local session: %v", err)
+	}
+	deliverer.MachineID = "local-machine"
+	deliverer.RequestLimit = 10 * time.Millisecond
+	deliverer.HTTPClient = nil
+
+	started := time.Now()
+	err := deliverer.Deliver(
+		newTestEnvelope("agent", "notifications.agent.ses_target", "test message"),
+		store.Interest{SessionID: "ses_target", Dir: "/test", MachineID: "local-machine"},
+	)
+	if err == nil {
+		t.Fatal("expected fallback HTTP client timeout, got nil")
+	}
+	if !strings.Contains(err.Error(), "Client.Timeout") {
+		t.Fatalf("expected fallback client timeout error, got %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > 250*time.Millisecond {
+		t.Fatalf("expected timeout-driven fallback client, request took %v", elapsed)
 	}
 }

--- a/packages/envoy/internal/smoke/listener_test.go
+++ b/packages/envoy/internal/smoke/listener_test.go
@@ -1,0 +1,177 @@
+//go:build smoke
+
+// Package smoke contains container-level smoke tests for the Envoy listener.
+// These tests build the Docker image from the local Dockerfile and verify
+// critical endpoints work end-to-end with a real NATS server via testcontainers.
+//
+// Run: go test -tags smoke -v -timeout 5m ./internal/smoke/
+package smoke
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	tcnats "github.com/testcontainers/testcontainers-go/modules/nats"
+	"github.com/testcontainers/testcontainers-go/network"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func TestSmoke(t *testing.T) {
+	ctx := context.Background()
+
+	net, err := network.New(ctx)
+	if err != nil {
+		t.Fatalf("create network: %v", err)
+	}
+	t.Cleanup(func() { net.Remove(ctx) })
+
+	natsC, err := tcnats.Run(ctx, "nats:2.10",
+		network.WithNetwork([]string{"nats"}, net),
+	)
+	testcontainers.CleanupContainer(t, natsC)
+	if err != nil {
+		t.Fatalf("start NATS: %v", err)
+	}
+
+	listenerC, err := testcontainers.Run(ctx, "",
+		testcontainers.WithDockerfile(testcontainers.FromDockerfile{
+			Context:       "../../",
+			Dockerfile:    "docker/Dockerfile",
+			PrintBuildLog: true,
+			KeepImage:     true,
+		}),
+		network.WithNetwork([]string{"listener"}, net),
+		testcontainers.WithEnv(map[string]string{
+			"NATS_URLS":        "nats://nats:4222",
+			"ENVOY_MACHINE_ID": "smoke-test",
+			"PORT":             "9020",
+		}),
+		testcontainers.WithExposedPorts("9020/tcp"),
+		testcontainers.WithWaitStrategy(
+			wait.ForHTTP("/healthz").
+				WithPort("9020/tcp").
+				WithStatusCodeMatcher(func(status int) bool {
+					return status == http.StatusOK
+				}).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	testcontainers.CleanupContainer(t, listenerC)
+	if err != nil {
+		t.Fatalf("start listener: %v", err)
+	}
+
+	host, err := listenerC.Host(ctx)
+	if err != nil {
+		t.Fatalf("get host: %v", err)
+	}
+	port, err := listenerC.MappedPort(ctx, "9020")
+	if err != nil {
+		t.Fatalf("get mapped port: %v", err)
+	}
+	baseURL := fmt.Sprintf("http://%s:%s", host, port.Port())
+
+	t.Run("healthz", func(t *testing.T) {
+		resp, err := http.Get(baseURL + "/healthz")
+		if err != nil {
+			t.Fatalf("GET /healthz: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("GET /healthz: got %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode /healthz: %v", err)
+		}
+
+		status, ok := body["status"].(string)
+		if !ok {
+			t.Fatal("/healthz missing 'status' field")
+		}
+		if status != "healthy" && status != "starting" {
+			t.Errorf("/healthz status=%q, want 'healthy' or 'starting'", status)
+		}
+	})
+
+	t.Run("metrics", func(t *testing.T) {
+		resp, err := http.Get(baseURL + "/metrics")
+		if err != nil {
+			t.Fatalf("GET /metrics: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("GET /metrics: got %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read /metrics: %v", err)
+		}
+		body := string(bodyBytes)
+
+		for _, metric := range []string{
+			"envoy_messages_received_total",
+			"envoy_active_sessions",
+			"envoy_active_interests",
+		} {
+			if !strings.Contains(body, metric) {
+				t.Errorf("/metrics missing %q", metric)
+			}
+		}
+	})
+
+	t.Run("sessions", func(t *testing.T) {
+		resp, err := http.Get(baseURL + "/v1/sessions")
+		if err != nil {
+			t.Fatalf("GET /v1/sessions: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("GET /v1/sessions: got %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+	})
+
+	t.Run("subscribe_and_verify", func(t *testing.T) {
+		subBody := `{"session_id":"ses_smoke_test","topics":["notifications.test.smoke"],"port":8080}`
+		resp, err := http.Post(
+			baseURL+"/v1/interests/subscribe",
+			"application/json",
+			strings.NewReader(subBody),
+		)
+		if err != nil {
+			t.Fatalf("POST /v1/interests/subscribe: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("POST /v1/interests/subscribe: got %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+
+		sessResp, err := http.Get(baseURL + "/v1/sessions")
+		if err != nil {
+			t.Fatalf("GET /v1/sessions: %v", err)
+		}
+		defer sessResp.Body.Close()
+
+		bodyBytes, err := io.ReadAll(sessResp.Body)
+		if err != nil {
+			t.Fatalf("read /v1/sessions: %v", err)
+		}
+
+		if !strings.Contains(string(bodyBytes), "ses_smoke_test") {
+			t.Error("registered session not visible in /v1/sessions")
+		}
+	})
+}

--- a/packages/envoy/internal/store/kv.go
+++ b/packages/envoy/internal/store/kv.go
@@ -3,7 +3,7 @@ package store
 import (
 	"encoding/json"
 	"errors"
-	"log"
+	"log/slog"
 	"sort"
 	"sync"
 	"time"
@@ -68,7 +68,7 @@ func openBucket(js nats.JetStreamContext, bucket string, replicas int) (nats.Key
 func (r *Registry) watch() {
 	w, err := r.kv.WatchAll()
 	if err != nil {
-		log.Printf("registry watch failed: %v", err)
+		slog.Error("registry watch failed", slog.String("error", err.Error()))
 		return
 	}
 	for entry := range w.Updates() {
@@ -218,4 +218,49 @@ func first(value string, fallback string) string {
 
 func curValue(value string) string {
 	return value
+}
+
+// Reap cross-references the interest cache with a session liveness check and
+// deletes interests whose sessions are dead AND whose UpdatedAt exceeds the
+// grace window. The isAlive function should return true when the session exists.
+// Returns the number of reaped interests.
+func (r *Registry) Reap(isAlive func(string) bool, graceWindow time.Duration) (int, error) {
+	now := time.Now().UnixMilli()
+	graceMs := graceWindow.Milliseconds()
+
+	r.mu.RLock()
+	var stale []string
+	for sid, item := range r.cache {
+		if isAlive(sid) {
+			continue // session still alive
+		}
+		if now-item.UpdatedAt <= graceMs {
+			continue // within grace window
+		}
+		stale = append(stale, sid)
+	}
+	r.mu.RUnlock()
+
+	for _, sid := range stale {
+		if err := r.kv.Delete(sid); err != nil {
+			return 0, err
+		}
+	}
+	return len(stale), nil
+}
+
+// StartReaper runs Reap in a background goroutine at the given interval.
+func (r *Registry) StartReaper(isAlive func(string) bool, interval, graceWindow time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for range ticker.C {
+			count, err := r.Reap(isAlive, graceWindow)
+			if err != nil {
+				slog.Error("reaper cycle failed", slog.String("error", err.Error()))
+				continue
+			}
+			slog.Info("reaper cycle", slog.Int("reaped", count))
+		}
+	}()
 }

--- a/packages/envoy/internal/store/kv_test.go
+++ b/packages/envoy/internal/store/kv_test.go
@@ -738,3 +738,76 @@ func TestSetRole_OldHolderMissing(t *testing.T) {
 		t.Fatalf("expected role holder ses_fresh, got %q", string(entry.Value()))
 	}
 }
+
+// --- Reaper Tests (cross-reference sessions for stale interest cleanup) ---
+
+func TestInterestReaper(t *testing.T) {
+	conn, cleanup := connectNATS(t)
+	defer cleanup()
+
+	reg, kv := coldRegistry(t, conn)
+
+	// Create interests for alive and dead sessions (both updated 10 min ago)
+	now := time.Now().UnixMilli()
+	putInterest(t, kv, Interest{SessionID: "ses_alive", MachineID: "m1", Topics: []string{"notifications.>"}, UpdatedAt: now - 600_000})
+	putInterest(t, kv, Interest{SessionID: "ses_dead", MachineID: "m1", Topics: []string{"notifications.>"}, UpdatedAt: now - 600_000})
+
+	// Warm cache via Get (coldRegistry has no watch())
+	if _, err := reg.Get("ses_alive"); err != nil {
+		t.Fatalf("Get ses_alive failed: %v", err)
+	}
+	if _, err := reg.Get("ses_dead"); err != nil {
+		t.Fatalf("Get ses_dead failed: %v", err)
+	}
+
+	// Reap with 0 grace window — all dead sessions should be reaped
+	count, err := reg.Reap(func(sessionID string) bool {
+		return sessionID == "ses_alive"
+	}, 0)
+	if err != nil {
+		t.Fatalf("Reap failed: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 reaped, got %d", count)
+	}
+
+	// ses_alive should still exist in KV
+	if _, err := kv.Get("ses_alive"); err != nil {
+		t.Fatalf("ses_alive should still exist: %v", err)
+	}
+
+	// ses_dead should be deleted from KV
+	if _, err := kv.Get("ses_dead"); err != natsgo.ErrKeyNotFound {
+		t.Fatalf("ses_dead should be deleted, got err: %v", err)
+	}
+}
+
+func TestReaperGraceWindow(t *testing.T) {
+	conn, cleanup := connectNATS(t)
+	defer cleanup()
+
+	reg, kv := coldRegistry(t, conn)
+
+	// Create interest updated 2 min ago — session is dead but within 10 min grace window
+	now := time.Now().UnixMilli()
+	putInterest(t, kv, Interest{SessionID: "ses_recent", MachineID: "m1", Topics: []string{"notifications.>"}, UpdatedAt: now - 120_000})
+
+	// Warm cache
+	if _, err := reg.Get("ses_recent"); err != nil {
+		t.Fatalf("Get ses_recent failed: %v", err)
+	}
+
+	// Reap with 10 min grace window — ses_recent updated only 2 min ago, should survive
+	count, err := reg.Reap(func(string) bool { return false }, 10*time.Minute)
+	if err != nil {
+		t.Fatalf("Reap failed: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected 0 reaped (within grace window), got %d", count)
+	}
+
+	// ses_recent should still exist in KV
+	if _, err := kv.Get("ses_recent"); err != nil {
+		t.Fatalf("ses_recent should still exist within grace window: %v", err)
+	}
+}

--- a/packages/envoy/internal/tsnet/config.go
+++ b/packages/envoy/internal/tsnet/config.go
@@ -34,6 +34,10 @@ type Config struct {
 	// constructed from OAuth client credentials (preferred). See
 	// resolveAuthKey for details.
 	AuthKey string
+
+	// Tags are the ACL tags to advertise (e.g. []string{"tag:envoy"}).
+	// Required when using OAuth client credentials.
+	Tags []string
 }
 
 // resolveAuthKey determines the auth key from environment variables.
@@ -78,18 +82,8 @@ func resolveAuthKey() (string, error) {
 		params := url.Values{}
 		params.Set("ephemeral", "false")
 		params.Set("preauthorized", "true")
-
-		// Normalize tags: split, trim, rejoin without spaces.
-		rawTags := strings.Split(tags, ",")
-		cleaned := make([]string, 0, len(rawTags))
-		for _, t := range rawTags {
-			t = strings.TrimSpace(t)
-			if t != "" {
-				cleaned = append(cleaned, t)
-			}
-		}
-		params.Set("tags", strings.Join(cleaned, ","))
-
+		// Tags are passed via tsnet.Server.AdvertiseTags, NOT in the auth key URL.
+		// tsnet rejects unknown query params like "tags=".
 		return oauthSecret + "?" + params.Encode(), nil
 	}
 
@@ -129,10 +123,20 @@ func LoadConfig() (Config, error) {
 		return Config{}, err
 	}
 
+	var parsedTags []string
+	if rawTags := strings.TrimSpace(os.Getenv("ENVOY_TSNET_TAGS")); rawTags != "" {
+		for _, t := range strings.Split(rawTags, ",") {
+			if t = strings.TrimSpace(t); t != "" {
+				parsedTags = append(parsedTags, t)
+			}
+		}
+	}
+
 	return Config{
 		Enabled:  true,
 		Hostname: hostname,
 		StateDir: stateDir,
 		AuthKey:  authKey,
+		Tags:     parsedTags,
 	}, nil
 }

--- a/packages/envoy/internal/tsnet/config_test.go
+++ b/packages/envoy/internal/tsnet/config_test.go
@@ -191,8 +191,11 @@ func TestLoadConfig_OAuth_HappyPath(t *testing.T) {
 	if !strings.Contains(cfg.AuthKey, "preauthorized=true") {
 		t.Fatalf("expected preauthorized=true in auth key, got %q", cfg.AuthKey)
 	}
-	if !strings.Contains(cfg.AuthKey, "tags=tag%3Aenvoy") {
-		t.Fatalf("expected tags=tag%%3Aenvoy in auth key, got %q", cfg.AuthKey)
+	if strings.Contains(cfg.AuthKey, "tags=") {
+		t.Fatalf("tags should not be in auth key URL, got %q", cfg.AuthKey)
+	}
+	if len(cfg.Tags) != 1 || cfg.Tags[0] != "tag:envoy" {
+		t.Fatalf("expected Tags=[tag:envoy], got %v", cfg.Tags)
 	}
 }
 
@@ -203,8 +206,8 @@ func TestLoadConfig_OAuth_MultipleTags(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(cfg.AuthKey, "tag%3Aenvoy%2Ctag%3Alegion") {
-		t.Fatalf("expected both tags in auth key, got %q", cfg.AuthKey)
+	if len(cfg.Tags) != 2 || cfg.Tags[0] != "tag:envoy" || cfg.Tags[1] != "tag:legion" {
+		t.Fatalf("expected Tags=[tag:envoy, tag:legion], got %v", cfg.Tags)
 	}
 }
 
@@ -215,9 +218,8 @@ func TestLoadConfig_OAuth_TagsWhitespace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Tags should be trimmed and joined without extra spaces
-	if !strings.Contains(cfg.AuthKey, "tag%3Aenvoy%2Ctag%3Alegion") {
-		t.Fatalf("expected trimmed tags in auth key, got %q", cfg.AuthKey)
+	if len(cfg.Tags) != 2 || cfg.Tags[0] != "tag:envoy" || cfg.Tags[1] != "tag:legion" {
+		t.Fatalf("expected trimmed Tags=[tag:envoy, tag:legion], got %v", cfg.Tags)
 	}
 }
 

--- a/packages/envoy/internal/tsnet/server.go
+++ b/packages/envoy/internal/tsnet/server.go
@@ -21,9 +21,10 @@ type Server struct {
 // The caller must call Close when finished.
 func New(cfg Config) *Server {
 	ts := &tsnet.Server{
-		Hostname: cfg.Hostname,
-		Dir:      cfg.StateDir,
-		AuthKey:  cfg.AuthKey,
+		Hostname:      cfg.Hostname,
+		Dir:           cfg.StateDir,
+		AuthKey:       cfg.AuthKey,
+		AdvertiseTags: cfg.Tags,
 		// Silence verbose internal logs (WireGuard, LocalBackend).
 		// Only user-visible logs (auth URL, status) go to the app logger.
 		Logf:     func(string, ...any) {},
@@ -83,4 +84,9 @@ func (s *Server) Close() error {
 // Hostname returns the configured Tailscale hostname.
 func (s *Server) Hostname() string {
 	return s.ts.Hostname
+}
+
+// HTTPClient returns an HTTP client configured to dial over tsnet.
+func (s *Server) HTTPClient() *http.Client {
+	return s.ts.HTTPClient()
 }

--- a/packages/envoy/scripts/verify-cluster.sh
+++ b/packages/envoy/scripts/verify-cluster.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# verify-cluster.sh — NATS cluster health verification script
+# Usage: ./verify-cluster.sh http://host1:8222 http://host2:8222 ...
+# Checks cluster routes, stream existence, and consumer state
+
+set -e
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <monitoring-url> [<monitoring-url> ...]"
+    echo "Example: $0 http://localhost:8222 http://nats-2:8222"
+    exit 1
+fi
+
+STREAM_NAME="ENVOY_NOTIFICATIONS"
+CONSUMER_NAME="listener"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+echo "=== NATS Cluster Health Verification ==="
+echo ""
+
+# Check each monitoring URL
+for url in "$@"; do
+    echo "Checking $url..."
+    
+    # Check /routez — cluster routes
+    if ! routes=$(curl -s "$url/routez" 2>/dev/null); then
+        echo "  ✗ FAIL: Could not reach $url/routez"
+        ((FAIL_COUNT++))
+        continue
+    fi
+    
+    # Extract peer count from routes response
+    # routez returns JSON with "routes" array
+    peer_count=$(echo "$routes" | grep -o '"routes"' | wc -l)
+    if [ "$peer_count" -gt 0 ]; then
+        echo "  ✓ PASS: Cluster routes reachable"
+        ((PASS_COUNT++))
+    else
+        echo "  ✗ FAIL: No cluster routes found"
+        ((FAIL_COUNT++))
+    fi
+    
+    # Check /jsz — JetStream info and stream existence
+    if ! jsz=$(curl -s "$url/jsz" 2>/dev/null); then
+        echo "  ✗ FAIL: Could not reach $url/jsz"
+        ((FAIL_COUNT++))
+        continue
+    fi
+    
+    # Check if ENVOY_NOTIFICATIONS stream exists
+    if echo "$jsz" | grep -q "\"$STREAM_NAME\""; then
+        echo "  ✓ PASS: Stream $STREAM_NAME exists"
+        ((PASS_COUNT++))
+    else
+        echo "  ✗ FAIL: Stream $STREAM_NAME not found"
+        ((FAIL_COUNT++))
+    fi
+    
+    # Check KV buckets (envoy_interests, envoy_sessions, envoy_roles)
+    for bucket in "envoy_interests" "envoy_sessions" "envoy_roles"; do
+        if echo "$jsz" | grep -q "\"$bucket\""; then
+            echo "  ✓ PASS: KV bucket $bucket exists"
+            ((PASS_COUNT++))
+        else
+            echo "  ✗ FAIL: KV bucket $bucket not found"
+            ((FAIL_COUNT++))
+        fi
+    done
+    
+    # Check for listener-* consumers in the jsz response
+    # Extract machine ID from URL or use a generic pattern
+    if echo "$jsz" | grep -q "listener-"; then
+        echo "  ✓ PASS: Listener consumers found"
+        ((PASS_COUNT++))
+    else
+        echo "  ✗ FAIL: No listener consumers found"
+        ((FAIL_COUNT++))
+    fi
+
+echo ""
+echo "=== Summary ==="
+echo "Passed: $PASS_COUNT"
+echo "Failed: $FAIL_COUNT"
+echo ""
+
+if [ $FAIL_COUNT -eq 0 ]; then
+    echo "✓ All checks passed"
+    exit 0
+else
+    echo "✗ Some checks failed"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- 3 critical bug fixes (durable consumer restart, tsnet HTTP client, /v1/* port exclusivity)
- Delivery hardening (interest reaper, dead-session NAK fix, idempotency keys)
- tsnet AdvertiseTags + clean OAuth auth key (no tags in URL)
- Structured JSON logging, Prometheus /metrics endpoint
- Dockerfile ENTRYPOINT fix
- Testcontainers-based container smoke test in CI (gates Docker push)
- CI workflow updates: smoke test in both PR and release pipelines

Companion to #559 which landed daemon changes (envoyTopics for all worker modes).