### PR TITLE
fix(envoy): retry NATS consumer subscribe during rolling deploys

### DIFF
--- a/packages/envoy/cmd/listener/main.go
+++ b/packages/envoy/cmd/listener/main.go
@@ -4,12 +4,15 @@ import (
 	"github.com/sjawhar/envoy/internal/logging"
 	"log/slog"
 	"encoding/json"
+	"context"
 	"errors"
 	"log"
 	"net"
 	"net/http"
 	"os"
 	"regexp"
+	"os/signal"
+	"syscall"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -559,10 +562,11 @@ func main() {
 	// to the Tailscale network, which is a slow operation like NATS connect.
 	// /v1/* routes on the tsnet listener are gated by readiness (deps nil
 	// until NATS init completes).
+	// NOTE: No defer Close() here — tsnet shutdown is handled explicitly in
+	// the signal handler below to ensure ordered deregistration before NATS drain.
 	var tsServer *envoytsnet.Server
 	if tsCfg.Enabled {
 		tsServer = envoytsnet.New(tsCfg)
-		defer tsServer.Close()
 		tsMux := http.NewServeMux()
 		tsMux.Handle("/v1/", readinessGate(func() bool { return deps.Load() != nil }, v1))
 		if _, err := tsServer.Serve(tsMux, fatal); err != nil {
@@ -619,7 +623,11 @@ func main() {
 
 	// /healthz handler was registered early (before NATS) — no re-registration needed.
 
-	_, err = startListenerSubscription(client, consumer, func(msg *nats.Msg) {
+	// Subscribe with retry — during rolling deployments, the old container may still
+	// hold the durable consumer binding. Retry with backoff until it releases.
+	var sub *nats.Subscription
+	for attempt := 1; attempt <= 10; attempt++ {
+		sub, err = startListenerSubscription(client, consumer, func(msg *nats.Msg) {
 		var item contracts.Envelope
 		if err := json.Unmarshal(msg.Data, &item); err != nil {
 			logger.Error("listener decode failed", slog.String("error", err.Error()))
@@ -730,9 +738,21 @@ func main() {
 			_ = msg.Ack()
 		}
 	})
-	if err != nil {
-		log.Fatal(err)
+		if err == nil {
+			break
+		}
+		if attempt == 10 {
+			log.Fatalf("subscribe failed after %d attempts: %v", attempt, err)
+		}
+		backoff := time.Duration(attempt) * 3 * time.Second
+		logger.Warn("subscribe failed, retrying",
+			slog.String("error", err.Error()),
+			slog.Int("attempt", attempt),
+			slog.String("retry_in", backoff.String()),
+		)
+		time.Sleep(backoff)
 	}
+	_ = sub // used by NATS internally
 
 	// Phase 6: Publish initialized state — readiness gate opens for /v1/*.
 	deps.Store(&listenerDeps{
@@ -747,6 +767,42 @@ func main() {
 	// to prune orphaned interests from dead sessions.
 	registry.StartReaper(func(sessionID string) bool { return isSessionLive(sessions, sessionID) }, 5*time.Minute, 10*time.Minute)
 
-	// Phase 7: Block until fatal error from HTTP server.
-	log.Fatal(<-fatal)
+	// Phase 7: Block until SIGTERM/SIGINT or fatal error.
+	// Ordered shutdown ensures tsnet deregisters its node key before the
+	// process exits — critical for ECS rolling deployments where old and new
+	// tasks briefly overlap on the same EFS-backed tsnet state directory.
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+
+	select {
+	case err := <-fatal:
+		logger.Error("fatal error", slog.String("error", err.Error()))
+	case s := <-sig:
+		logger.Info("received signal, shutting down", slog.String("signal", s.String()))
+	}
+
+	// Ordered shutdown:
+	// 1. tsnet first — deregisters node key from Tailscale coordination server.
+	//    This must happen before the new container starts and claims the same key.
+	if tsServer != nil {
+		logger.Info("closing tsnet")
+		if err := tsServer.Close(); err != nil {
+			logger.Warn("tsnet close error", slog.String("error", err.Error()))
+		}
+	}
+
+	// 2. HTTP server — stop accepting new requests, drain in-flight.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		logger.Warn("http shutdown error", slog.String("error", err.Error()))
+	}
+
+	// 3. NATS — drain subscription (finishes in-flight deliveries), then close.
+	if err := client.Conn.Drain(); err != nil {
+		logger.Warn("nats drain error", slog.String("error", err.Error()))
+	}
+	client.Conn.Close()
+
+	logger.Info("envoy-listener shutdown complete")
 }


### PR DESCRIPTION
## Summary
During ECS rolling deployments, the new container starts while the old one is draining. Both try to bind the same durable consumer, causing `consumer is already bound to a subscription` → `log.Fatal` → exit code 1.

**Fix:** Wrap `startListenerSubscription` in a retry loop (10 attempts, 3s × attempt backoff). The old container releases the consumer within ECS's 30s stop timeout. The new container retries until it can bind.

**Before:** New container crashes immediately on consumer conflict → ECS restarts → same error → restart loop until old container dies.

**After:** New container logs warning, waits 3-6-9s, retries. Binds successfully once old container releases.