### PR TITLE
fix(envoy): systemd watchdog for on-prem container recovery (#564)

### DIFF
--- a/packages/envoy/deploy/envoy-watchdog.sh
+++ b/packages/envoy/deploy/envoy-watchdog.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# envoy-watchdog.sh — Detects and recovers from container removal.
+#
+# Installed by Pulumi to /usr/local/bin/envoy-watchdog.sh on each on-prem machine.
+# Called by a systemd timer every 60s.
+#
+# Unlike `restart: unless-stopped` (which only handles exits), this watchdog
+# handles containers being completely removed from Docker state.
+#
+# Usage: envoy-watchdog.sh <config-file>
+# Config file is JSON with container parameters, written by Pulumi.
+set -euo pipefail
+
+CONFIG="${1:-/etc/envoy/watchdog.json}"
+
+if [ ! -f "$CONFIG" ]; then
+    echo "ERROR: config file not found: $CONFIG"
+    exit 1
+fi
+
+# Read config — Pulumi writes this during provisioning.
+CONTAINER_NAME=$(jq -r '.container_name' "$CONFIG")
+IMAGE=$(jq -r '.image' "$CONFIG")
+ENV_FILE=$(jq -r '.env_file' "$CONFIG")
+NETWORK_MODE=$(jq -r '.network_mode' "$CONFIG")
+HEALTHCHECK_CMD=$(jq -r '.healthcheck_cmd' "$CONFIG")
+
+check_container() {
+    # Returns 0 if container exists and is running, 1 otherwise.
+    local state
+    state=$(docker inspect --format '{{.State.Status}}' "$CONTAINER_NAME" 2>/dev/null || echo "missing")
+    [ "$state" = "running" ]
+}
+
+recover_container() {
+    local state
+    state=$(docker inspect --format '{{.State.Status}}' "$CONTAINER_NAME" 2>/dev/null || echo "missing")
+
+    case "$state" in
+        running)
+            return 0
+            ;;
+        exited|created|paused)
+            echo "Container $CONTAINER_NAME is $state — starting"
+            docker start "$CONTAINER_NAME"
+            ;;
+        missing)
+            echo "Container $CONTAINER_NAME is missing — recreating"
+
+            # Build docker run args from config
+            local -a args=(
+                --name "$CONTAINER_NAME"
+                --restart unless-stopped
+                --network "$NETWORK_MODE"
+                --env-file "$ENV_FILE"
+            )
+
+            # Add volumes from config (if any)
+            local volumes
+            volumes=$(jq -r '.volumes[]? // empty' "$CONFIG" 2>/dev/null)
+            while IFS= read -r vol; do
+                [ -n "$vol" ] && args+=(--volume "$vol")
+            done <<< "$volumes"
+
+            # Add healthcheck
+            if [ -n "$HEALTHCHECK_CMD" ] && [ "$HEALTHCHECK_CMD" != "null" ]; then
+                args+=(
+                    --health-cmd "$HEALTHCHECK_CMD"
+                    --health-interval 10s
+                    --health-timeout 3s
+                    --health-retries 3
+                    --health-start-period 30s
+                )
+            fi
+
+            docker run -d "${args[@]}" "$IMAGE"
+            ;;
+        *)
+            echo "Container $CONTAINER_NAME is in unexpected state: $state — removing and recreating"
+            docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+            recover_container  # recurse once (will hit 'missing' branch)
+            ;;
+    esac
+}
+
+if ! check_container; then
+    recover_container
+    echo "Recovery complete"
+else
+    # Silent when healthy — only log on recovery
+    :
+fi

--- a/packages/envoy/infra/index.ts
+++ b/packages/envoy/infra/index.ts
@@ -4,7 +4,8 @@ import { pullImages } from "./images";
 import type { MachineConfig } from "./machines";
 import { createProvider } from "./machines";
 import { createNatsPeer } from "./nats";
-import { createListener } from "./services";
+import { computeNatsUrls, createListener } from "./services";
+import { deployWatchdog } from "./watchdog";
 
 const cfg = new pulumi.Config("envoy");
 
@@ -48,5 +49,18 @@ for (const machine of machines) {
   }
 
   // Listener — on ALL machines
-  createListener(provider, machine, machines, images.envoy, secrets, natsDependency);
+  const listener = createListener(provider, machine, machines, images.envoy, secrets, natsDependency);
+
+  // Watchdog — on-prem machines only (machines with SSH access).
+  // Detects container removal and recreates via systemd timer.
+  if (machine.sshHost) {
+    const envs = [
+      "PORT=9020",
+      `ENVOY_MACHINE_ID=${machine.machineId}`,
+      `NATS_URLS=${computeNatsUrls(machine.name, !!machine.nats, machines.map(m => ({ name: m.name, nats: !!m.nats })))}`,
+      "ENVOY_HOST_BRIDGE=127.0.0.1",
+      `ENVOY_KV_REPLICAS=${machines.filter(m => !!m.nats).length}`,
+    ];
+    deployWatchdog(machine, envs, `${registry}/envoy:${imageTag}`, [listener]);
+  }
 }

--- a/packages/envoy/infra/package-lock.json
+++ b/packages/envoy/infra/package-lock.json
@@ -8,6 +8,7 @@
       "name": "envoy-infra",
       "version": "0.0.1",
       "dependencies": {
+        "@pulumi/command": "^1.2.1",
         "@pulumi/docker": "4.11.0",
         "@pulumi/pulumi": "^3.0.0"
       }
@@ -775,6 +776,16 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@pulumi/command": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@pulumi/command/-/command-1.2.1.tgz",
+      "integrity": "sha512-mutNDIUYP67yCBYOVIidQyxuTwZDY9v/sx9EGbgIv4PXfyfolOKGgGLeoHEbI1lxRwaw2wbTZ3VNIynDnA5VKA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@pulumi/pulumi": "^3.142.0"
+      }
     },
     "node_modules/@pulumi/docker": {
       "version": "4.11.0",

--- a/packages/envoy/infra/package.json
+++ b/packages/envoy/infra/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "main": "index.ts",
   "dependencies": {
-    "@pulumi/pulumi": "^3.0.0",
-    "@pulumi/docker": "4.11.0"
+    "@pulumi/command": "^1.2.1",
+    "@pulumi/docker": "4.11.0",
+    "@pulumi/pulumi": "^3.0.0"
   }
 }

--- a/packages/envoy/infra/watchdog.ts
+++ b/packages/envoy/infra/watchdog.ts
@@ -1,0 +1,179 @@
+import * as command from "@pulumi/command";
+import * as pulumi from "@pulumi/pulumi";
+import type { MachineConfig } from "./machines";
+
+/**
+ * Deploy a systemd watchdog on an on-prem machine that detects and recovers
+ * from container removal. Runs every 60s via systemd timer.
+ *
+ * The watchdog checks if the envoy-listener container exists and is running.
+ * If stopped: `docker start`. If removed: `docker run` with saved config.
+ *
+ * Config is written to /etc/envoy/watchdog.json with the container parameters.
+ * The watchdog script, systemd unit, and timer are deployed via SSH.
+ */
+export function deployWatchdog(
+  machine: MachineConfig,
+  containerEnvs: string[],
+  image: string,
+  dependsOn: pulumi.Resource[]
+): command.remote.Command {
+  // Only deploy on machines with SSH access (on-prem, not Fargate).
+  if (!machine.sshHost) {
+    throw new Error(`Watchdog requires SSH — machine ${machine.name} has no sshHost`);
+  }
+
+  const connection: command.types.input.remote.ConnectionArgs = {
+    host: machine.sshHost.replace("ssh://", ""),
+  };
+
+  // Build the env file content from the container envs.
+  const envFileContent = containerEnvs.join("\n");
+
+  // Build volume args from machine config.
+  const volumeArgs: string[] = [];
+  const tsnet = machine.listener.tsnet;
+  if (tsnet) {
+    const volumeName = `envoy-listener-tsnet-state-${machine.name}`;
+    volumeArgs.push(`${volumeName}:${tsnet.stateDir}`);
+  }
+
+  // Watchdog config JSON.
+  const watchdogConfig = JSON.stringify(
+    {
+      container_name: "envoy-listener",
+      image,
+      env_file: "/etc/envoy/listener.env",
+      network_mode: "host",
+      healthcheck_cmd: "curl -sf http://127.0.0.1:9020/healthz",
+      volumes: volumeArgs,
+    },
+    null,
+    2
+  );
+
+  // The watchdog script (self-contained, no external dependencies beyond docker + jq).
+  const watchdogScript = `#!/usr/bin/env bash
+# envoy-watchdog — detects and recovers from container removal.
+# Deployed by Pulumi. Run by systemd timer every 60s.
+set -euo pipefail
+
+CONFIG="/etc/envoy/watchdog.json"
+CONTAINER_NAME="envoy-listener"
+
+check_running() {
+    local state
+    state=$(docker inspect --format '{{.State.Status}}' "$CONTAINER_NAME" 2>/dev/null || echo "missing")
+    [ "$state" = "running" ]
+}
+
+if check_running; then
+    exit 0
+fi
+
+STATE=$(docker inspect --format '{{.State.Status}}' "$CONTAINER_NAME" 2>/dev/null || echo "missing")
+echo "envoy-watchdog: container is $STATE — recovering"
+
+case "$STATE" in
+    exited|created|paused)
+        docker start "$CONTAINER_NAME"
+        ;;
+    missing)
+        IMAGE=$(jq -r '.image' "$CONFIG")
+        ENV_FILE=$(jq -r '.env_file' "$CONFIG")
+        NETWORK=$(jq -r '.network_mode' "$CONFIG")
+        HC_CMD=$(jq -r '.healthcheck_cmd' "$CONFIG")
+
+        ARGS=(--name "$CONTAINER_NAME" --restart unless-stopped --network "$NETWORK" --env-file "$ENV_FILE")
+
+        for vol in $(jq -r '.volumes[]? // empty' "$CONFIG"); do
+            [ -n "$vol" ] && ARGS+=(--volume "$vol")
+        done
+
+        if [ -n "$HC_CMD" ] && [ "$HC_CMD" != "null" ]; then
+            ARGS+=(--health-cmd "$HC_CMD" --health-interval 10s --health-timeout 3s --health-retries 3 --health-start-period 30s)
+        fi
+
+        docker run -d "\${ARGS[@]}" "$IMAGE"
+        ;;
+    *)
+        docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+        exec "$0"  # re-exec to hit 'missing' branch
+        ;;
+esac
+echo "envoy-watchdog: recovery complete"
+`;
+
+  const systemdUnit = `[Unit]
+Description=Envoy Listener Watchdog
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/envoy-watchdog
+`;
+
+  const systemdTimer = `[Unit]
+Description=Envoy Listener Watchdog Timer
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=60s
+AccuracySec=5s
+
+[Install]
+WantedBy=timers.target
+`;
+
+  // Deploy everything in one SSH command.
+  return new command.remote.Command(
+    `watchdog-${machine.name}`,
+    {
+      connection,
+      create: pulumi.interpolate`
+        set -e
+        mkdir -p /etc/envoy
+
+        # Write env file
+        cat > /etc/envoy/listener.env << 'ENVEOF'
+${envFileContent}
+ENVEOF
+
+        # Write watchdog config
+        cat > /etc/envoy/watchdog.json << 'CFGEOF'
+${watchdogConfig}
+CFGEOF
+
+        # Write watchdog script
+        cat > /usr/local/bin/envoy-watchdog << 'SCRIPTEOF'
+${watchdogScript}
+SCRIPTEOF
+        chmod +x /usr/local/bin/envoy-watchdog
+
+        # Write systemd unit
+        cat > /etc/systemd/system/envoy-watchdog.service << 'UNITEOF'
+${systemdUnit}
+UNITEOF
+
+        # Write systemd timer
+        cat > /etc/systemd/system/envoy-watchdog.timer << 'TIMEREOF'
+${systemdTimer}
+TIMEREOF
+
+        # Enable and start the timer
+        systemctl daemon-reload
+        systemctl enable envoy-watchdog.timer
+        systemctl start envoy-watchdog.timer
+        echo "Watchdog deployed on ${machine.name}"
+      `,
+      delete: `
+        systemctl stop envoy-watchdog.timer 2>/dev/null || true
+        systemctl disable envoy-watchdog.timer 2>/dev/null || true
+        rm -f /usr/local/bin/envoy-watchdog /etc/systemd/system/envoy-watchdog.{service,timer} /etc/envoy/watchdog.json /etc/envoy/listener.env
+        systemctl daemon-reload
+      `,
+    },
+    { dependsOn }
+  );
+}


### PR DESCRIPTION
## Summary
Closes #564. Adds a systemd watchdog that detects and recovers from container removal on on-prem machines.

**Problem:** `restart: unless-stopped` handles container exits but NOT container removal (e.g., `docker system prune`, Pulumi state drift). When containers are removed, the listener silently stops and never recovers.

**Fix:** A systemd timer runs every 60s on each on-prem machine:
1. `docker inspect envoy-listener` — check if container exists and is running
2. If stopped → `docker start`
3. If removed → `docker run` with saved config from `/etc/envoy/watchdog.json`
4. If running → silent exit (no log spam)

**What's deployed:**
- `/usr/local/bin/envoy-watchdog` — the watchdog script
- `/etc/envoy/watchdog.json` — container config (image, env file, volumes, healthcheck)
- `/etc/envoy/listener.env` — container environment variables
- `/etc/systemd/system/envoy-watchdog.{service,timer}` — systemd units

**Implementation:**
- New `@pulumi/command` dependency for SSH-based remote execution
- `infra/watchdog.ts` — deploys watchdog via `command.remote.Command`
- `infra/index.ts` — wires watchdog into the deploy loop (on-prem machines only, skipped for Fargate)
- `deploy/envoy-watchdog.sh` — standalone version for manual testing

**Cleanup:** `pulumi destroy` removes the watchdog (systemd timer, scripts, config).