### PR TITLE
fix(envoy): improve tsnet first-boot detection logging

### DIFF
--- a/packages/envoy/cmd/listener/main.go
+++ b/packages/envoy/cmd/listener/main.go
@@ -571,12 +571,18 @@ func main() {
 		// restarts with existing state, skip it so tsnet reuses the persisted identity.
 		if tsCfg.StateDir != "" {
 			stateFile := tsCfg.StateDir + "/tailscaled.state"
-			if _, err := os.Stat(stateFile); os.IsNotExist(err) {
-				logger.Info("tsnet state dir is empty (first boot), setting TSNET_FORCE_LOGIN=1")
+			logger.Info("tsnet first-boot check", slog.String("state_file", stateFile))
+			fi, statErr := os.Stat(stateFile)
+			if statErr != nil && os.IsNotExist(statErr) {
+				logger.Info("tsnet state file missing (first boot), setting TSNET_FORCE_LOGIN=1")
+				os.Setenv("TSNET_FORCE_LOGIN", "1")
+			} else if statErr != nil {
+				logger.Warn("tsnet state file stat error (treating as first boot)",
+					slog.String("error", statErr.Error()))
 				os.Setenv("TSNET_FORCE_LOGIN", "1")
 			} else {
-				// Ensure TSNET_FORCE_LOGIN is NOT set for restarts — it forces
-				// re-authentication which creates duplicate Tailscale nodes.
+				logger.Info("tsnet state file exists, reusing identity",
+					slog.Int64("size", fi.Size()))
 				os.Unsetenv("TSNET_FORCE_LOGIN")
 			}
 		}


### PR DESCRIPTION
## Summary
Follow-up to #573. Adds explicit `os.Stat` logging so operators can see exactly what the first-boot detection does:

- Logs the exact state file path being checked
- Logs whether file exists (with size), is missing (first boot), or has a stat error
- Handles non-IsNotExist errors (e.g., permission denied) as first boot rather than silently falling through

Verified in production by Telemetry PO — debug-v2 image shows correct behavior:
```
tsnet first-boot check  state_file="/var/lib/envoy-tsnet/listener/tailscaled.state"
tsnet state file exists, reusing identity  size=2479
```