### PR TITLE
fix(envoy): auto-detect first boot for tsnet FORCE_LOGIN

### DIFF
--- a/packages/envoy/cmd/listener/main.go
+++ b/packages/envoy/cmd/listener/main.go
@@ -566,6 +566,20 @@ func main() {
 	// the signal handler below to ensure ordered deregistration before NATS drain.
 	var tsServer *envoytsnet.Server
 	if tsCfg.Enabled {
+		// On first boot (empty state dir), tsnet sees NoState and ignores the
+		// auth key. Set TSNET_FORCE_LOGIN=1 to force authentication. On subsequent
+		// restarts with existing state, skip it so tsnet reuses the persisted identity.
+		if tsCfg.StateDir != "" {
+			stateFile := tsCfg.StateDir + "/tailscaled.state"
+			if _, err := os.Stat(stateFile); os.IsNotExist(err) {
+				logger.Info("tsnet state dir is empty (first boot), setting TSNET_FORCE_LOGIN=1")
+				os.Setenv("TSNET_FORCE_LOGIN", "1")
+			} else {
+				// Ensure TSNET_FORCE_LOGIN is NOT set for restarts — it forces
+				// re-authentication which creates duplicate Tailscale nodes.
+				os.Unsetenv("TSNET_FORCE_LOGIN")
+			}
+		}
 		tsServer = envoytsnet.New(tsCfg)
 		tsMux := http.NewServeMux()
 		tsMux.Handle("/v1/", readinessGate(func() bool { return deps.Load() != nil }, v1))


### PR DESCRIPTION
## Summary
Eliminates the need for manual `TSNET_FORCE_LOGIN=1` env var management.

**Problem:** tsnet ignores the auth key when state is `NoState` (empty state dir). We told the Telemetry PO to set `TSNET_FORCE_LOGIN=1` for first boot, but it forces re-authentication on EVERY restart, creating duplicate Tailscale nodes.

**Fix:** Before creating the tsnet server, check if `tailscaled.state` exists:
- **Missing** (first boot): `os.Setenv("TSNET_FORCE_LOGIN", "1")` → forces auth
- **Present** (restart): `os.Unsetenv("TSNET_FORCE_LOGIN")` → reuses persisted identity

The Telemetry PO can remove `TSNET_FORCE_LOGIN` from the ECS task definition entirely. The listener handles it automatically.