### PR TITLE
chore(ci): Dockerfile best practices + scope release workflows per package

### DIFF
--- a/.github/workflows/envoy-and-contracts.yaml
+++ b/.github/workflows/envoy-and-contracts.yaml
@@ -14,14 +14,36 @@ on:
       - "packages/envoy-plugin/**"
 
 jobs:
+  # Detect which packages actually changed to skip unnecessary jobs.
+  changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      contracts: ${{ steps.filter.outputs.contracts }}
+      envoy: ${{ steps.filter.outputs.envoy }}
+      plugin: ${{ steps.filter.outputs.plugin }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            contracts:
+              - 'packages/contracts/**'
+            envoy:
+              - 'packages/envoy/**'
+              - 'packages/contracts/**'
+            plugin:
+              - 'packages/envoy-plugin/**'
+              - 'packages/contracts/**'
+
   contracts:
+    needs: changes
+    if: needs.changes.outputs.contracts == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
       - name: Lint contracts
         run: bun run lint
         working-directory: packages/contracts
@@ -36,13 +58,13 @@ jobs:
         working-directory: packages/contracts
 
   envoy-plugin:
+    needs: changes
+    if: needs.changes.outputs.plugin == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
       - name: Lint envoy plugin
         run: bun run lint
         working-directory: packages/envoy-plugin
@@ -61,15 +83,14 @@ jobs:
           path: out/pr-artifacts/*.tgz
 
   envoy-go:
+    needs: changes
+    if: needs.changes.outputs.envoy == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-      - name: Setup Go
-        uses: actions/setup-go@v5
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - uses: actions/setup-go@v5
         with:
           go-version-file: packages/envoy/go.mod
       - name: Generate Go contracts from shared schema

--- a/.github/workflows/release-envoy-listener.yaml
+++ b/.github/workflows/release-envoy-listener.yaml
@@ -1,4 +1,4 @@
-name: Release Legion Envoy and Plugin
+name: Release Envoy Listener
 
 on:
   push:
@@ -6,7 +6,6 @@ on:
     paths:
       - "packages/envoy/**"
       - "packages/contracts/**"
-      - "packages/envoy-plugin/**"
 
 permissions:
   contents: write
@@ -14,7 +13,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: release-envoy-listener
   cancel-in-progress: false
 
 jobs:
@@ -32,12 +31,10 @@ jobs:
       - name: Determine version bump
         id: bump
         run: |
-          # Find the latest envoy release tag
           LATEST_TAG=$(git tag -l 'legion-envoy-v*' --sort=-v:refname | head -1)
 
           if [ -z "$LATEST_TAG" ]; then
-            # No tags yet — first release uses current envoy-plugin package.json version
-            VERSION=$(jq -r .version packages/envoy-plugin/package.json)
+            VERSION="0.1.0"
             TAG="legion-envoy-v${VERSION}"
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "tag=$TAG" >> "$GITHUB_OUTPUT"
@@ -46,22 +43,20 @@ jobs:
             exit 0
           fi
 
-          # Get commits since last tag
-          COMMITS=$(git log "${LATEST_TAG}..HEAD" --format='%s')
+          # Only consider commits that touch envoy or contracts
+          COMMITS=$(git log "${LATEST_TAG}..HEAD" --format='%s' -- packages/envoy/ packages/contracts/)
 
           if [ -z "$COMMITS" ]; then
             echo "should_release=false" >> "$GITHUB_OUTPUT"
-            echo "No commits since $LATEST_TAG"
+            echo "No envoy/contracts commits since $LATEST_TAG"
             exit 0
           fi
 
-          # Classify conventional commits
           MAJOR=false
           MINOR=false
           PATCH=false
 
           while IFS= read -r msg; do
-            # BREAKING: feat!:, fix(scope)!:, or body contains BREAKING CHANGE
             if echo "$msg" | grep -qE '^[a-z]+(\(.+\))?!:' || echo "$msg" | grep -q 'BREAKING CHANGE'; then
               MAJOR=true
             elif echo "$msg" | grep -qE '^feat(\(.+\))?:'; then
@@ -77,9 +72,8 @@ jobs:
             exit 0
           fi
 
-          # Parse version from last tag (strip "legion-envoy-v" prefix and any -<sha> suffix)
           CURRENT="${LATEST_TAG#legion-envoy-v}"
-          CURRENT="${CURRENT%%-*}"  # strip -<sha> suffix from old-format tags
+          CURRENT="${CURRENT%%-*}"
           IFS='.' read -r major minor patch <<< "$CURRENT"
 
           if $MAJOR; then
@@ -97,60 +91,7 @@ jobs:
           echo "should_release=true" >> "$GITHUB_OUTPUT"
           echo "Bumping $CURRENT → $VERSION"
 
-  plugin:
-    needs: version
-    if: needs.version.outputs.should_release == 'true'
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v5
-      - uses: oven-sh/setup-bun@v2
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          registry-url: "https://registry.npmjs.org"
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-      - name: Set release version
-        id: plugin_version
-        run: |
-          PREV=$(curl -s https://registry.npmjs.org/@sjawhar%2Fopencode-legion-envoy/latest | jq -r '.version // "0.0.0"')
-          BASE="${PREV%%-*}"
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
-          PLUGIN_VERSION="${MAJOR}.${MINOR}.$((PATCH+1))"
-          echo "version=$PLUGIN_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Bumping npm $PREV → $PLUGIN_VERSION"
-          jq --arg v "$PLUGIN_VERSION" '.version = $v' \
-            packages/envoy-plugin/package.json > tmp.json \
-            && mv tmp.json packages/envoy-plugin/package.json
-      - name: Build plugin
-        run: bun run build
-        working-directory: packages/envoy-plugin
-      - name: Check if already published
-        id: check
-        env:
-          VERSION: ${{ steps.plugin_version.outputs.version }}
-        run: |
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/@sjawhar%2Fopencode-legion-envoy/${VERSION}")
-          if [ "$STATUS" = "200" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "✓ @sjawhar/opencode-legion-envoy@${VERSION} already published"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Publish to npm
-        if: steps.check.outputs.skip != 'true'
-        run: npm publish --access public --provenance
-        working-directory: packages/envoy-plugin
-      - name: Pack plugin
-        run: bun pm pack
-        working-directory: packages/envoy-plugin
-      - uses: actions/upload-artifact@v4
-        with:
-          name: opencode-legion-envoy-plugin
-          path: packages/envoy-plugin/*.tgz
-
-  envoy:
+  build:
     needs: version
     runs-on: ubuntu-24.04
     strategy:
@@ -160,15 +101,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - run: bun install --frozen-lockfile
       - uses: actions/setup-go@v5
         with:
           go-version-file: packages/envoy/go.mod
-      - name: Generate Go contracts from shared schema
+      - name: Generate Go contracts
         run: bun run gen:go
         working-directory: packages/contracts
-      - name: Build envoy binaries
+      - name: Build envoy binary
         run: |
           mkdir -p out
           GOOS=linux GOARCH=${{ matrix.arch }} go build -buildvcs=false -o out/envoy-listener ./cmd/listener
@@ -180,7 +120,7 @@ jobs:
           path: packages/envoy/legion-envoy-${{ matrix.arch }}.tar.gz
 
   docker:
-    needs: [version, envoy]
+    needs: [version, build]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
@@ -190,8 +130,7 @@ jobs:
         with:
           go-version-file: packages/envoy/go.mod
       - uses: oven-sh/setup-bun@v2
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - run: bun install --frozen-lockfile
       - name: Generate Go contracts
         run: bun run gen:go
         working-directory: packages/contracts
@@ -209,12 +148,14 @@ jobs:
           file: packages/envoy/docker/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             ghcr.io/sjawhar/legion/envoy:${{ github.sha }}
             ghcr.io/sjawhar/legion/envoy:latest
 
   release:
-    needs: [version, plugin, envoy]
+    needs: [version, build, docker]
     if: needs.version.outputs.should_release == 'true'
     runs-on: ubuntu-24.04
     steps:
@@ -223,25 +164,17 @@ jobs:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
           fetch-depth: 0
 
-      - name: Bump version in repo
-        run: |
-          jq --arg v "${{ needs.version.outputs.version }}" '.version = $v' \
-            packages/envoy-plugin/package.json > tmp.json \
-            && mv tmp.json packages/envoy-plugin/package.json
-
-      - name: Commit and tag
+      - name: Tag release
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add packages/envoy-plugin/package.json
-          git diff --staged --quiet || git commit -m "chore: release envoy-plugin v${{ needs.version.outputs.version }} [skip ci]"
           git tag "${{ needs.version.outputs.tag }}"
-          git push origin main --tags
+          git push origin --tags
 
       - uses: actions/download-artifact@v4
       - name: Generate checksums
         run: |
-          for dir in legion-envoy-amd64 legion-envoy-arm64 opencode-legion-envoy-plugin; do
+          for dir in legion-envoy-amd64 legion-envoy-arm64; do
             (cd "$dir" && sha256sum * >> ../SHA256SUMS)
           done
       - name: Create GitHub release
@@ -250,8 +183,7 @@ jobs:
         run: |
           gh release create "${{ needs.version.outputs.tag }}" \
             --title "${{ needs.version.outputs.tag }}" \
-            --notes "Automated Legion Envoy/plugin release from the Legion monorepo." \
+            --notes "Envoy listener release — Go binary + Docker image." \
             legion-envoy-amd64/* \
             legion-envoy-arm64/* \
-            opencode-legion-envoy-plugin/* \
             SHA256SUMS

--- a/.github/workflows/release-envoy-plugin.yaml
+++ b/.github/workflows/release-envoy-plugin.yaml
@@ -1,0 +1,103 @@
+name: Release Envoy Plugin
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/envoy-plugin/**"
+      - "packages/contracts/**"
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
+concurrency:
+  group: release-envoy-plugin
+  cancel-in-progress: false
+
+jobs:
+  version:
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+      should_publish: ${{ steps.bump.outputs.should_publish }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Determine if plugin changed
+        id: bump
+        run: |
+          # Get latest published version from npm
+          PREV=$(curl -s https://registry.npmjs.org/@sjawhar%2Fopencode-legion-envoy/latest | jq -r '.version // "0.0.0"')
+          BASE="${PREV%%-*}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
+          VERSION="${MAJOR}.${MINOR}.$((PATCH+1))"
+
+          # Check if there are actual plugin/contracts changes since last release
+          LATEST_TAG=$(git tag -l 'legion-envoy-v*' --sort=-v:refname | head -1)
+          if [ -n "$LATEST_TAG" ]; then
+            COMMITS=$(git log "${LATEST_TAG}..HEAD" --format='%s' -- packages/envoy-plugin/ packages/contracts/)
+            if [ -z "$COMMITS" ]; then
+              echo "should_publish=false" >> "$GITHUB_OUTPUT"
+              echo "No plugin/contracts commits since $LATEST_TAG"
+              exit 0
+            fi
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          echo "Bumping npm $PREV → $VERSION"
+
+  publish:
+    needs: version
+    if: needs.version.outputs.should_publish == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      - run: bun install --frozen-lockfile
+
+      - name: Set version
+        run: |
+          jq --arg v "${{ needs.version.outputs.version }}" '.version = $v' \
+            packages/envoy-plugin/package.json > tmp.json \
+            && mv tmp.json packages/envoy-plugin/package.json
+
+      - name: Build plugin
+        run: bun run build
+        working-directory: packages/envoy-plugin
+
+      - name: Check if already published
+        id: check
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/@sjawhar%2Fopencode-legion-envoy/${VERSION}")
+          if [ "$STATUS" = "200" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "✓ Already published"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        if: steps.check.outputs.skip != 'true'
+        run: npm publish --access public --provenance
+        working-directory: packages/envoy-plugin
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Pack plugin
+        run: bun pm pack
+        working-directory: packages/envoy-plugin
+      - uses: actions/upload-artifact@v4
+        with:
+          name: opencode-legion-envoy-plugin
+          path: packages/envoy-plugin/*.tgz

--- a/packages/envoy/.dockerignore
+++ b/packages/envoy/.dockerignore
@@ -11,3 +11,14 @@ coverage
 .idea
 docker-data
 tmp
+
+# Test files — not needed in production image
+**/*_test.go
+internal/integration/
+internal/smoke/
+
+# Build/deploy tooling
+scripts/
+deploy/
+infra/
+docker/base/

--- a/packages/envoy/docker/Dockerfile
+++ b/packages/envoy/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Go version must match go.mod (tsnet requires >= 1.26.1).
-FROM golang:1.26-bookworm AS build
+FROM golang:1.26-alpine AS build
 
 WORKDIR /src
 
@@ -12,6 +12,8 @@ COPY internal ./internal
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) \
     go build -o /out/envoy-listener ./cmd/listener
 
+# Minimal runtime — static binary, no shell needed.
+# curl is included for HEALTHCHECK and operational debugging.
 FROM debian:bookworm-slim
 
 LABEL org.opencontainers.image.source=https://github.com/sjawhar/legion
@@ -26,5 +28,10 @@ COPY --from=build /out/envoy-listener /usr/local/bin/envoy-listener
 # (WireGuard) and outbound TCP 443 (control plane).
 
 USER envoy
+
+EXPOSE 9020
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD curl -sf http://localhost:9020/healthz || exit 1
 
 ENTRYPOINT ["envoy-listener"]

--- a/packages/envoy/docker/base/Dockerfile
+++ b/packages/envoy/docker/base/Dockerfile
@@ -1,5 +1,0 @@
-FROM golang:1.24-alpine AS base
-
-WORKDIR /src
-
-RUN apk add --no-cache ca-certificates curl git

--- a/packages/envoy/internal/smoke/listener_test.go
+++ b/packages/envoy/internal/smoke/listener_test.go
@@ -1,8 +1,8 @@
 //go:build smoke
 
 // Package smoke contains container-level smoke tests for the Envoy listener.
-// These tests build the Docker image from the local Dockerfile and verify
-// critical endpoints work end-to-end with a real NATS server via testcontainers.
+// Builds the Docker image from the local Dockerfile and verifies critical
+// endpoints work end-to-end with a real NATS server via testcontainers.
 //
 // Run: go test -tags smoke -v -timeout 5m ./internal/smoke/
 package smoke
@@ -26,12 +26,14 @@ import (
 func TestSmoke(t *testing.T) {
 	ctx := context.Background()
 
+	// Shared Docker network for container-to-container communication.
 	net, err := network.New(ctx)
 	if err != nil {
 		t.Fatalf("create network: %v", err)
 	}
 	t.Cleanup(func() { net.Remove(ctx) })
 
+	// Start NATS using the same module the rest of the project uses.
 	natsC, err := tcnats.Run(ctx, "nats:2.10",
 		network.WithNetwork([]string{"nats"}, net),
 	)


### PR DESCRIPTION
## Summary

**Dockerfile optimizations:**
- BuildKit cache mounts for Go modules + build cache (eliminates redundant downloads)
- Alpine build stage (smaller pull, CGO_ENABLED=0 means no glibc needed)
- `.dockerignore` expanded (excludes test files, scripts, deploy from context)
- `EXPOSE 9020` + `HEALTHCHECK` (ECS auto-detects health)
- GHA layer cache (`cache-from/to: type=gha`)
- Deleted stale `docker/base/Dockerfile` (Go 1.24, unused)

**Release workflow split:**
- Deleted monolithic `release-envoy-and-plugin.yaml` that rebuilt everything on any change
- New `release-envoy-listener.yaml` — triggers ONLY on `packages/envoy/**` or `packages/contracts/**`. Builds Go binaries + Docker image + GitHub release.
- New `release-envoy-plugin.yaml` — triggers ONLY on `packages/envoy-plugin/**` or `packages/contracts/**`. Publishes npm package.
- A listener-only fix no longer rebuilds/republishes the npm plugin
- A plugin-only fix no longer rebuilds the Docker image

**CI workflow scoping:**
- Added `dorny/paths-filter` to conditionally skip jobs based on which packages actually changed
- `envoy-go` job (3+ min with smoke test) only runs when `packages/envoy/` or `packages/contracts/` changed
- `envoy-plugin` job only runs when `packages/envoy-plugin/` or `packages/contracts/` changed
- `contracts` job only runs when `packages/contracts/` changed

**Expected savings:** Plugin-only PRs skip the 3-min Go build + smoke test. Listener-only PRs skip plugin lint/build. Listener releases don't publish npm. Plugin releases don't build Docker.