### PR TITLE
fix(envoy): fix subscribe retry race with auto-resubscribe + release consumer on exit

### DIFF
--- a/packages/envoy/cmd/listener/main.go
+++ b/packages/envoy/cmd/listener/main.go
@@ -742,7 +742,21 @@ func main() {
 			break
 		}
 		if attempt == 10 {
-			log.Fatalf("subscribe failed after %d attempts: %v", attempt, err)
+			logger.Error("subscribe failed after max attempts, shutting down",
+				slog.String("error", err.Error()),
+				slog.Int("attempts", attempt),
+			)
+			// Close NATS before exiting — releases the consumer binding so the
+			// next container can claim it. log.Fatal/os.Exit skips cleanup.
+			client.Conn.Close()
+			os.Exit(1)
+		}
+		// Check if auto-resubscribe (bus.Client.onReconnect) already succeeded
+		// while we were sleeping. If so, the consumer is bound by our own client
+		// and retrying would hit "consumer is already bound" from ourselves.
+		if client.SubOK() {
+			logger.Info("subscribe succeeded via auto-resubscribe during retry backoff")
+			break
 		}
 		backoff := time.Duration(attempt) * 3 * time.Second
 		logger.Warn("subscribe failed, retrying",


### PR DESCRIPTION
## Summary
**URGENT — blocks all Fargate listener deployments.**

Fixes two bugs in the subscribe retry loop (added in PR #569):

**Bug 1: Race with auto-resubscribe**
The `bus.Client.onReconnect` auto-resubscribes when NATS reconnects. The retry loop in `main.go` also tries to subscribe. If NATS briefly disconnects during startup, both race to bind the same consumer → "consumer is already bound" (client-side, not server-side).

Fix: check `client.SubOK()` before each retry. If auto-resubscribe already succeeded, stop retrying.

**Bug 2: `log.Fatalf` skips NATS cleanup**
After exhausting 10 retries, `log.Fatalf` calls `os.Exit` which skips all cleanup. The NATS connection stays open → consumer stays bound → next container hits the same error → death loop.

Fix: `client.Conn.Close()` before `os.Exit(1)` to release the consumer binding.

Supersedes #570 (which conflicted with merged #569).