### PR TITLE
fix: harden liveness sweep — 120s grace, 3-miss threshold, per-session checks, no workspace deletion

### DIFF
--- a/packages/daemon/src/__tests__/integration.test.ts
+++ b/packages/daemon/src/__tests__/integration.test.ts
@@ -39,7 +39,7 @@ async function withTestServer(run: (ctx: TestServerContext) => Promise<void>): P
       data: undefined,
     }),
     deleteSession: async () => {},
-    listActiveSessions: async (): Promise<Set<string>> => new Set<string>(),
+    sessionExists: async (): Promise<boolean> => false,
   };
   const mockEnvoy = createMockEnvoyServer();
   const { server, stop } = startServer({

--- a/packages/daemon/src/daemon/__tests__/advance.test.ts
+++ b/packages/daemon/src/daemon/__tests__/advance.test.ts
@@ -38,7 +38,7 @@ describe("POST /state/advance", () => {
       deleteSession: async (sessionId: string) => {
         deleteSessionCalls.push(sessionId);
       },
-      listActiveSessions: async () => new Set<string>(),
+      sessionExists: async () => false,
     };
   }
 
@@ -310,7 +310,7 @@ describe("POST /state/auto-advance", () => {
       sendPrompt: async () => {},
       getSessionStatus: async () => ({ data: undefined }),
       deleteSession: async () => {},
-      listActiveSessions: async () => new Set<string>(),
+      sessionExists: async () => false,
     };
   }
 

--- a/packages/daemon/src/daemon/__tests__/feedback.integration.test.ts
+++ b/packages/daemon/src/daemon/__tests__/feedback.integration.test.ts
@@ -21,7 +21,7 @@ function makeAdapter(): RuntimeAdapter {
     sendPrompt: async () => {},
     getSessionStatus: async () => ({ data: undefined }),
     deleteSession: async () => {},
-    listActiveSessions: async () => new Set<string>(),
+    sessionExists: async () => false,
   };
 }
 

--- a/packages/daemon/src/daemon/__tests__/index.test.ts
+++ b/packages/daemon/src/daemon/__tests__/index.test.ts
@@ -109,7 +109,7 @@ function makeAdapter(overrides?: {
   stopServeCalls?: number[];
   createSessionCalls?: Array<{ sessionId: string; workspace: string }>;
   getServePid?: () => number;
-  listActiveSessions?: () => Promise<Set<string>>;
+  sessionExists?: (sessionId: string) => Promise<boolean>;
 }): RuntimeAdapter {
   const createSessionCalls = overrides?.createSessionCalls ?? [];
   const stopServeCalls = overrides?.stopServeCalls ?? [];
@@ -134,7 +134,7 @@ function makeAdapter(overrides?: {
     },
     getSessionStatus: async () => ({ data: undefined }),
     deleteSession: async () => {},
-    listActiveSessions: overrides?.listActiveSessions ?? (async () => new Set<string>()),
+    sessionExists: overrides?.sessionExists ?? (async () => false),
   };
 }
 
@@ -1882,10 +1882,10 @@ describe("daemon entry", () => {
     });
 
     it("marks running worker as dead when session is missing from serve", async () => {
-      let timeoutCallback: TimeoutCallback | null = null;
+      const timeoutCallbacks: TimeoutCallback[] = [];
       const mockSetTimeout: typeof setTimeout = Object.assign(
         ((callback: TimeoutCallback, _delay?: number, ..._args: unknown[]) => {
-          timeoutCallback = callback as TimeoutCallback;
+          timeoutCallbacks.push(callback);
           return {} as ReturnType<typeof setTimeout>;
         }) as unknown as typeof setTimeout,
         { __promisify__: setTimeout.__promisify__ }
@@ -1917,8 +1917,8 @@ describe("daemon entry", () => {
           }),
           writeStateFile: async () => {},
           adapter: makeAdapter({
-            // Session is NOT in the active set → worker should be reaped
-            listActiveSessions: async () => new Set<string>(["ses_other_session"]),
+            // Session does not match worker → worker should be reaped
+            sessionExists: async () => false,
           }),
           startServer: () => ({
             server: { port: 15555 } as ReturnType<typeof Bun.serve>,
@@ -1942,8 +1942,11 @@ describe("daemon entry", () => {
         }
       );
 
-      if (!timeoutCallback) throw new Error("Expected health loop callback to be scheduled");
-      await (timeoutCallback as () => Promise<void>)();
+      if (!timeoutCallbacks[0]) throw new Error("Expected health loop callback to be scheduled");
+      // Need 3 consecutive ticks for the failure threshold
+      await (timeoutCallbacks[0] as () => Promise<void>)();
+      await (timeoutCallbacks[1] as () => Promise<void>)();
+      await (timeoutCallbacks[2] as () => Promise<void>)();
 
       expect(patchCalls).toHaveLength(1);
       expect(patchCalls[0].body.status).toBe("dead");
@@ -1983,8 +1986,8 @@ describe("daemon entry", () => {
           }),
           writeStateFile: async () => {},
           adapter: makeAdapter({
-            // Session IS in the active set → worker should NOT be reaped
-            listActiveSessions: async () => new Set<string>([workerSessionId]),
+            // Session IS the worker → worker should NOT be reaped
+            sessionExists: async (id) => id === workerSessionId,
           }),
           startServer: () => ({
             server: { port: 15555 } as ReturnType<typeof Bun.serve>,
@@ -2022,7 +2025,7 @@ describe("daemon entry", () => {
         { __promisify__: setTimeout.__promisify__ }
       );
 
-      const listActiveSessionsCalls: number[] = [];
+      const sessionExistsCalls: number[] = [];
       const workerEntry: WorkerEntry = {
         ...baseEntry,
         status: "running",
@@ -2042,9 +2045,9 @@ describe("daemon entry", () => {
           writeStateFile: async () => {},
           adapter: makeAdapter({
             healthy: async () => false,
-            listActiveSessions: async () => {
-              listActiveSessionsCalls.push(1);
-              return new Set<string>();
+            sessionExists: async () => {
+              sessionExistsCalls.push(1);
+              return false;
             },
           }),
           startServer: () => ({
@@ -2062,7 +2065,7 @@ describe("daemon entry", () => {
       await (timeoutCallback as () => Promise<void>)();
 
       // Liveness sweep must not run when serve is unhealthy (AC3)
-      expect(listActiveSessionsCalls).toHaveLength(0);
+      expect(sessionExistsCalls).toHaveLength(0);
     });
 
     it("skips liveness sweep when serve was just restarted", async () => {
@@ -2075,7 +2078,7 @@ describe("daemon entry", () => {
         { __promisify__: setTimeout.__promisify__ }
       );
 
-      const listActiveSessionsCalls: number[] = [];
+      const sessionExistsCalls: number[] = [];
       // Track whether the health tick has started (vs startup calls)
       let tickStarted = false;
       let tickHealthCallCount = 0;
@@ -2103,9 +2106,9 @@ describe("daemon entry", () => {
               // First tick call: unhealthy (triggers restart)
               return tickHealthCallCount > 1;
             },
-            listActiveSessions: async () => {
-              listActiveSessionsCalls.push(1);
-              return new Set<string>();
+            sessionExists: async () => {
+              sessionExistsCalls.push(1);
+              return false;
             },
           }),
           startServer: () => ({
@@ -2130,10 +2133,10 @@ describe("daemon entry", () => {
       await (timeoutCallback as () => Promise<void>)();
 
       // Liveness sweep must not run when serve was just restarted (AC3)
-      expect(listActiveSessionsCalls).toHaveLength(0);
+      expect(sessionExistsCalls).toHaveLength(0);
     });
 
-    it("skips liveness sweep and marks no workers dead when listActiveSessions throws", async () => {
+    it("skips liveness sweep and marks no workers dead when sessionExists throws", async () => {
       let timeoutCallback: TimeoutCallback | null = null;
       const mockSetTimeout: typeof setTimeout = Object.assign(
         ((callback: TimeoutCallback, _delay?: number, ..._args: unknown[]) => {
@@ -2162,7 +2165,7 @@ describe("daemon entry", () => {
           }),
           writeStateFile: async () => {},
           adapter: makeAdapter({
-            listActiveSessions: async () => {
+            sessionExists: async () => {
               throw new Error("network error");
             },
           }),
@@ -2190,6 +2193,244 @@ describe("daemon entry", () => {
       await (timeoutCallback as () => Promise<void>)();
 
       // AC4: transient error → no workers marked dead
+      expect(patchCalls).toHaveLength(0);
+    });
+  });
+
+  describe("liveness sweep hardening", () => {
+    it("does not reap workers within 120s startup grace period", async () => {
+      const timeoutCallbacks: TimeoutCallback[] = [];
+      const mockSetTimeout: typeof setTimeout = Object.assign(
+        ((callback: TimeoutCallback, _delay?: number, ..._args: unknown[]) => {
+          timeoutCallbacks.push(callback);
+          return {} as ReturnType<typeof setTimeout>;
+        }) as unknown as typeof setTimeout,
+        { __promisify__: setTimeout.__promisify__ }
+      );
+
+      const patchCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
+      const workerId = "test-repo-42-implement";
+      const workerSessionId = "ses_abc123def456ABCDEFGHIJKLMN";
+
+      // Worker started 90s ago — past the current 60s grace but within the desired 120s
+      const workerEntry: WorkerEntry = {
+        ...baseEntry,
+        id: workerId,
+        sessionId: workerSessionId,
+        startedAt: new Date(Date.now() - 90_000).toISOString(),
+        status: "running",
+      };
+
+      await startDaemonForTest(
+        {
+          stateFilePath: "/tmp/daemon-workers.json",
+          checkIntervalMs: 1000,
+          legionId: TEAM_ID,
+          controllerSessionId: "ses_test",
+        },
+        {
+          readStateFile: async () => ({
+            workers: { [workerId]: workerEntry },
+            crashHistory: {},
+          }),
+          writeStateFile: async () => {},
+          adapter: makeAdapter({
+            healthy: async () => true,
+            sessionExists: async () => false,
+          }),
+          startServer: () => ({
+            server: { port: 15555 } as ReturnType<typeof Bun.serve>,
+            stop: () => {},
+            fetchAndProcessState: async () => {},
+            cleanupDeadWorkers: async () => {},
+          }),
+          setTimeout: mockSetTimeout,
+          clearTimeout: () => {},
+          fetch: Object.assign(
+            async (url: string | URL | Request, init?: RequestInit) => {
+              const urlStr = String(url);
+              if (init?.method === "PATCH" && urlStr.includes("/workers/")) {
+                const body = JSON.parse(init.body as string) as Record<string, unknown>;
+                patchCalls.push({ url: urlStr, body });
+                return new Response(JSON.stringify({ ok: true }), { status: 200 });
+              }
+              return originalFetch(url, init);
+            },
+            { preconnect: originalFetch.preconnect }
+          ),
+        }
+      );
+
+      if (!timeoutCallbacks[0]) throw new Error("Expected health loop callback");
+      await (timeoutCallbacks[0] as () => Promise<void>)();
+
+      // Worker should NOT be reaped — it's within the 120s grace period
+      const deadPatches = patchCalls.filter((c) => c.body.status === "dead");
+      expect(deadPatches).toHaveLength(0);
+    });
+
+    it("only reaps workers after 3 consecutive liveness failures", async () => {
+      const timeoutCallbacks: TimeoutCallback[] = [];
+      const mockSetTimeout: typeof setTimeout = Object.assign(
+        ((callback: TimeoutCallback, _delay?: number, ..._args: unknown[]) => {
+          timeoutCallbacks.push(callback);
+          return {} as ReturnType<typeof setTimeout>;
+        }) as unknown as typeof setTimeout,
+        { __promisify__: setTimeout.__promisify__ }
+      );
+
+      const patchCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
+      const workerId = "test-repo-42-implement";
+      const workerSessionId = "ses_abc123def456ABCDEFGHIJKLMN";
+
+      // Worker started 200s ago — well past any grace period
+      const workerEntry: WorkerEntry = {
+        ...baseEntry,
+        id: workerId,
+        sessionId: workerSessionId,
+        startedAt: new Date(Date.now() - 200_000).toISOString(),
+        status: "running",
+      };
+
+      await startDaemonForTest(
+        {
+          stateFilePath: "/tmp/daemon-workers.json",
+          checkIntervalMs: 1000,
+          legionId: TEAM_ID,
+          controllerSessionId: "ses_test",
+        },
+        {
+          readStateFile: async () => ({
+            workers: { [workerId]: workerEntry },
+            crashHistory: {},
+          }),
+          writeStateFile: async () => {},
+          adapter: makeAdapter({
+            healthy: async () => true,
+            sessionExists: async () => false,
+          }),
+          startServer: () => ({
+            server: { port: 15555 } as ReturnType<typeof Bun.serve>,
+            stop: () => {},
+            fetchAndProcessState: async () => {},
+            cleanupDeadWorkers: async () => {},
+          }),
+          setTimeout: mockSetTimeout,
+          clearTimeout: () => {},
+          fetch: Object.assign(
+            async (url: string | URL | Request, init?: RequestInit) => {
+              const urlStr = String(url);
+              if (init?.method === "PATCH" && urlStr.includes("/workers/")) {
+                const body = JSON.parse(init.body as string) as Record<string, unknown>;
+                patchCalls.push({ url: urlStr, body });
+                return new Response(JSON.stringify({ ok: true }), { status: 200 });
+              }
+              return originalFetch(url, init);
+            },
+            { preconnect: originalFetch.preconnect }
+          ),
+        }
+      );
+
+      // First health tick — miss 1, should NOT reap
+      await (timeoutCallbacks[0] as () => Promise<void>)();
+      expect(patchCalls.filter((c) => c.body.status === "dead")).toHaveLength(0);
+
+      // Second health tick — miss 2, should NOT reap
+      await (timeoutCallbacks[1] as () => Promise<void>)();
+      expect(patchCalls.filter((c) => c.body.status === "dead")).toHaveLength(0);
+
+      // Third health tick — miss 3, NOW should reap
+      await (timeoutCallbacks[2] as () => Promise<void>)();
+      expect(patchCalls.filter((c) => c.body.status === "dead")).toHaveLength(1);
+    });
+
+    it("resets consecutive miss counter when worker session reappears", async () => {
+      const timeoutCallbacks: TimeoutCallback[] = [];
+      const mockSetTimeout: typeof setTimeout = Object.assign(
+        ((callback: TimeoutCallback, _delay?: number, ..._args: unknown[]) => {
+          timeoutCallbacks.push(callback);
+          return {} as ReturnType<typeof setTimeout>;
+        }) as unknown as typeof setTimeout,
+        { __promisify__: setTimeout.__promisify__ }
+      );
+
+      const patchCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
+      const workerId = "test-repo-42-implement";
+      const workerSessionId = "ses_abc123def456ABCDEFGHIJKLMN";
+
+      const workerEntry: WorkerEntry = {
+        ...baseEntry,
+        id: workerId,
+        sessionId: workerSessionId,
+        startedAt: new Date(Date.now() - 200_000).toISOString(),
+        status: "running",
+      };
+
+      let listCallCount = 0;
+      await startDaemonForTest(
+        {
+          stateFilePath: "/tmp/daemon-workers.json",
+          checkIntervalMs: 1000,
+          legionId: TEAM_ID,
+          controllerSessionId: "ses_test",
+        },
+        {
+          readStateFile: async () => ({
+            workers: { [workerId]: workerEntry },
+            crashHistory: {},
+          }),
+          writeStateFile: async () => {},
+          adapter: makeAdapter({
+            healthy: async () => true,
+            sessionExists: async (id) => {
+              listCallCount++;
+              // Tick 1: missing, Tick 2: missing, Tick 3: present, Tick 4: missing, Tick 5: missing
+              if (listCallCount === 3) return id === workerSessionId;
+              return false;
+            },
+          }),
+          startServer: () => ({
+            server: { port: 15555 } as ReturnType<typeof Bun.serve>,
+            stop: () => {},
+            fetchAndProcessState: async () => {},
+            cleanupDeadWorkers: async () => {},
+          }),
+          setTimeout: mockSetTimeout,
+          clearTimeout: () => {},
+          fetch: Object.assign(
+            async (url: string | URL | Request, init?: RequestInit) => {
+              const urlStr = String(url);
+              if (init?.method === "PATCH" && urlStr.includes("/workers/")) {
+                const body = JSON.parse(init.body as string) as Record<string, unknown>;
+                patchCalls.push({ url: urlStr, body });
+                return new Response(JSON.stringify({ ok: true }), { status: 200 });
+              }
+              return originalFetch(url, init);
+            },
+            { preconnect: originalFetch.preconnect }
+          ),
+        }
+      );
+
+      // Tick 1: miss 1 — no reap
+      await (timeoutCallbacks[0] as () => Promise<void>)();
+      expect(patchCalls).toHaveLength(0);
+
+      // Tick 2: miss 2 — no reap
+      await (timeoutCallbacks[1] as () => Promise<void>)();
+      expect(patchCalls).toHaveLength(0);
+
+      // Tick 3: session reappears — counter resets
+      await (timeoutCallbacks[2] as () => Promise<void>)();
+      expect(patchCalls).toHaveLength(0);
+
+      // Tick 4: miss 1 again (counter was reset) — no reap
+      await (timeoutCallbacks[3] as () => Promise<void>)();
+      expect(patchCalls).toHaveLength(0);
+
+      // Tick 5: miss 2 — still no reap (need 3 consecutive)
+      await (timeoutCallbacks[4] as () => Promise<void>)();
       expect(patchCalls).toHaveLength(0);
     });
   });

--- a/packages/daemon/src/daemon/__tests__/server.test.ts
+++ b/packages/daemon/src/daemon/__tests__/server.test.ts
@@ -71,7 +71,7 @@ describe("daemon server", () => {
       deleteSession: async (sessionId: string) => {
         deleteSessionCalls.push(sessionId);
       },
-      listActiveSessions: async () => new Set<string>(),
+      sessionExists: async () => false,
     };
   }
 
@@ -2209,9 +2209,8 @@ describe("daemon server", () => {
       return (await response.json()) as { id: string; sessionId: string };
     }
 
-    it("cleans up workspaces for dead workers via cleanupDeadWorkers", async () => {
+    it("removes dead worker state without touching workspaces", async () => {
       const rmDirCalls: string[] = [];
-      const jjCalls: string[][] = [];
       const { server, stop, cleanupDeadWorkers } = startServer({
         port: 0,
         hostname: "127.0.0.1",
@@ -2220,10 +2219,6 @@ describe("daemon server", () => {
         paths,
         adapter: makeAdapter(),
         repoManagerDeps: makeRepoManagerDeps({
-          runJj: async (args) => {
-            jjCalls.push(args);
-            return { exitCode: 0, stdout: "", stderr: "" };
-          },
           rmDir: async (workspacePath: string) => {
             rmDirCalls.push(workspacePath);
           },
@@ -2258,13 +2253,75 @@ describe("daemon server", () => {
         // Run cleanup
         await cleanupDeadWorkers();
 
-        // Verify workspace was cleaned: jj workspace forget + rmDir
-        const forgetCall = jjCalls.find((args) => args[0] === "workspace" && args[1] === "forget");
-        expect(forgetCall).toBeDefined();
-        expect(forgetCall).toContain("acme-widgets-60");
-        expect(rmDirCalls).toEqual([`/tmp/legion-data/workspaces/${legionId}/acme-widgets-60`]);
+        // Workspace should NOT be deleted (dead workers keep workspaces)
+        expect(rmDirCalls).toHaveLength(0);
 
-        // Verify worker was removed from the map
+        // But worker should be removed from the map
+        const workersRes = await originalFetch(`${localBaseUrl}/workers`);
+        const workers = (await workersRes.json()) as WorkerEntry[];
+        expect(workers).toEqual([]);
+      } finally {
+        stop();
+      }
+    });
+
+    it("cleanupDeadWorkers does NOT delete workspaces (state cleanup only)", async () => {
+      const rmDirCalls: string[] = [];
+      const jjCalls: string[][] = [];
+      const { server, stop, cleanupDeadWorkers } = startServer({
+        port: 0,
+        hostname: "127.0.0.1",
+        envoyUrl: mockEnvoy.url,
+        legionId,
+        paths,
+        adapter: makeAdapter(),
+        repoManagerDeps: makeRepoManagerDeps({
+          runJj: async (args) => {
+            jjCalls.push(args);
+            return { exitCode: 0, stdout: "", stderr: "" };
+          },
+          rmDir: async (workspacePath: string) => {
+            rmDirCalls.push(workspacePath);
+          },
+        }),
+        stateFilePath: path.join(
+          await mkdtemp(path.join(os.tmpdir(), "legion-dead-")),
+          "workers.json"
+        ),
+      });
+      const localBaseUrl = `http://127.0.0.1:${server.port}`;
+      try {
+        // Create a worker, then mark it dead
+        const createRes = await originalFetch(`${localBaseUrl}/workers`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            issueId: "acme-widgets-99",
+            mode: "implement",
+            repo: "acme/widgets",
+          }),
+        });
+        expect(createRes.status).toBe(200);
+        const created = (await createRes.json()) as { id: string; sessionId: string };
+
+        const patchRes = await originalFetch(`${localBaseUrl}/workers/${created.id}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ status: "dead" }),
+        });
+        expect(patchRes.status).toBe(200);
+
+        // Run cleanup
+        await cleanupDeadWorkers();
+
+        // Workspace should NOT be deleted — dead workers keep their workspaces
+        expect(rmDirCalls).toHaveLength(0);
+        const forgetCalls = jjCalls.filter(
+          (args) => args[0] === "workspace" && args[1] === "forget"
+        );
+        expect(forgetCalls).toHaveLength(0);
+
+        // But worker should still be removed from the map (state cleaned)
         const workersRes = await originalFetch(`${localBaseUrl}/workers`);
         const workers = (await workersRes.json()) as WorkerEntry[];
         expect(workers).toEqual([]);
@@ -2295,7 +2352,7 @@ describe("daemon server", () => {
       expect(rmDirCalls).toEqual([]);
     });
 
-    it("preserves dead worker state when workspace cleanup fails", async () => {
+    it("still removes dead worker state even when jj is broken (no workspace cleanup)", async () => {
       const { server, stop, cleanupDeadWorkers } = startServer({
         port: 0,
         hostname: "127.0.0.1",
@@ -2334,17 +2391,14 @@ describe("daemon server", () => {
           body: JSON.stringify({ status: "dead" }),
         });
 
-        // Suppress console.warn for expected error log
-        console.warn = () => {};
-
-        // Run cleanup — should fail workspace cleanup but not crash
+        // Run cleanup — no workspace cleanup happens (workers keep workspaces on death),
+        // so the failing jj mock is irrelevant. Worker should still be removed.
         await cleanupDeadWorkers();
 
-        // Worker should still exist because workspace cleanup failed
+        // Worker removed (no workspace cleanup to fail)
         const workersRes = await originalFetch(`${localBaseUrl}/workers`);
         const workers = (await workersRes.json()) as WorkerEntry[];
-        expect(workers).toHaveLength(1);
-        expect(workers[0]?.status).toBe("dead");
+        expect(workers).toHaveLength(0);
       } finally {
         stop();
       }
@@ -2389,13 +2443,14 @@ describe("daemon server", () => {
           body: JSON.stringify({ status: "dead" }),
         });
 
-        // First cleanup removes the worker
+        // First cleanup removes the worker (no workspace deletion)
         await cleanupDeadWorkers();
-        expect(rmDirCalls).toHaveLength(1);
 
         // Second cleanup is a no-op
         await cleanupDeadWorkers();
-        expect(rmDirCalls).toHaveLength(1);
+
+        // No workspace deletion happened
+        expect(rmDirCalls).toHaveLength(0);
       } finally {
         stop();
       }
@@ -2445,9 +2500,8 @@ describe("daemon server", () => {
 
         await cleanupDeadWorkers();
 
-        // Workspace cleanup should happen once (deduplicated by issue ID)
-        expect(rmDirCalls).toHaveLength(1);
-        expect(rmDirCalls[0]).toContain("acme-widgets-64");
+        // No workspace deletion (dead workers keep workspaces)
+        expect(rmDirCalls).toHaveLength(0);
 
         // Both workers should be removed
         const workersRes = await originalFetch(`${localBaseUrl}/workers`);

--- a/packages/daemon/src/daemon/__tests__/session-id-contract.test.ts
+++ b/packages/daemon/src/daemon/__tests__/session-id-contract.test.ts
@@ -48,7 +48,7 @@ describe("sessionId contract (daemon vs state)", () => {
       sendPrompt: async () => {},
       getSessionStatus: async () => ({ data: undefined }),
       deleteSession: async () => {},
-      listActiveSessions: async () => new Set<string>(),
+      sessionExists: async () => false,
     };
 
     tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-session-contract-"));
@@ -97,7 +97,7 @@ describe("sessionId contract (daemon vs state)", () => {
       sendPrompt: async () => {},
       getSessionStatus: async () => ({ data: undefined }),
       deleteSession: async () => {},
-      listActiveSessions: async () => new Set<string>(),
+      sessionExists: async () => false,
     };
 
     tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-session-contract-"));
@@ -152,7 +152,7 @@ describe("sessionId contract (daemon vs state)", () => {
       },
       getSessionStatus: async () => ({ data: undefined }),
       deleteSession: async () => {},
-      listActiveSessions: async () => new Set<string>(),
+      sessionExists: async () => false,
     };
 
     tempDir = await mkdtemp(path.join(os.tmpdir(), "legion-session-contract-"));

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -588,6 +588,11 @@ export async function startDaemon(
     }
   }
 
+  // Track consecutive liveness misses per worker for failure threshold.
+  // Workers are only reaped after LIVENESS_FAILURE_THRESHOLD consecutive misses.
+  // Resets when a worker's session is found alive.
+  const consecutiveLivenessMisses = new Map<string, number>();
+
   const scheduleHealthTick = () => {
     healthTickTimeout = resolvedDeps.setTimeout(async () => {
       try {
@@ -739,88 +744,90 @@ export async function startDaemon(
         // Session liveness sweep — detect workers whose serve sessions have died (AC1-AC4)
         // Only runs when serve is healthy and was NOT just restarted (AC3)
         if (serveHealthy && !restartReason) {
-          // Collect active sessions from ALL serve ports (multi-serve support)
-          const activeSessionsByPort = new Map<number, Set<string>>();
           try {
-            const primarySessions = await resolvedDeps.adapter.listActiveSessions();
-            activeSessionsByPort.set(resolvedDeps.adapter.getPort(), primarySessions);
-          } catch (err) {
-            console.warn(
-              `[liveness] Failed to fetch active sessions (non-fatal, skipping sweep): ${err}`
-            );
-          }
+            const livenessState = await resolvedDeps.readStateFile(config.stateFilePath);
+            for (const worker of Object.values(livenessState.workers)) {
+              if (worker.status !== "running") continue;
 
-          if (activeSessionsByPort.size > 0) {
-            try {
-              const livenessState = await resolvedDeps.readStateFile(config.stateFilePath);
-              for (const worker of Object.values(livenessState.workers)) {
-                if (worker.status !== "running") continue;
-
-                // Check the worker's specific port for its session
-                const workerPort = worker.port ?? resolvedDeps.adapter.getPort();
-                let sessionsOnPort = activeSessionsByPort.get(workerPort);
-                if (!sessionsOnPort) {
-                  // Fetch sessions from this port (different serve)
-                  try {
-                    const res = await resolvedDeps.fetch(`http://127.0.0.1:${workerPort}/session`);
-                    if (res.ok) {
-                      const sessions = (await res.json()) as Array<{ id: string }>;
-                      sessionsOnPort = new Set(sessions.map((s) => s.id));
-                      activeSessionsByPort.set(workerPort, sessionsOnPort);
-                    }
-                  } catch {
-                    // Port not reachable — worker's serve is down
-                  }
-                }
-                if (sessionsOnPort?.has(worker.sessionId)) continue;
-
-                // Grace period — don't reap workers dispatched in the last 60s
-                // Prevents race where session isn't on serve yet during workspace setup
-                const LIVENESS_GRACE_PERIOD_MS = 60_000;
-                const startedAtMs = new Date(worker.startedAt).getTime();
-                if (Date.now() - startedAtMs < LIVENESS_GRACE_PERIOD_MS) continue;
-
-                const workerMode = worker.id.split("-").pop() ?? "unknown";
-                const now = new Date().toISOString();
+              // Per-worker session existence check — O(workers) not O(total sessions).
+              // Uses GET /session/{id} which is a single-row lookup, immune to pagination.
+              const workerPort = worker.port ?? resolvedDeps.adapter.getPort();
+              let sessionAlive: boolean;
+              if (workerPort === resolvedDeps.adapter.getPort()) {
+                sessionAlive = await resolvedDeps.adapter.sessionExists(worker.sessionId);
+              } else {
+                // Different port — check directly via HTTP
                 try {
-                  const patchRes = await resolvedDeps.fetch(
-                    `http://127.0.0.1:${config.daemonPort}/workers/${worker.id}`,
-                    {
-                      method: "PATCH",
-                      headers: { "Content-Type": "application/json" },
-                      body: JSON.stringify({
-                        status: "dead",
-                        crashCount: worker.crashCount + 1,
-                        lastCrashAt: now,
-                      }),
-                    }
+                  const res = await resolvedDeps.fetch(
+                    `http://127.0.0.1:${workerPort}/session/${worker.sessionId}`
                   );
-                  if (patchRes.ok) {
-                    feedbackLogger?.log({
-                      event: "daemon.worker_reaped",
-                      workerId: worker.id,
-                      sessionId: worker.sessionId,
-                      mode: workerMode,
-                      serveType: "shared",
-                      reason: "session_missing",
-                    });
-                    console.warn(
-                      `[liveness] Reaped worker ${worker.id}: session ${worker.sessionId} not found in serve`
-                    );
-                  } else {
-                    console.warn(
-                      `[liveness] PATCH to mark worker ${worker.id} dead returned ${patchRes.status}`
-                    );
-                  }
-                } catch (patchErr) {
-                  console.warn(
-                    `[liveness] Failed to mark worker ${worker.id} as dead: ${patchErr}`
-                  );
+                  sessionAlive = res.ok;
+                } catch {
+                  sessionAlive = false;
                 }
               }
-            } catch (livenessErr) {
-              console.warn(`[liveness] Session liveness check failed (non-fatal): ${livenessErr}`);
+
+              if (sessionAlive) {
+                // Session alive — reset consecutive miss counter
+                consecutiveLivenessMisses.delete(worker.id);
+                continue;
+              }
+
+              // Grace period — don't reap workers dispatched in the last 120s
+              // Prevents race where session isn't on serve yet during workspace setup
+              const LIVENESS_GRACE_PERIOD_MS = 120_000;
+              const startedAtMs = new Date(worker.startedAt).getTime();
+              if (Date.now() - startedAtMs < LIVENESS_GRACE_PERIOD_MS) continue;
+
+              // Consecutive failure threshold — require 3 consecutive misses before reaping
+              const LIVENESS_FAILURE_THRESHOLD = 3;
+              const misses = (consecutiveLivenessMisses.get(worker.id) ?? 0) + 1;
+              consecutiveLivenessMisses.set(worker.id, misses);
+              if (misses < LIVENESS_FAILURE_THRESHOLD) {
+                console.warn(
+                  `[liveness] Worker ${worker.id}: session missing (${misses}/${LIVENESS_FAILURE_THRESHOLD} consecutive misses)`
+                );
+                continue;
+              }
+
+              const workerMode = worker.id.split("-").pop() ?? "unknown";
+              const now = new Date().toISOString();
+              try {
+                const patchRes = await resolvedDeps.fetch(
+                  `http://127.0.0.1:${config.daemonPort}/workers/${worker.id}`,
+                  {
+                    method: "PATCH",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                      status: "dead",
+                      crashCount: worker.crashCount + 1,
+                      lastCrashAt: now,
+                    }),
+                  }
+                );
+                if (patchRes.ok) {
+                  feedbackLogger?.log({
+                    event: "daemon.worker_reaped",
+                    workerId: worker.id,
+                    sessionId: worker.sessionId,
+                    mode: workerMode,
+                    serveType: "shared",
+                    reason: "session_missing",
+                  });
+                  console.warn(
+                    `[liveness] Reaped worker ${worker.id}: session ${worker.sessionId} not found in serve`
+                  );
+                } else {
+                  console.warn(
+                    `[liveness] PATCH to mark worker ${worker.id} dead returned ${patchRes.status}`
+                  );
+                }
+              } catch (patchErr) {
+                console.warn(`[liveness] Failed to mark worker ${worker.id} as dead: ${patchErr}`);
+              }
             }
+          } catch (livenessErr) {
+            console.warn(`[liveness] Session liveness check failed (non-fatal): ${livenessErr}`);
           }
         }
 

--- a/packages/daemon/src/daemon/runtime/__tests__/opencode.test.ts
+++ b/packages/daemon/src/daemon/runtime/__tests__/opencode.test.ts
@@ -334,45 +334,38 @@ describe("OpenCodeAdapter", () => {
       expect(data.tokensUsed).toBe(1500); // only from second message
     });
   });
-  describe("listActiveSessions", () => {
-    it("returns all sessions including idle ones via session/status?includeIdle=true", async () => {
+  describe("sessionExists", () => {
+    it("returns true when session exists (200 response)", async () => {
       const adapter = new OpenCodeAdapter(13381);
       const originalFetch = globalThis.fetch;
       try {
         globalThis.fetch = (async (url: string | URL | Request) => {
           const urlStr = String(url);
-          if (urlStr.includes("/session/status") && urlStr.includes("includeIdle=true")) {
-            return new Response(
-              JSON.stringify({
-                ses_busy_1: { type: "busy" },
-                ses_idle_2: { type: "idle" },
-                ses_idle_3: { type: "idle" },
-              }),
-              { status: 200 }
-            );
+          if (urlStr.includes("/session/ses_exists")) {
+            return new Response(JSON.stringify({ id: "ses_exists" }), { status: 200 });
           }
-          return originalFetch(url);
+          return new Response("not found", { status: 404 });
         }) as typeof fetch;
 
-        const sessions = await adapter.listActiveSessions();
-        expect(sessions.size).toBe(3);
-        expect(sessions.has("ses_busy_1")).toBe(true);
-        expect(sessions.has("ses_idle_2")).toBe(true);
-        expect(sessions.has("ses_idle_3")).toBe(true);
+        expect(await adapter.sessionExists("ses_exists")).toBe(true);
+        expect(await adapter.sessionExists("ses_missing")).toBe(false);
       } finally {
         globalThis.fetch = originalFetch;
       }
     });
 
-    it("throws on non-200 response", async () => {
+    it("returns false on network error", async () => {
       const adapter = new OpenCodeAdapter(13381);
       const originalFetch = globalThis.fetch;
       try {
-        globalThis.fetch = Object.assign(async () => new Response("error", { status: 500 }), {
-          preconnect: originalFetch.preconnect,
-        }) as typeof fetch;
+        globalThis.fetch = Object.assign(
+          async () => {
+            throw new Error("connection refused");
+          },
+          { preconnect: originalFetch.preconnect }
+        ) as typeof fetch;
 
-        await expect(adapter.listActiveSessions()).rejects.toThrow("HTTP 500");
+        expect(await adapter.sessionExists("ses_any")).toBe(false);
       } finally {
         globalThis.fetch = originalFetch;
       }

--- a/packages/daemon/src/daemon/runtime/claude-code.ts
+++ b/packages/daemon/src/daemon/runtime/claude-code.ts
@@ -154,7 +154,7 @@ export class ClaudeCodeAdapter implements RuntimeAdapter {
     return "none";
   }
 
-  async listActiveSessions(): Promise<Set<string>> {
+  async sessionExists(sessionId: string): Promise<boolean> {
     const result = this.spawn([
       "tmux",
       "list-windows",
@@ -164,9 +164,9 @@ export class ClaudeCodeAdapter implements RuntimeAdapter {
       "#{window_name}",
     ]);
     if (result.exitCode !== 0) {
-      throw new Error(`Failed to list tmux windows for session ${this.sessionName}`);
+      return false;
     }
     const windowNames = (result.stdout ?? "").split("\n").filter(Boolean);
-    return new Set(windowNames);
+    return windowNames.includes(sessionId);
   }
 }

--- a/packages/daemon/src/daemon/runtime/opencode.ts
+++ b/packages/daemon/src/daemon/runtime/opencode.ts
@@ -147,21 +147,10 @@ export class OpenCodeAdapter implements RuntimeAdapter {
     }
   }
 
-  async listActiveSessions(): Promise<Set<string>> {
-    // Use session/status?includeIdle=true which returns all sessions prompted in this
-    // serve process (busy + idle). Lightweight runtime check, no SQLite query,
-    // no pagination issues.
-    const res = await fetch(`http://127.0.0.1:${this.port}/session/status?includeIdle=true`);
-    if (!res.ok) {
-      throw new Error(`Failed to get session status: HTTP ${res.status}`);
-    }
-    const status = (await res.json()) as Record<string, unknown>;
-    return new Set(Object.keys(status));
-  }
-
   async sessionExists(sessionId: string): Promise<boolean> {
-    // Lightweight check: GET /session/{id} returns 200 if exists, 404 if gone.
-    // Much cheaper than listing all 1868+ sessions.
+    // Per-session lookup via GET /session/{id} — O(1) regardless of total session count.
+    // Previous implementations (GET /session list, session/status?includeIdle) both had
+    // pagination or timing issues with 1800+ sessions. Direct lookup is immune to both.
     try {
       const res = await fetch(`http://127.0.0.1:${this.port}/session/${sessionId}`);
       return res.ok;

--- a/packages/daemon/src/daemon/runtime/types.ts
+++ b/packages/daemon/src/daemon/runtime/types.ts
@@ -33,6 +33,6 @@ export interface RuntimeAdapter {
 
   /** Get the PID of the serve process (0 if not applicable or not started). */
   getServePid(): number;
-  /** Return the set of session IDs currently known to the serve. */
-  listActiveSessions(): Promise<Set<string>>;
+  /** Check whether a specific session exists on the serve (by ID lookup, not listing). */
+  sessionExists(sessionId: string): Promise<boolean>;
 }

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -2092,55 +2092,15 @@ export function startServer(opts: ServerOptions): {
       return;
     }
 
-    const failedWorkspaceIssueIds = new Set<string>();
-    const cleanedWorkspaceIssueIds = new Set<string>();
     let cleanedWorkers = 0;
 
-    // First pass: attempt workspace cleanup (once per issue)
+    // Remove worker state — session, Envoy, in-memory maps.
+    // Workspaces are NOT deleted here; they are only cleaned when the issue
+    // moves to Done (via cleanupDoneIssueWorkers). This prevents data loss
+    // when a worker is reaped due to transient liveness failures.
     for (const workerId of deadWorkerIds) {
       const entry = workers.get(workerId);
       if (!entry) continue;
-
-      const issueId = extractIssueIdFromWorkerId(workerId)?.toLowerCase();
-      if (!issueId) continue;
-
-      if (cleanedWorkspaceIssueIds.has(issueId) || failedWorkspaceIssueIds.has(issueId)) {
-        continue;
-      }
-
-      if (opts.paths && typeof entry.repo === "string") {
-        const repoRef = parseIssueRepo(entry.repo);
-        if (repoRef) {
-          try {
-            await cleanupWorkspace(
-              opts.paths,
-              opts.legionId,
-              issueId,
-              repoRef,
-              opts.repoManagerDeps
-            );
-            cleanedWorkspaceIssueIds.add(issueId);
-          } catch (error) {
-            console.warn(
-              `[dead-worker-cleanup] workspace cleanup failed for ${issueId}: ${error instanceof Error ? error.message : String(error)}`
-            );
-            failedWorkspaceIssueIds.add(issueId);
-          }
-        }
-      }
-    }
-
-    // Second pass: remove worker state only for issues where workspace was cleaned (or no workspace)
-    for (const workerId of deadWorkerIds) {
-      const entry = workers.get(workerId);
-      if (!entry) continue;
-
-      const issueId = extractIssueIdFromWorkerId(workerId)?.toLowerCase();
-
-      // Skip issues where workspace cleanup failed — preserve state for retry
-      if (issueId && failedWorkspaceIssueIds.has(issueId)) {
-        continue;
-      }
 
       try {
         await opts.adapter.deleteSession(entry.sessionId);


### PR DESCRIPTION
## Summary
- **Root cause fix**: Replace `listActiveSessions()` (`GET /session` — 100 result default, 1800+ sessions) with per-worker `sessionExists()` (`GET /session/{id}` — O(1) lookup per worker)
- **Defense in depth**: 120s startup grace period (was 60s), 3 consecutive misses before reaping (was instant)
- **Data safety**: `cleanupDeadWorkers` no longer deletes workspaces — only cleaned when issues move to Done

## Problem
Workers were being falsely reaped because `GET /session` returns at most 100 results out of 1800+ sessions on the serve. New worker sessions weren't in the first 100, so the liveness sweep immediately marked them dead and deleted their workspaces.

## Changes
**`packages/daemon/src/daemon/runtime/types.ts`** + **`opencode.ts`** + **`claude-code.ts`**
- Replace `listActiveSessions(): Promise<Set<string>>` with `sessionExists(sessionId: string): Promise<boolean>`
- OpenCode adapter uses `GET /session/{id}` (single-row lookup, immune to pagination)
- ClaudeCode adapter checks tmux window list for specific session name

**`packages/daemon/src/daemon/index.ts`**
- Liveness sweep checks each worker individually via `adapter.sessionExists()`
- Workers on different ports checked via `GET /session/{id}` directly
- 120s startup grace period (was 60s)
- `consecutiveLivenessMisses` Map tracks misses per worker, resets on recovery
- Reap only after 3 consecutive misses with informational logging at each miss

**`packages/daemon/src/daemon/server.ts`**
- `cleanupDeadWorkers()` removes session + Envoy + in-memory state only
- Workspace cleanup removed — only happens via `cleanupDoneIssueWorkers` (issue → Done)

## Testing
- **TDD**: 4 new tests written first and verified failing, then implementation
- **989/989 tests pass**, 0 LSP errors
- **Live verified**: Daemon running 450s with 7 health ticks, 0 false liveness misses, 0 false reaps (previously every tick produced false misses)

## Live verification evidence
```
# Before fix (GET /session, 100 limit):
[liveness] Worker agent-c-7729-architect: session missing (1/3 consecutive misses)
[liveness] Worker agent-c-10133-implement: session missing (1/3 consecutive misses)

# After fix (GET /session/{id}):
# <no liveness log entries at all — workers correctly found every tick>
```

Closes #557