### PR TITLE
docs(skills): clarify opencode-api serve scope and port discovery

### DIFF
--- a/.opencode/skills/opencode-api/SKILL.md
+++ b/.opencode/skills/opencode-api/SKILL.md
@@ -1,12 +1,22 @@
 ---
 name: opencode-api
-description: OpenCode serve HTTP API reference. Use when interacting with sessions, reading messages/todos, aborting workers, managing workspaces, or any direct OpenCode serve API call. The shared serve runs on port 13381 and handles all worker and controller sessions.
+description: OpenCode serve HTTP API reference. Use when interacting with sessions, reading messages/todos, aborting workers, managing workspaces, or any direct OpenCode serve API call. Each `opencode serve` process is independent with its own port; Legion runs one shared serve per daemon (default port 13381, may differ if multiple daemons coexist on the host).
 ---
 
 # OpenCode Serve API
 
-HTTP API for the shared OpenCode serve process. All worker and controller sessions run on a
-single `opencode serve` instance (default port **13381**).
+HTTP API exposed by every `opencode serve` process. Each serve runs as an independent process
+with its own port, its own sessions, and its own state — there is no single global "the serve".
+This skill documents the API contract; the URL you target depends on which serve instance you mean.
+
+**Legion's deployment:** Legion runs **one shared `opencode serve` per daemon** that hosts all
+worker + controller sessions for that team. That shared serve defaults to **port 13381** (the
+daemon's `baseWorkerPort`). If multiple Legion daemons run on the same host (port collision on
+13381), each daemon's serve gets a different auto-incremented port — always discover the actual
+port via the daemon API rather than hardcoding 13381 (see [Port Discovery](#port-discovery)).
+
+Examples below use `13381` as a placeholder for the Legion shared serve port. Substitute the
+actual port for your environment when running commands.
 
 **When to use this skill:**
 - Reading session messages or todos (diagnostics)
@@ -22,7 +32,10 @@ single `opencode serve` instance (default port **13381**).
 - `POST /state/collect` — state machine decisions
 - `GET /health` — daemon health
 
-## Architecture
+## Legion's Architecture
+
+In Legion's deployment, one daemon owns one shared `opencode serve`. The daemon's HTTP API
+proxies a few endpoints to that serve; everything else is reached directly on the serve port.
 
 ```
 Controller ──► Daemon API (port $LEGION_DAEMON_PORT, default 13370)
@@ -33,7 +46,7 @@ Controller ──► Daemon API (port $LEGION_DAEMON_PORT, default 13370)
                   └── POST /state/collect  → state machine
                   │
                   ▼
-              Shared Serve (port 13381)
+              Shared Serve (default 13381 — actual port may differ)
                   │
                   ├── Session 1 (controller)
                   ├── Session 2 (worker: eng-42-implement)
@@ -41,14 +54,22 @@ Controller ──► Daemon API (port $LEGION_DAEMON_PORT, default 13370)
                   └── ...
 ```
 
+A second Legion daemon on the same host would spawn its own daemon (e.g. on 13371) and its own
+shared serve (e.g. on 13382) with an entirely independent set of sessions. Plain `opencode serve`
+processes started outside Legion are also independent — each on whatever port you started it with.
+
 ## Port Discovery
 
-The shared serve port is **13381** by default. To discover it programmatically:
+The Legion shared serve defaults to **13381** but may differ if multiple daemons coexist on the
+host. **Always discover the actual port via the daemon API**, never hardcode it:
 
 ```bash
 # From any worker entry returned by the daemon
 SERVE_PORT=$(curl -s http://127.0.0.1:$LEGION_DAEMON_PORT/workers | jq '.[0].port')
 ```
+
+Outside Legion (e.g. running `opencode serve` manually), the port is whatever you started the
+serve with — there is no discovery API for arbitrary serves.
 
 ## Request Scoping
 

--- a/.opencode/skills/opencode-api/reference.md
+++ b/.opencode/skills/opencode-api/reference.md
@@ -1,6 +1,6 @@
 # OpenCode Serve API — Complete Endpoint Reference
 
-Base URL: `http://127.0.0.1:13381`
+Base URL: `http://127.0.0.1:$SERVE_PORT`. Each `opencode serve` process listens on its own port — there is no single global serve. Examples below use **13381** as a placeholder (the default for Legion's shared serve, which may differ if multiple daemons coexist). Substitute the actual port for the serve you're targeting; for Legion, discover via the daemon's `/workers` endpoint.
 
 All per-project endpoints accept `?directory=/path` query param or `x-opencode-directory` header.
 


### PR DESCRIPTION
## Summary

The `opencode-api` skill described the OpenCode serve API as if there were a single global serve at port 13381 hosting "all worker and controller sessions". This caused agents to assume every `opencode serve` process they encountered was the Legion shared serve — conflating the generic API contract with Legion's specific deployment pattern.

## Changes

**[`SKILL.md`](.opencode/skills/opencode-api/SKILL.md)**

- **Frontmatter description** — clarifies each `opencode serve` is independent; Legion's shared serve is one deployment pattern.
- **Intro paragraphs** — replaced "HTTP API for the shared OpenCode serve process. All worker and controller sessions run on a single `opencode serve` instance" with a generic description plus a separate "Legion's deployment" paragraph.
- **Architecture section** — renamed `## Architecture` → `## Legion's Architecture`. Added a paragraph explaining a second daemon on the same host gets its own daemon port and its own serve port (e.g. 13371 / 13382) with independent sessions.
- **Diagram label** — `Shared Serve (port 13381)` → `Shared Serve (default 13381 — actual port may differ)`.
- **Port Discovery** — bolded "always discover via the daemon API, never hardcode it". Added a note that plain `opencode serve` outside Legion has no discovery API; the port is whatever you started it with.
- Examples still use `13381` for readability, but the intro now explicitly flags it as a placeholder.

**[`reference.md`](.opencode/skills/opencode-api/reference.md)**

- Base URL changed from the bare `Base URL: http://127.0.0.1:13381` (which read as authoritative) to `http://127.0.0.1:$SERVE_PORT` with an explanation that 13381 is just a placeholder/Legion default.

## Why

Agents reading the old doc assumed `opencode serve` was a single global service. The reality:

- The OpenCode serve HTTP API is exposed by every `opencode serve` process; each is independent (own port, own sessions, own state).
- Legion happens to run **one** shared serve **per daemon** — but that's a Legion-specific deployment choice, not a property of OpenCode.
- Multiple Legion daemons on the same host get auto-incremented ports (`baseWorkerPort` starts at 13381 and increments on collision; see `packages/daemon/src/daemon/index.ts:276-281`).

Doc-only change. No code touched.