### PR TITLE
feat(daemon): worker mode → agent type mapping (#541)

### DIFF
--- a/packages/daemon/src/daemon/config.ts
+++ b/packages/daemon/src/daemon/config.ts
@@ -42,6 +42,8 @@ export interface DaemonConfig {
   /** Stall detection threshold in ms. Workers with flat message count while busy
    *  for longer than this are reported as stalled. 0 = disabled. */
   stallThresholdMs: number;
+  /** Maps worker mode to agent type for the initial prompt's AgentPartInput. */
+  modeAgents: Partial<Record<string, string>>;
 }
 
 export interface LoadedConfigFile {
@@ -117,6 +119,9 @@ const CONFIG_SCHEMA: ConfigSchema = {
   },
   auto_advance: null,
   stall_threshold_minutes: null,
+  mode_agents: {
+    [CONFIG_ANY_KEY]: null,
+  },
 };
 
 function parseOptionalNumber(value: string | undefined): number | undefined {
@@ -620,6 +625,28 @@ export function loadConfigFromFile(yamlText: string, configDir: string): LoadedC
     fields.extraProjects = extraProjects;
   }
 
+  const modeAgents = parsed.mode_agents;
+  if (modeAgents !== undefined && modeAgents !== null) {
+    if (!isRecord(modeAgents)) {
+      throw new Error("mode_agents must be a mapping");
+    }
+    const validModes = new Set(["architect", "plan", "implement", "test", "review", "merge"]);
+    const mapping: Record<string, string> = {};
+    for (const [mode, agent] of Object.entries(modeAgents)) {
+      if (!validModes.has(mode)) {
+        warnings.push(`mode_agents: unknown mode '${mode}' (valid: ${[...validModes].join(", ")})`);
+        continue;
+      }
+      const agentName = readString(agent, `mode_agents.${mode}`);
+      if (agentName !== undefined) {
+        mapping[mode] = agentName;
+      }
+    }
+    if (Object.keys(mapping).length > 0) {
+      fields.modeAgents = mapping;
+    }
+  }
+
   return { fields, warnings };
 }
 
@@ -843,6 +870,7 @@ export function resolveDaemonConfig(
       rssCheckIntervalMs: rssCheckIntervalMs.value,
       autoAdvance: autoAdvance.value,
       stallThresholdMs: stallThresholdMs.value,
+      modeAgents: (configFields.modeAgents as Partial<Record<string, string>> | undefined) ?? {},
     },
     warnings,
   };

--- a/packages/daemon/src/daemon/index.ts
+++ b/packages/daemon/src/daemon/index.ts
@@ -530,6 +530,7 @@ export async function startDaemon(
         envoyUrl: config.envoyUrl,
         issueBackend: config.issueBackend,
         autoAdvance: config.autoAdvance,
+        modeAgents: config.modeAgents,
         shutdownFn: async () => {
           resolvedDeps.setTimeout(async () => {
             await shutdown(true);

--- a/packages/daemon/src/daemon/runtime/claude-code.ts
+++ b/packages/daemon/src/daemon/runtime/claude-code.ts
@@ -101,7 +101,7 @@ export class ClaudeCodeAdapter implements RuntimeAdapter {
     return sessionId;
   }
 
-  async sendPrompt(sessionId: string, text: string): Promise<void> {
+  async sendPrompt(sessionId: string, text: string, _agentName?: string): Promise<void> {
     const windowTarget = `${this.sessionName}:${sessionId}`;
     const alive = this.isProcessAlive(sessionId);
 

--- a/packages/daemon/src/daemon/runtime/opencode.ts
+++ b/packages/daemon/src/daemon/runtime/opencode.ts
@@ -77,12 +77,17 @@ export class OpenCodeAdapter implements RuntimeAdapter {
     this.workspaces.delete(sessionId);
   }
 
-  async sendPrompt(sessionId: string, text: string): Promise<void> {
+  async sendPrompt(sessionId: string, text: string, agentName?: string): Promise<void> {
     await this.ensureRunning();
     const client = createWorkerClient(this.port, this.workspaces.get(sessionId) ?? "");
+    const parts: Array<{ type: string; text?: string; name?: string }> = [];
+    if (agentName) {
+      parts.push({ type: "agent", name: agentName });
+    }
+    parts.push({ type: "text", text });
     await client.session.promptAsync({
       sessionID: sessionId,
-      parts: [{ type: "text", text }],
+      parts: parts as Array<{ type: "text"; text: string }>,
     });
   }
 

--- a/packages/daemon/src/daemon/runtime/types.ts
+++ b/packages/daemon/src/daemon/runtime/types.ts
@@ -21,7 +21,7 @@ export interface RuntimeAdapter {
   deleteSession(sessionId: string): Promise<void>;
 
   /** Send a prompt to an existing session */
-  sendPrompt(sessionId: string, text: string): Promise<void>;
+  sendPrompt(sessionId: string, text: string, agentName?: string): Promise<void>;
 
   /** Get the port for direct client connections (0 if not applicable).
    * NOTE: This is an OpenCode-specific concept. ClaudeCode returns 0.

--- a/packages/daemon/src/daemon/server.ts
+++ b/packages/daemon/src/daemon/server.ts
@@ -80,6 +80,8 @@ export interface ServerOptions {
   issueBackend?: "linear" | "github";
   /** Auto-advance: dispatch next worker when current one finishes */
   autoAdvance?: boolean;
+  /** Maps worker mode to agent type for AgentPartInput on initial prompt. */
+  modeAgents?: Partial<Record<string, string>>;
 }
 
 interface ErrorResponse {
@@ -1105,7 +1107,8 @@ export function startServer(opts: ServerOptions): {
                 let lastError: Error = new Error("All prompt retry attempts failed");
                 for (let attempt = 0; attempt < PROMPT_RETRY_ATTEMPTS; attempt++) {
                   try {
-                    await workerAdapter.sendPrompt(actualSessionId, prompt);
+                    const agentName = opts.modeAgents?.[mode];
+                    await workerAdapter.sendPrompt(actualSessionId, prompt, agentName);
                     promptDelivered = true;
                     break;
                   } catch (error) {


### PR DESCRIPTION
## Summary
Closes #541 (Steps 1-2). Maps worker modes to agent types so different phases use the right model.

**Changes:**
- `DaemonConfig.modeAgents`: new `Partial<Record<string, string>>` field
- `legion.yaml` parser: `mode_agents` mapping with mode validation and unknown-mode warnings
- `RuntimeAdapter.sendPrompt()`: new optional `agentName` parameter
- `opencode.ts`: prepends `AgentPartInput` (`{type: "agent", name}`) to the message parts when `agentName` is set
- `claude-code.ts`: accepts `_agentName` param (unused — Claude Code doesn't have agent selection)
- `server.ts`: looks up `opts.modeAgents[mode]` at dispatch and passes to `sendPrompt`
- `index.ts`: wires `config.modeAgents` into `startServer` options

**Usage in legion.yaml:**
```yaml
mode_agents:
  architect: orchestrator
  plan: orchestrator
  implement: orchestrator
  test: executor
  review: conductor
  merge: executor
```

No mapping = default `build` agent (backwards compatible). 1003 tests pass.

Step 3 (review conductor skill for cross-model council) is a separate PR.