### PR TITLE
feat(envoy): payload-based topic routing for MCP bridge (WhatsApp support)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -260,3 +260,6 @@ $RECYCLE.BIN/
 !.sisyphus/rules/
 # .legion/ handoff data must be committed — do not ignore the directory
 # (see implement.md step 6 note)
+
+# Locally built MCP bridge binary (built artifact, not source)
+packages/envoy/mcp

--- a/.opencode/skills/CLAUDE.md
+++ b/.opencode/skills/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/contracts/CLAUDE.md
+++ b/packages/contracts/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/daemon/src/daemon/CLAUDE.md
+++ b/packages/daemon/src/daemon/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/daemon/src/state/CLAUDE.md
+++ b/packages/daemon/src/state/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/envoy-plugin/CLAUDE.md
+++ b/packages/envoy-plugin/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/envoy/CLAUDE.md
+++ b/packages/envoy/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/envoy/internal/mcpbridge/bridge.go
+++ b/packages/envoy/internal/mcpbridge/bridge.go
@@ -1,10 +1,13 @@
 package mcpbridge
 
 import (
+	"encoding/json"
 	"log"
 	"sync"
 	"time"
 	"github.com/sjawhar/envoy/internal/bus"
+	"github.com/sjawhar/envoy/internal/contracts"
+	"github.com/sjawhar/envoy/internal/id"
 )
 
 type Bridge struct {
@@ -64,14 +67,54 @@ func (b *Bridge) handleNotification(cfg *ServerConfig, uri string) {
 	}
 	b.mu.Unlock()
 	if server == nil { log.Printf("mcp-bridge: no server for %s", cfg.Name); return }
-	if _, err := cfg.RenderTopic(uri); err != nil { log.Printf("mcp-bridge: %s: URI does not match pattern: %s", cfg.Name, uri); return }
+
 	contents, err := server.ReadResource(uri)
 	if err != nil { log.Printf("mcp-bridge: %s: resources/read failed for %s: %v", cfg.Name, uri, err); return }
+
+	// Payload routing: parse resource content as JSON array, publish one
+	// envelope per item with topic derived from payload fields.
+	if len(cfg.PayloadRouting) > 0 {
+		b.handlePayloadRouted(cfg, uri, contents)
+		return
+	}
+
+	// URI routing: topic derived from the notification URI.
+	if _, err := cfg.RenderTopic(uri); err != nil { log.Printf("mcp-bridge: %s: URI does not match pattern: %s", cfg.Name, uri); return }
 	envelope, err := BuildEnvelope(cfg, uri, contents)
 	if err != nil { log.Printf("mcp-bridge: %s: envelope construction failed: %v", cfg.Name, err); return }
 	if err := envelope.Validate(); err != nil { log.Printf("mcp-bridge: %s: invalid envelope: %v", cfg.Name, err); return }
 	if err := b.client.Publish(envelope); err != nil { log.Printf("mcp-bridge: %s: publish failed: %v", cfg.Name, err); return }
 	log.Printf("mcp-bridge: %s: published to %s", cfg.Name, envelope.Topic)
+}
+
+func (b *Bridge) handlePayloadRouted(cfg *ServerConfig, uri string, contents []resourceContent) {
+	for _, c := range contents {
+		if c.Text == "" { continue }
+		var items []map[string]interface{}
+		if err := json.Unmarshal([]byte(c.Text), &items); err != nil {
+			var single map[string]interface{}
+			if err := json.Unmarshal([]byte(c.Text), &single); err != nil {
+				log.Printf("mcp-bridge: %s: payload not JSON array or object: %v", cfg.Name, err)
+				continue
+			}
+			items = []map[string]interface{}{single}
+		}
+		for _, item := range items {
+			topic, err := cfg.RenderTopicFromPayload(item)
+			if err != nil { log.Printf("mcp-bridge: %s: payload routing: %v", cfg.Name, err); continue }
+			itemJSON, _ := json.Marshal(item)
+			summary := truncateSummary(string(itemJSON), 200)
+			envelope := contracts.Envelope{
+				EventID: id.New(), Source: cfg.Source, SourceEventID: uri,
+				Topic: topic, DedupeKey: buildDedupeKey(cfg.Source, topic, summary),
+				IssuedAt: contracts.NowMillis(), PayloadSummary: summary,
+				PayloadRef: uri, TraceID: id.New(),
+			}
+			if err := envelope.Validate(); err != nil { log.Printf("mcp-bridge: %s: invalid envelope: %v", cfg.Name, err); continue }
+			if err := b.client.Publish(envelope); err != nil { log.Printf("mcp-bridge: %s: publish to %s failed: %v", cfg.Name, topic, err); continue }
+			log.Printf("mcp-bridge: %s: published to %s", cfg.Name, topic)
+		}
+	}
 }
 
 func (b *Bridge) monitor(s Server, cfg *ServerConfig) {

--- a/packages/envoy/internal/mcpbridge/config.go
+++ b/packages/envoy/internal/mcpbridge/config.go
@@ -20,6 +20,12 @@ type ServerConfig struct {
 	Source        string            `json:"source"`
 	TopicTemplate string            `json:"topic_template"`
 	URIPattern    string            `json:"uri_pattern"`
+	// PayloadRouting enables extracting topic variables from JSON payload
+	// fields instead of the URI. When set, the bridge parses each resource
+	// content as a JSON array and publishes one envelope per item.
+	// Keys are topic template placeholders, values are JSON field names.
+	// Example: {"phone": "chat", "jid": "chat_jid"}
+	PayloadRouting map[string]string `json:"payload_routing,omitempty"`
 	compiled *regexp.Regexp
 }
 
@@ -91,27 +97,38 @@ func (s *ServerConfig) validate() error {
 	if strings.TrimSpace(s.TopicTemplate) == "" {
 		return fmt.Errorf("topic_template is required")
 	}
-	if strings.TrimSpace(s.URIPattern) == "" {
-		return fmt.Errorf("uri_pattern is required")
-	}
-	re, err := regexp.Compile(s.URIPattern)
-	if err != nil {
-		return fmt.Errorf("uri_pattern: %w", err)
-	}
-	s.compiled = re
-	groups := make(map[string]bool)
-	for _, name := range re.SubexpNames() {
-		if name != "" {
-			groups[name] = true
+	// When payload_routing is set, URI pattern is optional — the URI is just
+	// a notification trigger, and topic variables come from the JSON payload.
+	if len(s.PayloadRouting) > 0 {
+		placeholders := extractPlaceholders(s.TopicTemplate)
+		for _, ph := range placeholders {
+			if _, ok := s.PayloadRouting[ph]; !ok {
+				return fmt.Errorf("topic_template placeholder {%s} has no matching payload_routing key", ph)
+			}
 		}
-	}
-	placeholders := extractPlaceholders(s.TopicTemplate)
-	if len(placeholders) == 0 {
-		return fmt.Errorf("topic_template has no {placeholder} variables")
-	}
-	for _, ph := range placeholders {
-		if !groups[ph] {
-			return fmt.Errorf("topic_template placeholder {%s} has no matching named capture group in uri_pattern", ph)
+	} else {
+		if strings.TrimSpace(s.URIPattern) == "" {
+			return fmt.Errorf("uri_pattern is required (or set payload_routing)")
+		}
+		re, err := regexp.Compile(s.URIPattern)
+		if err != nil {
+			return fmt.Errorf("uri_pattern: %w", err)
+		}
+		s.compiled = re
+		groups := make(map[string]bool)
+		for _, name := range re.SubexpNames() {
+			if name != "" {
+				groups[name] = true
+			}
+		}
+		placeholders := extractPlaceholders(s.TopicTemplate)
+		if len(placeholders) == 0 {
+			return fmt.Errorf("topic_template has no {placeholder} variables")
+		}
+		for _, ph := range placeholders {
+			if !groups[ph] {
+				return fmt.Errorf("topic_template placeholder {%s} has no matching named capture group in uri_pattern", ph)
+			}
 		}
 	}
 	if s.Transport == "stdio" {
@@ -152,6 +169,20 @@ func (s *ServerConfig) RenderTopic(uri string) (string, error) {
 		if name != "" && i < len(match) {
 			result = strings.ReplaceAll(result, "{"+name+"}", match[i])
 		}
+	}
+	return result, nil
+}
+
+// RenderTopicFromPayload builds a topic string by extracting values from a
+// JSON payload map using the PayloadRouting field mapping.
+func (s *ServerConfig) RenderTopicFromPayload(payload map[string]interface{}) (string, error) {
+	result := s.TopicTemplate
+	for placeholder, jsonField := range s.PayloadRouting {
+		val, ok := payload[jsonField]
+		if !ok {
+			return "", fmt.Errorf("payload missing field %q for placeholder {%s}", jsonField, placeholder)
+		}
+		result = strings.ReplaceAll(result, "{"+placeholder+"}", fmt.Sprint(val))
 	}
 	return result, nil
 }


### PR DESCRIPTION
## Summary
Adds payload-based topic routing to the MCP bridge, enabling the WhatsApp MCP server integration.

**Problem:** The WhatsApp MCP server exposes a single resource (`whatsapp://messages/new`) containing ALL messages from ALL chats. The existing bridge assumes 1 resource URI = 1 topic (extracting topic variables from the URI path). WhatsApp's single-resource model needs topic variables extracted from the JSON payload instead.

**Fix:** New `payload_routing` config option on `ServerConfig`:

```json
{
  "name": "whatsapp",
  "transport": "http",
  "url": "http://localhost:3456/mcp",
  "source": "whatsapp",
  "topic_template": "notifications.whatsapp.{phone}.{jid}.message",
  "resources": ["whatsapp://messages/new"],
  "payload_routing": {
    "phone": "chat",
    "jid": "chat_jid"
  }
}
```

When `payload_routing` is set:
1. Resource notification arrives (`whatsapp://messages/new`)
2. Bridge reads resource content (JSON array of messages)
3. For each message in the array, extracts `chat` → `{phone}` and `chat_jid` → `{jid}`
4. Publishes one envelope per message with the correct per-chat topic
5. `uri_pattern` becomes optional (the URI is just a trigger, not a topic source)

**Changes:**
- `config.go`: Added `PayloadRouting map[string]string` field, `RenderTopicFromPayload()` method, relaxed validation when payload routing is set
- `bridge.go`: New `handlePayloadRouted()` method that parses JSON array/object and fans out per-item

**Backwards compatible:** Existing URI-based routing is unchanged. `payload_routing` is optional — omitting it uses the existing behavior.

All tests pass.