### PR TITLE
fix(envoy): gate listener startup on interest cache warm-up

### DIFF
--- a/packages/envoy/cmd/listener/main.go
+++ b/packages/envoy/cmd/listener/main.go
@@ -646,6 +646,23 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// Wait for the interest cache to finish its initial scan of existing KV
+	// entries before we start accepting NATS messages. Without this gate, real
+	// events that arrive in the warm-up window get "no matching interests"
+	// even when the durable KV entry has subscribers — the second half of the
+	// Atlas dropout investigation (PR #610 fixed the silent-fallback half).
+	//
+	// Bounded at 30s: a healthy NATS cluster completes the scan in milliseconds.
+	// If the watcher fails to start, signalReady() is called from the error
+	// path so we fail open and let the self-health watchdog catch a persistently
+	// broken registry via its KV pings.
+	cacheReadyCtx, cacheReadyCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	if err := registry.WaitForCacheReady(cacheReadyCtx); err != nil {
+		logger.Warn("interest cache warm-up timed out; serving with possibly empty cache",
+			slog.String("error", err.Error()))
+	}
+	cacheReadyCancel()
+
 	sessions, err := session.OpenSessionRegistry(
 		client.Conn,
 		session.WithSessionReplicas(cfg.NATSReplicas),

--- a/packages/envoy/internal/store/kv.go
+++ b/packages/envoy/internal/store/kv.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -16,10 +17,17 @@ const Bucket = "envoy_interests"
 const RoleBucket = "envoy_roles"
 
 type Registry struct {
-	kv     nats.KeyValue
-	roleKV nats.KeyValue
-	mu     sync.RWMutex
-	cache  map[string]Interest
+	kv        nats.KeyValue
+	roleKV    nats.KeyValue
+	mu        sync.RWMutex
+	cache     map[string]Interest
+	// readyCh is closed when watch() finishes its initial scan of existing KV
+	// entries (signalled by the nil sentinel WatchAll() emits after delivering
+	// the current value of each existing key). After readyCh is closed, the
+	// cache is consistent with the durable KV state and Match() can answer
+	// every "is this session subscribed?" question without falling through.
+	readyCh   chan struct{}
+	readyOnce sync.Once
 }
 
 // OpenOption configures the registry.
@@ -49,7 +57,7 @@ func Open(conn *nats.Conn, options ...OpenOption) (*Registry, error) {
 	if err != nil {
 		return nil, err
 	}
-	r := &Registry{kv: kv, roleKV: roleKV, cache: map[string]Interest{}}
+	r := &Registry{kv: kv, roleKV: roleKV, cache: map[string]Interest{}, readyCh: make(chan struct{})}
 	// Skip eager load — watch() populates cache asynchronously via KV watcher.
 	// The synchronous load() did N individual kv.Get() calls that block indefinitely
 	// when the KV stream leader is on a remote node.
@@ -84,10 +92,18 @@ func (r *Registry) watch() {
 	w, err := r.kv.WatchAll()
 	if err != nil {
 		slog.Error("registry watch failed", slog.String("error", err.Error()))
+		// Unblock callers of WaitForCacheReady even on watcher failure — they'd
+		// rather see the empty-cache symptom than hang. Self-health watchdog
+		// (added in #608) will catch a persistently broken registry.
+		r.signalReady()
 		return
 	}
 	for entry := range w.Updates() {
 		if entry == nil {
+			// NATS KV WatchAll() emits a nil sentinel after delivering the
+			// current value of each existing key. Treat that as "initial scan
+			// complete" and unblock cache-readiness gates.
+			r.signalReady()
 			continue
 		}
 		r.mu.Lock()
@@ -100,6 +116,38 @@ func (r *Registry) watch() {
 			}
 		}
 		r.mu.Unlock()
+	}
+}
+
+// signalReady closes readyCh exactly once, unblocking any callers of
+// WaitForCacheReady. Safe to call from multiple code paths (success / error).
+func (r *Registry) signalReady() {
+	r.readyOnce.Do(func() {
+		if r.readyCh != nil {
+			close(r.readyCh)
+		}
+	})
+}
+
+// WaitForCacheReady blocks until watch() has finished its initial scan of
+// existing KV entries, or until the context is cancelled. After this returns
+// nil, registry.Match sees every existing subscription in the bucket.
+//
+// Callers should set a bounded timeout: WatchAll() on a healthy NATS cluster
+// completes in milliseconds, but the watcher may legitimately fail to start
+// (e.g., bucket misconfigured). The caller is responsible for deciding what to
+// do with a non-nil error — typically log + proceed (fail open) so the listener
+// can still answer the new-subscription path while the self-health watchdog
+// arranges a restart.
+func (r *Registry) WaitForCacheReady(ctx context.Context) error {
+	if r == nil || r.readyCh == nil {
+		return nil
+	}
+	select {
+	case <-r.readyCh:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/packages/envoy/internal/store/kv_test.go
+++ b/packages/envoy/internal/store/kv_test.go
@@ -996,3 +996,101 @@ func TestPing_ClosedConnReturnsError(t *testing.T) {
 		t.Fatal("Ping after conn close should return error")
 	}
 }
+
+// --- Cache readiness tests ---
+//
+// Follow-up to PR #610. The Upsert silent-fallback fix doesn't address the
+// initial-cache-warmup race: after Open() returns, watch() populates the cache
+// asynchronously, and events arriving in that window get "no matching
+// interests" even when the durable KV entry has subscribers. This was ~36/235
+// of Atlas's observed drops (the 07:39:38 burst right at listener restart).
+
+func TestWaitForCacheReady_ReturnsAfterInitialScan(t *testing.T) {
+	conn, cleanup := connectNATS(t)
+	defer cleanup()
+
+	reg, err := Open(conn, WithReplicas(1))
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := reg.WaitForCacheReady(ctx); err != nil {
+		t.Fatalf("WaitForCacheReady timed out on a healthy registry: %v", err)
+	}
+}
+
+func TestWaitForCacheReady_PrePopulatedKVIsVisibleAfterReady(t *testing.T) {
+	// The whole point of this gate: after WaitForCacheReady returns, every
+	// existing KV entry must be findable via Match without falling through to
+	// "no matching interests".
+	conn, cleanup := connectNATS(t)
+	defer cleanup()
+
+	// Pre-populate KV via a temporary registry, then Close conn to release
+	// any watcher state.
+	reg1, err := Open(conn, WithReplicas(1))
+	if err != nil {
+		t.Fatalf("first Open failed: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := reg1.WaitForCacheReady(ctx); err != nil {
+		t.Fatalf("first WaitForCacheReady: %v", err)
+	}
+	if _, err := reg1.Upsert(Interest{SessionID: "ses_pre", MachineID: "m1"}, []string{"topic.pre"}); err != nil {
+		t.Fatalf("pre-populate Upsert failed: %v", err)
+	}
+
+	// Second registry on the same bucket — simulates listener restart against
+	// existing KV state.
+	reg2, err := Open(conn, WithReplicas(1))
+	if err != nil {
+		t.Fatalf("second Open failed: %v", err)
+	}
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel2()
+	if err := reg2.WaitForCacheReady(ctx2); err != nil {
+		t.Fatalf("second WaitForCacheReady: %v", err)
+	}
+
+	// Critical: Match must find the pre-populated entry IMMEDIATELY after
+	// WaitForCacheReady returns (no further sleeps).
+	got := reg2.Match("m1", "topic.pre")
+	if len(got) != 1 || got[0].SessionID != "ses_pre" {
+		t.Fatalf("expected pre-populated entry visible after WaitForCacheReady; got %v", got)
+	}
+}
+
+func TestWaitForCacheReady_RespectsContextCancellation(t *testing.T) {
+	// Build a Registry with NO watch() goroutine running, so readyCh never closes.
+	// WaitForCacheReady must return ctx.Err() instead of hanging.
+	r := &Registry{cache: map[string]Interest{}, readyCh: make(chan struct{})}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err := r.WaitForCacheReady(ctx)
+	if err == nil {
+		t.Fatal("WaitForCacheReady must return error when readyCh stays open and ctx expires")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestWaitForCacheReady_IdempotentAfterReady(t *testing.T) {
+	// Calling WaitForCacheReady after the channel has been signaled must
+	// return immediately, not block or panic on double-close.
+	r := &Registry{cache: map[string]Interest{}, readyCh: make(chan struct{})}
+	close(r.readyCh)
+
+	for i := 0; i < 3; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		err := r.WaitForCacheReady(ctx)
+		cancel()
+		if err != nil {
+			t.Fatalf("call %d: expected nil after readyCh closed, got %v", i, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #610. The Upsert silent-fallback fix in #610 stopped the cache from being **corrupted at runtime**, but didn't address the separate **initial cache warm-up race**: after `store.Open()` returns, `watch()` populates the cache asynchronously, and events arriving in that window get `"no matching interests"` even when the durable KV entry has subscribers.

## Forensics

~36 of Atlas's 235 dropped `pr.11416.ci` events on 2026-05-18 were in the burst at 07:39:38, immediately after the on-prem listener restart — before Atlas's first post-restart heartbeat re-Upserted her interest. The remaining ~199 drops were spread across 2 hours and explained by the silent-fallback bug fixed in #610.

## Fix

- **`Registry` now holds `readyCh`** that `watch()` closes when it sees the nil sentinel `WatchAll()` emits after delivering the current value of each existing key. The existing nil-skip path becomes the readiness signal — no extra round-trip to NATS.
- **`WaitForCacheReady(ctx)`** blocks until `readyCh` closes or the context is cancelled. Idempotent (`sync.Once` on the close), nil-safe for tests that construct `Registry` by hand.
- **Watch error path also calls `signalReady()`** so a misconfigured bucket fails *open* instead of hanging the listener forever. The #608 self-health watchdog (registry/sessions Ping) will catch a persistently broken registry and self-terminate.
- **`cmd/listener`**: after `store.Open`, block up to 30s on `WaitForCacheReady` before subscribing to NATS messages. Healthy clusters complete the scan in milliseconds; the timeout is just a safety bound. Timeout logs WARN and proceeds (fail open).

## Test coverage

- `TestWaitForCacheReady_ReturnsAfterInitialScan` — happy path against real NATS via testcontainers.
- **`TestWaitForCacheReady_PrePopulatedKVIsVisibleAfterReady`** — the actual regression test: opens a second `Registry` against an existing KV bucket (simulates listener restart against existing subscriptions), waits for ready, then `Match()` must immediately see the pre-existing entry. Without this fix, the test would fail or be flaky.
- `TestWaitForCacheReady_RespectsContextCancellation` — returns `context.DeadlineExceeded` when `readyCh` never closes.
- `TestWaitForCacheReady_IdempotentAfterReady` — multiple calls after ready return `nil`; `sync.Once` prevents double-close panic.

All 36 store tests pass. Full envoy `./...` suite green (including `internal/integration` at ~127s).

## Failure-open rationale

If `WaitForCacheReady` times out, the listener logs WARN and continues. Two alternatives considered:

1. **Fail closed** (refuse to start): would prevent the race but at the cost of total listener unavailability if KV is briefly slow. The original bug only drops a small initial burst; refusing to start is strictly worse.
2. **Block reads in `Match()` until ready**: would block on every event, even after warm-up — unnecessary overhead.

Chose: fail open with WARN + 30s bound. Self-health watchdog from #608 catches genuinely broken registries via KV pings and self-terminates.

## Stacking

Branches off `main` after #610 merged. No conflicts.